### PR TITLE
feat: automate DB migrations via Helm pre-upgrade hook Job

### DIFF
--- a/deploy/treadstone/templates/migration-job.yaml
+++ b/deploy/treadstone/templates/migration-job.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "treadstone.fullname" . }}-migrate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "treadstone.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{- include "treadstone.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["uv", "run", "alembic", "upgrade", "head"]
+          envFrom:
+            - configMapRef:
+                name: {{ include "treadstone.fullname" . }}-config
+            {{- if .Values.envSecretRef }}
+            - secretRef:
+                name: {{ .Values.envSecretRef }}
+            {{- end }}
+{{- end }}

--- a/deploy/treadstone/values-demo.yaml
+++ b/deploy/treadstone/values-demo.yaml
@@ -15,5 +15,8 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+migration:
+  enabled: true
+
 hpa:
   enabled: false

--- a/deploy/treadstone/values-local.yaml
+++ b/deploy/treadstone/values-local.yaml
@@ -15,5 +15,8 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+migration:
+  enabled: true
+
 hpa:
   enabled: false

--- a/deploy/treadstone/values-prod.yaml
+++ b/deploy/treadstone/values-prod.yaml
@@ -15,6 +15,9 @@ resources:
     cpu: 200m
     memory: 256Mi
 
+migration:
+  enabled: true
+
 hpa:
   enabled: true
   minReplicas: 2

--- a/deploy/treadstone/values.yaml
+++ b/deploy/treadstone/values.yaml
@@ -25,6 +25,9 @@ serviceAccount:
   create: true
   name: ""
 
+migration:
+  enabled: true
+
 hpa:
   enabled: false
   minReplicas: 2


### PR DESCRIPTION
## Summary
- Add a Helm pre-install/pre-upgrade hook Job that runs `alembic upgrade head` before each deployment rollout
- The Job reuses the same app image and env secrets, so no separate migration image is needed
- Failed migrations abort the Helm release — the Deployment is NOT updated, and the failed Job is preserved for log inspection
- Add `migration.enabled: true` toggle to all environment values files (default, local, demo, prod)

## Design decisions
- **Helm hook Job over init container**: avoids concurrent migration attempts when running multiple replicas (prod has 2+ with HPA)
- **`backoffLimit: 0`**: migration failures require human intervention, not blind retries
- **`hook-delete-policy: before-hook-creation,hook-succeeded`**: successful Jobs are cleaned up automatically; failed Jobs are kept for debugging

## Test plan
- [ ] `helm template` renders the Job correctly when `migration.enabled: true`
- [ ] `helm template` omits the Job when `migration.enabled: false`
- [ ] Deploy to local Kind cluster with `make up` and verify migration Job runs before app pods start
- [ ] Verify migration Job has access to `TREADSTONE_DATABASE_URL` from the secret

Made with [Cursor](https://cursor.com)