### PR TITLE
feat: add Hurl-based E2E test suite

### DIFF
--- a/.agents/skills/dev-lifecycle/SKILL.md
+++ b/.agents/skills/dev-lifecycle/SKILL.md
@@ -104,7 +104,7 @@ If the change affects sandbox orchestration or deployment, verify on a local Kin
 
 ```bash
 make up          # build + deploy to Kind
-# ... run smoke tests from deploy/README.md ...
+make test-e2e    # run E2E tests against the cluster
 make down        # tear down when done
 ```
 

--- a/.agents/skills/dev-setup/SKILL.md
+++ b/.agents/skills/dev-setup/SKILL.md
@@ -19,13 +19,14 @@ docker --version         # Container builds + Kind cluster
 kind --version           # Local K8s cluster (sandbox dev only)
 kubectl version --client # K8s CLI
 helm version --short     # Helm chart deployment
+hurl --version           # E2E testing (HTTP request runner)
 ```
 
 Install missing tools (macOS):
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
-brew install kind kubectl helm
+brew install kind kubectl helm hurl
 ```
 
 ## 2. Install Python Dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Agent-native sandbox service. Run code, build projects, deploy environments — 
 - Database: Neon (Serverless PostgreSQL)
 - Package manager: uv
 - Linter/formatter: ruff
-- Testing: pytest + pytest-asyncio + httpx
+- Testing: pytest + pytest-asyncio + httpx; Hurl for E2E
 - Containerization: Docker
 - Orchestration: Kubernetes (Kind for dev, GKE/EKS/AKS for prod)
 
@@ -24,6 +24,7 @@ treadstone/        # Application source
   auth/            # Authentication
   services/        # Business logic
 tests/             # pytest test suites
+  e2e/             # Hurl E2E tests (run against deployed cluster)
 alembic/           # Database migrations
 deploy/            # Helm charts, Kind config, K8s manifests
 docs/              # Design docs and plans (zh-CN)
