### PR TITLE
feat: add optional Ingress resource to Helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-hooks dev test test-unit test-api test-integration test-all test-cov lint format migrate migration downgrade gen-openapi build clean ship up down deploy-infra deploy-runtime deploy-app deploy-all undeploy-app undeploy-runtime undeploy-all restart-app kind-create kind-delete
+.PHONY: help install install-hooks dev test test-unit test-api test-integration test-all test-cov lint format migrate migration downgrade gen-openapi build clean ship up down deploy-infra deploy-runtime deploy-app deploy-all undeploy-app undeploy-runtime undeploy-all restart-app kind-create kind-delete port-forward
 
 # ── Development ──────────────────────────────────────────────────────────────
 
@@ -107,6 +107,9 @@ deploy-all: deploy-infra deploy-runtime deploy-app ## Deploy everything (infra �
 
 restart-app: ## Rolling restart to pick up new env vars
 	kubectl rollout restart deployment/treadstone -n treadstone
+
+port-forward: ## Port-forward treadstone service to localhost:8000
+	kubectl -n treadstone port-forward svc/treadstone-treadstone 8000:8000
 
 undeploy-app: ## Undeploy Treadstone application
 	helm uninstall treadstone -n treadstone 2>/dev/null || true

--- a/deploy/deploy-and-e2e-test.md
+++ b/deploy/deploy-and-e2e-test.md
@@ -79,11 +79,20 @@ kubectl -n treadstone rollout status deploy/treadstone-treadstone --timeout=60s
 kubectl -n treadstone exec deploy/treadstone-treadstone -- uv run alembic upgrade head
 ```
 
-## Step 6：设置端口转发
+## Step 6：访问服务
+
+Kind 集群已自动安装 ingress-nginx 并配置了端口映射（80/443），Helm chart 默认创建 Ingress 资源。部署完成后可直接通过 `http://localhost` 访问：
 
 ```bash
-kubectl -n treadstone port-forward svc/treadstone-treadstone 8000:8000
+curl -s http://localhost/health
 ```
+
+> **备选方案**：如果 Ingress 不可用（端口冲突、未安装 ingress-nginx 等），可以用 port-forward：
+>
+> ```bash
+> make port-forward
+> # 然后通过 http://localhost:8000 访问
+> ```
 
 在新终端中继续以下步骤。
 
@@ -91,10 +100,12 @@ kubectl -n treadstone port-forward svc/treadstone-treadstone 8000:8000
 
 ## E2E 测试
 
+> **注意**：以下示例使用 `http://localhost`（通过 Ingress）。如果你使用 port-forward，请将 URL 替换为 `http://localhost:8000`。
+
 ### 6.1 健康检查
 
 ```bash
-curl -s http://localhost:8000/health
+curl -s http://localhost/health
 ```
 
 期望输出：
@@ -108,7 +119,7 @@ curl -s http://localhost:8000/health
 第一个注册的用户自动成为 admin：
 
 ```bash
-curl -s -X POST http://localhost:8000/v1/auth/register \
+curl -s -X POST http://localhost/v1/auth/register \
   -H "Content-Type: application/json" \
   -d '{"email":"admin@example.com","password":"StrongPass123!"}' | python3 -m json.tool
 ```
@@ -127,11 +138,11 @@ curl -s -X POST http://localhost:8000/v1/auth/register \
 
 ```bash
 # 登录（Cookie-based，返回 204 + Set-Cookie）
-curl -s -c /tmp/cookies -X POST http://localhost:8000/v1/auth/login \
+curl -s -c /tmp/cookies -X POST http://localhost/v1/auth/login \
   -d "username=admin@example.com&password=StrongPass123!"
 
 # 创建 API Key
-curl -s -b /tmp/cookies -X POST http://localhost:8000/v1/auth/api-keys \
+curl -s -b /tmp/cookies -X POST http://localhost/v1/auth/api-keys \
   -H "Content-Type: application/json" \
   -d '{"name":"e2e-test"}' | python3 -m json.tool
 ```
@@ -145,7 +156,7 @@ export API_KEY="sk-your-key-here"
 ### 6.4 查看 Sandbox 模板
 
 ```bash
-curl -s http://localhost:8000/v1/sandbox-templates \
+curl -s http://localhost/v1/sandbox-templates \
   -H "Authorization: Bearer $API_KEY" | python3 -m json.tool
 ```
 
@@ -154,7 +165,7 @@ curl -s http://localhost:8000/v1/sandbox-templates \
 ### 6.5 创建 Sandbox
 
 ```bash
-curl -s -X POST http://localhost:8000/v1/sandboxes \
+curl -s -X POST http://localhost/v1/sandboxes \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"template":"treadstone-sandbox","name":"e2e-test-sb"}' | python3 -m json.tool
@@ -178,21 +189,21 @@ kubectl -n treadstone get pods
 
 ```bash
 # 用上一步返回的 sandbox id
-curl -s http://localhost:8000/v1/sandboxes/{sandbox_id} \
+curl -s http://localhost/v1/sandboxes/{sandbox_id} \
   -H "Authorization: Bearer $API_KEY" | python3 -m json.tool
 ```
 
 ### 6.7 列出所有 Sandbox
 
 ```bash
