### PR TITLE
docs: add data model, state machine, and K8s sync strategy to Phase 2 design

### DIFF
--- a/docs/zh-CN/plans/2026-03-17-phase2-sandbox-orchestration.md
+++ b/docs/zh-CN/plans/2026-03-17-phase2-sandbox-orchestration.md
@@ -720,7 +720,7 @@ K8s Watch 必须携带 `resourceVersion` 参数续接，断线期间的事件不
 > 水平扩展前必须实现 **Leader Election**（K8s Lease 或 Redis 分布式锁），
 > 确保只有一个副本运行 Watch 和 Reconciliation。
 >
-> 参见 Issue: #TBD
+> 参见 Issue: [#15](https://github.com/earayu/treadstone/issues/15)
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds Sandbox DB model design with Source of Truth strategy: DB stores business intent + creation snapshots, K8s stores runtime state, Watch events drive DB cache updates
- Defines explicit state machine with legal transition table and optimistic locking (`version` field) for concurrent write protection
- Adds K8s Watch + periodic Reconciliation (List-based, not per-GET) sync architecture
- Documents single-replica constraint; Leader Election deferred to Phase 5 (see #TBD issue)
- Updates architecture diagram to show Watch/Reconciliation background tasks
- Adds references to Daytona architecture, RecordOps pattern, kr8s, kubernetes-asyncio

## Test plan

- [ ] Review data model fields for completeness
- [ ] Verify state machine transitions cover all user operations and K8s events
- [ ] Confirm sync strategy handles edge cases (Watch disconnect, concurrent writes, unexpected CR deletion)


Made with [Cursor](https://cursor.com)