### PR TITLE
fix: resolve agent-sandbox Helm duplicate Deployment conflict

### DIFF
--- a/deploy/agent-sandbox/README.md
+++ b/deploy/agent-sandbox/README.md
@@ -1,0 +1,39 @@
+# agent-sandbox Helm Chart
+
+Thin Helm wrapper around the upstream [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) controller.
+
+## Vendor Patch
+
+The upstream release provides two files meant to be applied sequentially:
+
+```bash
+kubectl apply -f manifest.yaml    # core install
+kubectl apply -f extensions.yaml  # add extensions (updates the Deployment)
+```
+
+`kubectl apply` is idempotent — the second command updates the existing Deployment
+by adding the `--extensions` flag. Helm's fresh install cannot do this; it tries to
+**create** both Deployments and fails with `already exists`.
+
+**What we changed:**
+
+- `upstream/manifest.yaml` — added `--extensions` to the controller Deployment args
+- `upstream/extensions.yaml` — removed the duplicate Deployment block (only the
+  Deployment was duplicated; all CRDs and RBAC are unique and unchanged)
+
+The end result is identical to applying both files sequentially with `kubectl apply`.
+
+## Upgrading Upstream Version
+
+When a new upstream version is released:
+
+1. Download the new `manifest.yaml` and `extensions.yaml` from the release page and
+   overwrite the files in `upstream/`.
+2. Diff the new `extensions.yaml` Deployment against the new `manifest.yaml` Deployment.
+3. Merge any new args/fields from the `extensions.yaml` Deployment into `manifest.yaml`.
+4. Remove the Deployment block from `extensions.yaml`.
+5. Re-add the `# VENDOR PATCH` comments so the next person knows why.
+
+A better long-term fix is to upgrade to Helm ≥ 3.13 and add `--server-side` to the
+`deploy-infra` Makefile target, which lets Helm use server-side apply semantics and
+handles the update naturally — no vendor modification required.

--- a/deploy/agent-sandbox/upstream/extensions.yaml
+++ b/deploy/agent-sandbox/upstream/extensions.yaml
@@ -4282,40 +4282,13 @@ rules:
   - update
   - watch
 ---
----
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: agent-sandbox-controller
-  namespace: agent-sandbox-system
-  labels:
-    app: agent-sandbox-controller
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: agent-sandbox-controller
-  template:
-    metadata:
-      labels:
-        app: agent-sandbox-controller
-    spec:
-      serviceAccountName: agent-sandbox-controller
-      containers:
-      - name: agent-sandbox-controller
-        image: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.2.1
-        args:
-        - "--leader-elect=true"
-        - "--extensions"
-        ports:
-        - name: metrics
-          containerPort: 8080
-          protocol: TCP
-        - name: healthz
-          containerPort: 8081
-          protocol: TCP
----
----
+# VENDOR PATCH: The Deployment that originally appeared here has been removed.
+# Upstream uses `kubectl apply` sequentially (manifest.yaml then extensions.yaml),
+# which updates the existing Deployment with --extensions. Our Helm chart applies
+# both files in one install, so we merged --extensions into manifest.yaml instead
+# and removed the duplicate Deployment block to avoid "already exists" conflict.
+# When upgrading upstream version: diff the new extensions.yaml Deployment against
+# manifest.yaml to check for any new args, then re-apply the merge.
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/agent-sandbox/upstream/manifest.yaml
+++ b/deploy/agent-sandbox/upstream/manifest.yaml
@@ -72,6 +72,15 @@ spec:
         image: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.2.1
         args:
         - --leader-elect=true
+        # VENDOR PATCH: --extensions added here (merged from extensions.yaml).
+        # Upstream applies manifest.yaml then extensions.yaml sequentially via
+        # `kubectl apply`, which idempotently updates this Deployment. Helm
+        # applies both files in one install and cannot CREATE the same Deployment
+        # twice, so we merge the flag here and remove the duplicate Deployment
+        # block from extensions.yaml.
+        # When upgrading upstream version: re-check extensions.yaml for any new
+        # Deployment args and re-apply this patch.
+        - --extensions
         ports:
         - name: metrics
           containerPort: 8080


### PR DESCRIPTION
## Summary

- Upstream `manifest.yaml` and `extensions.yaml` both define a `Deployment` named `agent-sandbox-controller`, designed for sequential `kubectl apply` (second apply updates the first). Helm's fresh install tries to **create** both and fails with `already exists`.
- Merged `--extensions` arg into `manifest.yaml`'s Deployment and removed the duplicate Deployment block from `extensions.yaml`. End result is identical to upstream sequential apply.
- Added `deploy/agent-sandbox/README.md` documenting the vendor patch and upgrade procedure.

## Test plan

- [ ] `make down && make up` completes without error
- [ ] `helm list -A` shows `agent-sandbox` with `STATUS: deployed`
- [ ] `kubectl get deployment agent-sandbox-controller -n agent-sandbox-system` shows `1/1 Ready`

Made with [Cursor](https://cursor.com)