### PR TITLE
fix: correct sandbox containerPort from 8888 to 8080

### DIFF
--- a/deploy/sandbox-runtime/values-dev.yaml
+++ b/deploy/sandbox-runtime/values-dev.yaml
@@ -16,7 +16,7 @@ router:
 sandboxTemplate:
   name: treadstone-sandbox
   image: enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
-  containerPort: 8888
+  containerPort: 8080
   resources:
     requests:
       cpu: 250m

--- a/deploy/sandbox-runtime/values-prod.yaml
+++ b/deploy/sandbox-runtime/values-prod.yaml
@@ -16,7 +16,7 @@ router:
 sandboxTemplate:
   name: treadstone-sandbox
   image: ghcr.io/agent-infra/sandbox:latest
-  containerPort: 8888
+  containerPort: 8080
   resources:
     requests:
       cpu: 500m

--- a/deploy/sandbox-runtime/values.yaml
+++ b/deploy/sandbox-runtime/values.yaml
@@ -19,7 +19,7 @@ router:
 sandboxTemplate:
   name: treadstone-sandbox
   image: ghcr.io/agent-infra/sandbox:latest
-  containerPort: 8888
+  containerPort: 8080
   resources:
     requests:
       cpu: 250m


### PR DESCRIPTION
## Summary
- Fix incorrect `containerPort` in sandbox Helm values (was 8888, should be 8080)
- Applies to `values.yaml`, `values-dev.yaml`, and `values-prod.yaml`
- Port 8080 is the correct default exposed by the [agent-infra/sandbox](https://github.com/agent-infra/sandbox) container image

## Test Plan
- [ ] Deploy to dev environment and verify sandbox container is reachable on port 8080

Made with [Cursor](https://cursor.com)