-curl -s http://localhost:8000/v1/sandboxes \
+curl -s http://localhost/v1/sandboxes \
   -H "Authorization: Bearer $API_KEY" | python3 -m json.tool
 ```
 
 ### 6.8 删除 Sandbox
 
 ```bash
-curl -s -X DELETE http://localhost:8000/v1/sandboxes/{sandbox_id} \
+curl -s -X DELETE http://localhost/v1/sandboxes/{sandbox_id} \
   -H "Authorization: Bearer $API_KEY" -w "\nHTTP Status: %{http_code}\n"
 ```
 
@@ -229,3 +240,4 @@ kubectl -n treadstone exec deploy/treadstone-treadstone -- uv run alembic upgrad
 | Create Sandbox 返回 202 但 K8s 无资源 | K8s API 调用静默失败 | 查看 Pod 日志 `kubectl logs deploy/treadstone-treadstone` |
 | Pod 一直不 Ready | 镜像拉取失败 | `kind load docker-image` 加载镜像到集群 |
 | 403 Forbidden in pod logs | RBAC 权限不足 | 确认 Helm chart 部署了 ClusterRole + ClusterRoleBinding |
+| `curl localhost` 连接被拒绝 | ingress-nginx 未安装或 Kind 缺少端口映射 | 重建集群 `make kind-delete && make kind-create`，或用 `make port-forward` 代替 |

--- a/deploy/kind/kind-config.yaml
+++ b/deploy/kind/kind-config.yaml
@@ -3,5 +3,18 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: treadstone
 nodes:
   - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP
   - role: worker
   - role: worker

--- a/deploy/treadstone/templates/ingress.yaml
+++ b/deploy/treadstone/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "treadstone.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "treadstone.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "treadstone.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/treadstone/values-demo.yaml
+++ b/deploy/treadstone/values-demo.yaml
@@ -20,3 +20,13 @@ migration:
 
 hpa:
   enabled: false
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  hosts:
+    - host: demo.treadstone-ai.dev
+      paths:
+        - path: /
+          pathType: Prefix

--- a/deploy/treadstone/values-local.yaml
+++ b/deploy/treadstone/values-local.yaml
@@ -20,3 +20,12 @@ migration:
 
 hpa:
   enabled: false
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: ""
+      paths:
+        - path: /
+          pathType: Prefix

--- a/deploy/treadstone/values-prod.yaml
+++ b/deploy/treadstone/values-prod.yaml
@@ -23,3 +23,17 @@ hpa:
   minReplicas: 2
   maxReplicas: 10
   targetCPUUtilizationPercentage: 80
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: api.treadstone-ai.dev
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: treadstone-tls
+      hosts:
+        - api.treadstone-ai.dev

--- a/deploy/treadstone/values.yaml
+++ b/deploy/treadstone/values.yaml
@@ -33,3 +33,14 @@ hpa:
   minReplicas: 2
   maxReplicas: 10
   targetCPUUtilizationPercentage: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: ""
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/scripts/kind-setup.sh
+++ b/scripts/kind-setup.sh
@@ -41,6 +41,24 @@ create_cluster() {
     kubectl cluster-info --context "kind-$CLUSTER_NAME"
 }
 
+install_ingress_nginx() {
+    if kubectl get namespace ingress-nginx &>/dev/null && \
+       kubectl get pods -n ingress-nginx -l app.kubernetes.io/component=controller --no-headers 2>/dev/null | grep -q Running; then
+        echo "ingress-nginx controller already running, skipping install."
+        return 0
+    fi
+
+    echo ""
+    echo "Installing ingress-nginx controller ..."
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+    echo "Waiting for ingress-nginx to be ready (timeout 120s) ..."
+    kubectl wait --namespace ingress-nginx \
+        --for=condition=ready pod \
+        --selector=app.kubernetes.io/component=controller \
+        --timeout=120s
+    echo "ingress-nginx is ready."
+}
+
 verify_cluster() {
     echo ""
     echo "Verifying cluster nodes ..."
@@ -54,10 +72,11 @@ main() {
     echo ""
     check_prerequisites
     create_cluster
+    install_ingress_nginx
     verify_cluster
     echo ""
     echo "Next steps:"
-    echo "  make deploy-all ENV=dev"
+    echo "  make deploy-all ENV=local"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- Add a conditional Ingress template to the treadstone Helm chart, controlled by `ingress.enabled`
- Supports `className`, `annotations`, multi-host rules, and TLS for multi-cloud compatibility (Kind/ACK/EKS/etc.)
- Update Kind cluster config with `extraPortMappings` (80/443) and auto-install ingress-nginx controller
- Add `make port-forward` as fallback, update deploy docs with Ingress-based access

## Test plan
- [ ] `make kind-delete && make kind-create` — verify Kind cluster recreated with port mappings and ingress-nginx installed
- [ ] `make deploy-app ENV=local` — verify Ingress resource created (`kubectl get ingress -n treadstone`)
- [ ] `curl http://localhost/health` — verify access via Ingress without port-forward
- [ ] `make port-forward` then `curl http://localhost:8000/health` — verify fallback still works
- [ ] `helm template` dry-run with `ingress.enabled=false` — verify no Ingress resource rendered

Made with [Cursor](https://cursor.com)