### PR TITLE
chore: add CD workflow to build and push images to GHCR

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,99 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "treadstone/**"
+      - "alembic/**"
+      - "Dockerfile"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/cd.yml"
+
+  workflow_dispatch:
+    inputs:
+      build_treadstone:
+        description: "Build and push treadstone image"
+        type: boolean
+        default: true
+      build_sandbox_router:
+        description: "Build and push sandbox-router image"
+        type: boolean
+        default: false
+      agent_sandbox_ref:
+        description: "agent-sandbox git ref for sandbox-router build"
+        type: string
+        default: "v0.2.1"
+
+env:
+  REGISTRY: ghcr.io
+  TREADSTONE_IMAGE: ghcr.io/${{ github.repository_owner }}/treadstone
+  SANDBOX_ROUTER_IMAGE: ghcr.io/${{ github.repository_owner }}/sandbox-router
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-treadstone:
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.build_treadstone)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.TREADSTONE_IMAGE }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-sandbox-router:
+    if: >
+      github.event_name == 'workflow_dispatch' && inputs.build_sandbox_router
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout agent-sandbox upstream
+        uses: actions/checkout@v4
+        with:
+          repository: kubernetes-sigs/agent-sandbox
+          ref: ${{ inputs.agent_sandbox_ref }}
+          path: agent-sandbox
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.SANDBOX_ROUTER_IMAGE }}
+          tags: |
+            type=raw,value=${{ inputs.agent_sandbox_ref }}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: agent-sandbox/clients/python/agentic-sandbox-client/sandbox-router
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/deploy/sandbox-runtime/values.yaml
+++ b/deploy/sandbox-runtime/values.yaml
@@ -2,7 +2,7 @@ router:
   enabled: false
   replicaCount: 1
   image:
-    repository: sandbox-router
+    repository: ghcr.io/earayu/sandbox-router
     tag: latest
     pullPolicy: IfNotPresent
   service:

--- a/deploy/treadstone/values.yaml
+++ b/deploy/treadstone/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: treadstone
+  repository: ghcr.io/earayu/treadstone
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Add `cd.yml` GitHub Actions workflow for continuous delivery
- **treadstone image**: auto-builds on push to `main` when app code changes, pushes to `ghcr.io/earayu/treadstone`
- **sandbox-router image**: manually triggered via `workflow_dispatch`, clones upstream [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) and builds from their Dockerfile (no local source copy needed)
- Update default Helm values to reference GHCR image paths

## Test Plan
- [ ] CI passes (lint, test, build)
- [ ] After merge, verify CD triggers and pushes treadstone image to GHCR
- [ ] Manually trigger sandbox-router build via Actions UI

Made with [Cursor](https://cursor.com)