@@ -70,7 +71,9 @@ For K8s deployment (Kind cluster, Helm, smoke tests), see [`deploy/README.md`](d
   - `tests/unit/` — pure logic, no IO
   - `tests/api/` — API route tests via ASGITransport
   - `tests/integration/` — requires real DB, marked `@pytest.mark.integration`, excluded by default
+  - `tests/e2e/*.hurl` — E2E tests against a deployed cluster, written in [Hurl](https://hurl.dev) (run with `make test-e2e`)
 - Shared fixtures live in `tests/conftest.py`.
+- After `make up`, run `make test-e2e` to validate the deployment. Prefer this over manual curl exploration.
 
 ## OpenAPI / SDK Generation
 
@@ -100,6 +103,7 @@ Run `make help` for the full list. Key commands:
 |---------|---------|
 | `make dev` | Start dev server (localhost:8000, hot reload) |
 | `make test` | Run tests (excludes integration) |
+| `make test-e2e` | Run E2E tests against deployed cluster |
 | `make lint` / `make format` | Lint check / auto-format |
 | `make migrate` | Apply database migrations |
 | `make migration MSG=x` | Generate a new Alembic migration |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-hooks dev test test-unit test-api test-integration test-all test-cov lint format migrate migration downgrade gen-openapi build clean ship up down deploy-infra deploy-runtime deploy-app deploy-all undeploy-app undeploy-runtime undeploy-all restart-app kind-create kind-delete port-forward
+.PHONY: help install install-hooks dev test test-unit test-api test-integration test-all test-e2e test-cov lint format migrate migration downgrade gen-openapi build clean ship up down deploy-infra deploy-runtime deploy-app deploy-all undeploy-app undeploy-runtime undeploy-all restart-app kind-create kind-delete port-forward
 
 # ── Development ──────────────────────────────────────────────────────────────
 
@@ -42,6 +42,9 @@ test-integration: ## Run integration tests only (needs real DB)
 
 test-all: ## Run all tests including integration (needs real DB)
 	uv run pytest tests/ -v -m ""
+
+test-e2e: ## Run E2E tests against deployed cluster (BASE_URL=http://localhost)
+	@bash scripts/e2e-test.sh
 
 test-cov: ## Run tests with coverage report
 	uv run pytest tests/ -v --cov=treadstone --cov-report=term-missing --cov-report=html

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -20,6 +20,7 @@ Each layer's Helm chart provides `values-{local,demo,prod}.yaml`, selected via t
 - Kind installed (`brew install kind`)
 - kubectl installed (`brew install kubectl`)
 - Helm installed (`brew install helm`)
+- Hurl installed (`brew install hurl`) — for E2E tests
 - Neon database connection string ready
 
 ## Environment Configuration Files
@@ -120,7 +121,9 @@ curl http://localhost:8000/health
 
 ## Basic Validation (Smoke Test)
 
-The following commands can quickly verify that the deployment is working. Use `BASE_URL=http://localhost` with Ingress, or `BASE_URL=http://localhost:8000` with port-forward.
+**Automated**: Run `make test-e2e` to execute the full E2E test suite against the deployed service. Override the target with `make test-e2e BASE_URL=http://localhost:8000` when using port-forward.
+
+**Manual**: The following commands can quickly verify that the deployment is working. Use `BASE_URL=http://localhost` with Ingress, or `BASE_URL=http://localhost:8000` with port-forward.
 
 ```bash
 BASE_URL=http://localhost
@@ -238,6 +241,7 @@ make deploy-app        # Deploy app only
 make restart-app       # Rolling restart
 make port-forward      # Forward port to localhost:8000
 make undeploy-all      # Uninstall app + runtime
+make test-e2e          # Run E2E tests against deployed service
 make up                # One-command deploy (includes cluster creation for local)
 make down              # One-command teardown
 ```

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# E2E test runner — generates dynamic variables and invokes Hurl.
+#
+# Usage:
+#   make test-e2e                            # default: BASE_URL=http://localhost
+#   make test-e2e BASE_URL=http://localhost:8000
+#   BASE_URL=http://localhost bash scripts/e2e-test.sh
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost}"
+UNIQUE=$(head -c 8 /dev/urandom | xxd -p | head -c 8)
+VARS_FILE=$(mktemp)
+REPORT_DIR=$(mktemp -d)
+E2E_DIR="$(cd "$(dirname "$0")/.." && pwd)/tests/e2e"
+
+cleanup() { rm -f "$VARS_FILE"; rm -rf "$REPORT_DIR"; }
+trap cleanup EXIT
+
+cat > "$VARS_FILE" <<EOF
+base_url=${BASE_URL}
+test_email=e2e-${UNIQUE}@test.treadstone.dev
+test_password=E2eStr0ng_Pass!
+new_password=E2eStr0ng_New1!
+unique=${UNIQUE}
+EOF
+
+# ── Wait for service ─────────────────────────────────────────────────────────
+
+printf "Waiting for %s to be ready " "$BASE_URL"
+for i in $(seq 1 30); do
+    if curl -sf -o /dev/null "$BASE_URL/health" 2>/dev/null; then
+        printf " ready!\n\n"
+        break
+    fi
+    printf "."
+    sleep 2
+    if [ "$i" -eq 30 ]; then
+        printf "\nERROR: timed out after 60s waiting for %s/health\n" "$BASE_URL"
+        exit 1
+    fi
+done
+
+# ── Phase 1: Register user (sequential, captures user_id) ───────────────────
+
+hurl --test --report-json "$REPORT_DIR" --variables-file "$VARS_FILE" \
+    "$E2E_DIR/01-auth-flow.hurl"
+
+USER_ID=$(python3 -c "
+import json, sys
+data = json.load(open('$REPORT_DIR/report.json'))
+for item in data:
+    for entry in item.get('entries', []):
+        for cap in entry.get('captures', []):
+            if cap.get('name') == 'user_id':
+                print(cap['value']); sys.exit(0)
+print('')
+" 2>/dev/null || echo "")
+
+if [ -n "$USER_ID" ]; then
+    echo "user_id=${USER_ID}" >> "$VARS_FILE"
+fi
+
+# ── Phase 2: API key + sandbox tests (parallel-safe, same password) ──────────
+
+hurl --test --variables-file "$VARS_FILE" \
+    "$E2E_DIR/02-api-key.hurl" \
+    "$E2E_DIR/03-sandbox-crud.hurl"
+
+# ── Phase 3: Password change + cleanup (sequential, mutates password) ────────
+
+hurl --test --jobs 1 --variables-file "$VARS_FILE" \
+    "$E2E_DIR/04-password-change.hurl" \
+    "$E2E_DIR/05-cleanup.hurl"

--- a/tests/e2e/01-auth-flow.hurl
+++ b/tests/e2e/01-auth-flow.hurl
@@ -1,0 +1,46 @@
+# Auth Flow: health → register → login → get user
+# Cookies persist automatically across requests within this file.
+
+# ── Health Check ─────────────────────────────────────────────────────────────
+
+GET {{base_url}}/health
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "ok"
+
+
+# ── Register ─────────────────────────────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/register
+Content-Type: application/json
+{
+    "email": "{{test_email}}",
+    "password": "{{test_password}}"
+}
+HTTP 201
+[Captures]
+user_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.email" == "{{test_email}}"
+jsonpath "$.id" isString
+
+
+# ── Login ────────────────────────────────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/login
+[FormParams]
+username: {{test_email}}
+password: {{test_password}}
+HTTP *
+[Asserts]
+status < 300
+cookie "session" exists
+
+
+# ── Get Current User ─────────────────────────────────────────────────────────
+
+GET {{base_url}}/v1/auth/user
+HTTP 200
+[Asserts]
+jsonpath "$.email" == "{{test_email}}"
+jsonpath "$.is_active" == true

--- a/tests/e2e/02-api-key.hurl
+++ b/tests/e2e/02-api-key.hurl
@@ -1,0 +1,49 @@
+# API Key: login → create key → list keys → use key for auth → delete key
+# Requires a registered user (run 01-auth-flow.hurl first via the wrapper).
+
+# ── Login ────────────────────────────────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/login
+[FormParams]
+username: {{test_email}}
+password: {{test_password}}
+HTTP *
+[Asserts]
+status < 300
+
+
+# ── Create API Key ───────────────────────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/api-keys
+Content-Type: application/json
+{"name": "e2e-test-key"}
+HTTP 201
+[Captures]
+api_key: jsonpath "$.key"
+api_key_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.key" startsWith "sk-"
+jsonpath "$.name" == "e2e-test-key"
+
+
+# ── List API Keys ───────────────────────────────────────────────────────────
+
+GET {{base_url}}/v1/auth/api-keys
+HTTP 200
+[Asserts]
+jsonpath "$.items" count >= 1
+
+
+# ── Use API Key Auth (GET /v1/me) ───────────────────────────────────────────
+
+GET {{base_url}}/v1/me
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.email" == "{{test_email}}"
+
+
+# ── Delete API Key ──────────────────────────────────────────────────────────
+
+DELETE {{base_url}}/v1/auth/api-keys/{{api_key_id}}
+HTTP 204

--- a/tests/e2e/03-sandbox-crud.hurl
+++ b/tests/e2e/03-sandbox-crud.hurl
@@ -1,0 +1,84 @@
+# Sandbox CRUD: login → create API key → list templates → create sandbox
+#               → get detail → list → delete sandbox → delete key
+# Requires a registered user (run 01-auth-flow.hurl first via the wrapper).
+
+# ── Login + Create API Key ───────────────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/login
+[FormParams]
+username: {{test_email}}
+password: {{test_password}}
+HTTP *
+[Asserts]
+status < 300
+
+POST {{base_url}}/v1/auth/api-keys
+Content-Type: application/json
+{"name": "e2e-sandbox-key"}
+HTTP 201
+[Captures]
+api_key: jsonpath "$.key"
+api_key_id: jsonpath "$.id"
+
+
+# ── List Sandbox Templates ──────────────────────────────────────────────────
+
+GET {{base_url}}/v1/sandbox-templates
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Captures]
+template_name: jsonpath "$.items[0].name"
+[Asserts]
+jsonpath "$.items" count >= 1
+
+
+# ── Create Sandbox ──────────────────────────────────────────────────────────
+
+POST {{base_url}}/v1/sandboxes
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+{
+    "template": "{{template_name}}",
+    "name": "e2e-{{unique}}"
+}
+HTTP 202
+[Captures]
+sandbox_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.template" == "{{template_name}}"
+jsonpath "$.status" isString
+
+
+# ── Get Sandbox Detail ──────────────────────────────────────────────────────
+
+GET {{base_url}}/v1/sandboxes/{{sandbox_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{sandbox_id}}"
+jsonpath "$.endpoints" exists
+jsonpath "$.proxy_url" isString
+
+
+# ── List Sandboxes ──────────────────────────────────────────────────────────
+
+GET {{base_url}}/v1/sandboxes
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.total" >= 1
+jsonpath "$.items" count >= 1
+
+
+# ── Delete Sandbox ──────────────────────────────────────────────────────────
+
+DELETE {{base_url}}/v1/sandboxes/{{sandbox_id}}
+Authorization: Bearer {{api_key}}
+HTTP 204
+
+
+# ── Cleanup: Delete API Key ─────────────────────────────────────────────────
+
+DELETE {{base_url}}/v1/auth/api-keys/{{api_key_id}}
+HTTP 204

--- a/tests/e2e/04-password-change.hurl
+++ b/tests/e2e/04-password-change.hurl
@@ -1,0 +1,37 @@
+# Password Change: login → change password → login with new password
+# Requires a registered user (run 01-auth-flow.hurl first via the wrapper).
+
+# ── Login with Original Password ────────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/login
+[FormParams]
+username: {{test_email}}
+password: {{test_password}}
+HTTP *
+[Asserts]
+status < 300
+
+
+# ── Change Password ─────────────────────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/change-password
+Content-Type: application/json
+{
+    "old_password": "{{test_password}}",
+    "new_password": "{{new_password}}"
+}
+HTTP 200
+[Asserts]
+jsonpath "$.detail" == "Password changed"
+
+
+# ── Login with New Password ─────────────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/login
+[FormParams]
+username: {{test_email}}
+password: {{new_password}}
+HTTP *
+[Asserts]
+status < 300
+cookie "session" exists

--- a/tests/e2e/05-cleanup.hurl
+++ b/tests/e2e/05-cleanup.hurl
@@ -1,0 +1,22 @@
+# Cleanup: login (with new_password since 04 changed it) → delete test user
+# This runs last. The delete may return 400 if the user is the last admin
+# or cannot delete self — both are acceptable, so we accept 204 or 400.
+
+# ── Login ────────────────────────────────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/login
+[FormParams]
+username: {{test_email}}
+password: {{new_password}}
+HTTP *
+[Asserts]
+status < 300
+
+
+# ── Delete Test User ────────────────────────────────────────────────────────
+# Accept 204 (deleted) or 400 (self-delete / last admin protection).
+
+DELETE {{base_url}}/v1/auth/users/{{user_id}}
+HTTP *
+[Asserts]
+status < 500


### PR DESCRIPTION
## Summary
- Add automated E2E tests using [Hurl](https://hurl.dev) to replace manual smoke test workflow
- 5 test scenarios covering auth flow, API key CRUD, sandbox CRUD, password change, and cleanup
- Thin wrapper script (`scripts/e2e-test.sh`) handles dynamic variable generation and phased execution
- Update docs: AGENTS.md, deploy/README.md, dev-setup skill, dev-lifecycle skill

## Test Plan
- [x] `make test-e2e` — all 5 scenarios pass against local Kind cluster
- [x] `hurlfmt --check` — all `.hurl` files pass syntax validation

Made with [Cursor](https://cursor.com)