### PR TITLE
chore: enable sandbox-router in dev and fix deployment template

### DIFF
--- a/deploy/sandbox-runtime/templates/router-deployment.yaml
+++ b/deploy/sandbox-runtime/templates/router-deployment.yaml
@@ -16,25 +16,31 @@ spec:
       labels:
         {{- include "sandbox-runtime.routerLabels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
       containers:
         - name: sandbox-router
           image: "{{ .Values.router.image.repository }}:{{ .Values.router.image.tag }}"
           imagePullPolicy: {{ .Values.router.image.pullPolicy }}
+          env:
+            - name: PROXY_TIMEOUT_SECONDS
+              value: "{{ .Values.router.proxyTimeoutSeconds | default 180 }}"
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 15
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
-            initialDelaySeconds: 3
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
             periodSeconds: 10
           resources:
             {{- toYaml .Values.router.resources | nindent 12 }}

--- a/deploy/sandbox-runtime/values-dev.yaml
+++ b/deploy/sandbox-runtime/values-dev.yaml
@@ -1,8 +1,8 @@
 router:
-  enabled: false
+  enabled: true
   replicaCount: 1
   image:
-    repository: sandbox-router
+    repository: ghcr.io/earayu/sandbox-router
     tag: latest
     pullPolicy: IfNotPresent
   resources:


### PR DESCRIPTION
## Summary
- Enable sandbox-router by default in dev environment (`values-dev.yaml`)
- Fix health check paths from `/` to `/healthz` to match [upstream sandbox_router.py](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py)
- Add pod `securityContext` (runAsUser/runAsGroup: 1000) per upstream Dockerfile
- Add `PROXY_TIMEOUT_SECONDS` env var support
- Point dev router image to `ghcr.io/earayu/sandbox-router:latest`

## Test Plan
- [ ] CI passes
- [ ] `make deploy-runtime ENV=dev` deploys router successfully on Kind cluster
- [ ] Router pod reaches Ready state with `/healthz` probe

Made with [Cursor](https://cursor.com)