### PR TITLE
fix: unify API errors with TreadstoneError and global handlers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,23 @@ For K8s deployment (Kind cluster, Helm, smoke tests), see [`deploy/README.md`](d
 - All function signatures must have type hints.
 - Ruff rules: E, F, I, UP (see `pyproject.toml`). Line width: 120.
 
+## Error Handling
+
+All API errors must return a consistent JSON envelope:
+
+```json
+{"error": {"code": "snake_case_code", "message": "Human-readable detail.", "status": 409}}
+```
+
+Rules:
+
+- **Never raise bare `HTTPException`** — always use a `TreadstoneError` subclass from `treadstone/core/errors.py`.
+- **Wrap every `session.commit()`** that can fail with a DB constraint (unique, FK, check) in `try/except IntegrityError`, rollback, and raise a domain-specific `TreadstoneError`.
+- **Catch external-service failures** (K8s API, HTTP proxy) — convert them to `TreadstoneError` subclasses, never let raw `ConnectionError`, `TimeoutError`, etc. escape to the client.
+- **Use the right HTTP status code**: 400 `BadRequestError` for invalid input, 404 `NotFoundError`, 409 `ConflictError` / `SandboxNameConflictError` for conflicts, 422 `ValidationError` for schema issues.
+- **Global fallback handlers** in `main.py` catch `RequestValidationError` (422), `IntegrityError` (409), and `Exception` (500), guaranteeing the envelope format even for unexpected errors. Service-level handlers should still be preferred for domain-specific messages.
+- **Always log before returning 5xx**: use `logger.exception(...)` so the stack trace is captured server-side, but never expose internal details to the client.
+
 ## Database
 
 - Neon Serverless PostgreSQL. Connection string injected via `TREADSTONE_DATABASE_URL` env var.

--- a/tests/api/test_auth_api.py
+++ b/tests/api/test_auth_api.py
@@ -62,7 +62,7 @@ async def test_register_duplicate_email(db_session):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         await client.post("/v1/auth/register", json={"email": "a@b.com", "password": "Pass123!"})
         resp = await client.post("/v1/auth/register", json={"email": "a@b.com", "password": "Pass123!"})
-    assert resp.status_code == 400
+    assert resp.status_code == 409
 
 
 @pytest.mark.asyncio

--- a/treadstone/api/auth.py
+++ b/treadstone/api/auth.py
@@ -1,7 +1,7 @@
 import secrets
 from datetime import timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from treadstone.api.deps import get_current_admin, get_current_user
 from treadstone.config import settings
 from treadstone.core.database import get_session
+from treadstone.core.errors import BadRequestError, ConflictError, ForbiddenError, NotFoundError
 from treadstone.core.users import auth_backend, fastapi_users
 from treadstone.models.api_key import ApiKey
 from treadstone.models.user import Invitation, Role, User, random_id, utc_now
@@ -38,17 +39,17 @@ async def register(
     invitation: Invitation | None = None
     if settings.register_mode == "invitation" and not is_first_user:
         if not body.invitation_token:
-            raise HTTPException(status_code=403, detail="Invitation token required")
+            raise ForbiddenError("Invitation token required")
         inv_result = await session.execute(select(Invitation).where(Invitation.token == body.invitation_token))
         invitation = inv_result.scalar_one_or_none()
         if not invitation or not invitation.is_valid():
-            raise HTTPException(status_code=403, detail="Invalid or expired invitation")
+            raise ForbiddenError("Invalid or expired invitation")
         if invitation.email != body.email:
-            raise HTTPException(status_code=403, detail="Invitation email mismatch")
+            raise ForbiddenError("Invitation email mismatch")
 
     existing = await session.execute(select(User).where(User.email == body.email))
     if existing.unique().scalar_one_or_none():
-        raise HTTPException(status_code=400, detail="Email already registered")
+        raise ConflictError("Email already registered")
 
     from fastapi_users.password import PasswordHelper
 
@@ -143,10 +144,10 @@ async def change_password(
     ph = PasswordHelper()
     valid, _ = ph.verify_and_update(body.old_password, current_user.hashed_password)
     if not valid:
-        raise HTTPException(status_code=400, detail="Wrong current password")
+        raise BadRequestError("Wrong current password")
     user = await session.get(User, current_user.id)
     if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise NotFoundError("User", current_user.id)
     user.hashed_password = ph.hash(body.new_password)
     session.add(user)
     await session.commit()
@@ -161,16 +162,16 @@ async def delete_user(
     session: AsyncSession = Depends(get_session),
 ):
     if user_id == current_user.id:
-        raise HTTPException(status_code=400, detail="Cannot delete yourself")
+        raise BadRequestError("Cannot delete yourself")
     target = await session.get(User, user_id)
     if not target:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise NotFoundError("User", user_id)
     if target.role == Role.ADMIN.value:
         admin_count_result = await session.execute(
             select(func.count()).select_from(User).where(User.role == Role.ADMIN.value)
         )
         if admin_count_result.scalar_one() <= 1:
-            raise HTTPException(status_code=400, detail="Cannot delete the last admin")
+            raise BadRequestError("Cannot delete the last admin")
     await session.delete(target)
     await session.commit()
 
@@ -244,7 +245,7 @@ async def delete_api_key(
     )
     api_key = result.scalar_one_or_none()
     if not api_key:
-        raise HTTPException(status_code=404, detail="API key not found")
+        raise NotFoundError("API key", key_id)
     api_key.gmt_deleted = utc_now()
     session.add(api_key)
     await session.commit()

--- a/treadstone/api/sandbox_proxy.py
+++ b/treadstone/api/sandbox_proxy.py
@@ -10,14 +10,20 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from treadstone.api.deps import get_current_user
 from treadstone.core.database import get_session
-from treadstone.core.errors import ForbiddenError, SandboxNotFoundError, SandboxNotReadyError, SandboxUnreachableError
+from treadstone.core.errors import (
+    ForbiddenError,
+    SandboxNotFoundError,
+    SandboxNotReadyError,
+    SandboxUnreachableError,
+    ValidationError,
+)
 from treadstone.models.sandbox import Sandbox, SandboxStatus
 from treadstone.models.user import User
 from treadstone.services.sandbox_proxy import (
@@ -62,7 +68,7 @@ async def http_proxy(
     try:
         routing = resolve_routing(headers, path_sandbox_id=sandbox.k8s_sandbox_name or sandbox.name)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise ValidationError(str(exc)) from exc
 
     body = await request.body()
 

--- a/treadstone/core/errors.py
+++ b/treadstone/core/errors.py
@@ -78,6 +78,34 @@ class SandboxTimeoutError(TreadstoneError):
         )
 
 
+class SandboxNameConflictError(TreadstoneError):
+    def __init__(self, name: str):
+        super().__init__(
+            code="sandbox_name_conflict",
+            message=f"A sandbox named '{name}' already exists.",
+            status=409,
+        )
+
+
+class NotFoundError(TreadstoneError):
+    def __init__(self, resource: str, identifier: str):
+        super().__init__(
+            code="not_found",
+            message=f"{resource} '{identifier}' not found.",
+            status=404,
+        )
+
+
+class ConflictError(TreadstoneError):
+    def __init__(self, message: str):
+        super().__init__(code="conflict", message=message, status=409)
+
+
+class BadRequestError(TreadstoneError):
+    def __init__(self, message: str):
+        super().__init__(code="bad_request", message=message, status=400)
+
+
 class ValidationError(TreadstoneError):
     def __init__(self, message: str = "Request validation failed"):
         super().__init__(code="validation_error", message=message, status=422)

--- a/treadstone/main.py
+++ b/treadstone/main.py
@@ -3,8 +3,10 @@ import logging
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
+from sqlalchemy.exc import IntegrityError
 
 from treadstone.api.auth import router as auth_router
 from treadstone.api.config import router as config_router
@@ -18,6 +20,8 @@ from treadstone.core.users import auth_backend, fastapi_users, github_oauth_clie
 from treadstone.middleware.sandbox_subdomain import SandboxSubdomainMiddleware
 from treadstone.models.user import User
 from treadstone.services.sandbox_proxy import close_http_client
+
+logger = logging.getLogger(__name__)
 
 
 def custom_generate_unique_id(route: APIRoute) -> str:
@@ -46,6 +50,45 @@ app = FastAPI(title=settings.app_name, generate_unique_id_function=custom_genera
 @app.exception_handler(TreadstoneError)
 async def treadstone_error_handler(request: Request, exc: TreadstoneError):
     return JSONResponse(status_code=exc.status, content=exc.to_dict())
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_error_handler(request: Request, exc: RequestValidationError):
+    details = exc.errors()
+    messages = []
+    for err in details:
+        loc = " -> ".join(str(part) for part in err.get("loc", []))
+        messages.append(f"{loc}: {err.get('msg', 'invalid')}")
+    return JSONResponse(
+        status_code=422,
+        content={"error": {"code": "validation_error", "message": "; ".join(messages), "status": 422}},
+    )
+
+
+@app.exception_handler(IntegrityError)
+async def integrity_error_handler(request: Request, exc: IntegrityError):
+    logger.error("Unhandled IntegrityError: %s", exc)
+    body = {
+        "error": {
+            "code": "conflict",
+            "message": "Resource already exists or constraint violated.",
+            "status": 409,
+        }
+    }
+    return JSONResponse(status_code=409, content=body)
+
+
+@app.exception_handler(Exception)
+async def generic_error_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+    body = {
+        "error": {
+            "code": "internal_error",
+            "message": "An unexpected error occurred.",
+            "status": 500,
+        }
+    }
+    return JSONResponse(status_code=500, content=body)
 
 
 # ── Middleware (outermost = first to run) ──

--- a/treadstone/services/sandbox_service.py
+++ b/treadstone/services/sandbox_service.py
@@ -10,10 +10,16 @@ start/stop use scale_sandbox on the Sandbox CR regardless of path.
 import logging
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from treadstone.config import settings
-from treadstone.core.errors import InvalidTransitionError, SandboxNotFoundError, TemplateNotFoundError
+from treadstone.core.errors import (
+    InvalidTransitionError,
+    SandboxNameConflictError,
+    SandboxNotFoundError,
+    TemplateNotFoundError,
+)
 from treadstone.models.sandbox import Sandbox, SandboxStatus, is_valid_transition
 from treadstone.models.user import random_id, utc_now
 from treadstone.services.k8s_client import K8sClientProtocol, get_k8s_client
@@ -85,7 +91,11 @@ class SandboxService:
             sandbox.k8s_sandbox_claim_name = sandbox_name
 
         self.session.add(sandbox)
-        await self.session.commit()
+        try:
+            await self.session.commit()
+        except IntegrityError:
+            await self.session.rollback()
+            raise SandboxNameConflictError(sandbox_name)
         await self.session.refresh(sandbox)
 
         try:


### PR DESCRIPTION
## Summary
- Replace bare `HTTPException` in auth and sandbox proxy with `TreadstoneError` subclasses.
- Add `BadRequestError`, `ConflictError`, `NotFoundError`, and `SandboxNameConflictError`.
- Register global handlers for `RequestValidationError`, `IntegrityError`, and uncaught `Exception` so clients always get the JSON error envelope.
- Duplicate registration returns 409; sandbox create maps unique constraint failures to `sandbox_name_conflict`.
- Document error-handling rules in `AGENTS.md`.

## Test Plan
- [x] `make test`
- [x] `make lint` (via pre-commit on commit)

Made with [Cursor](https://cursor.com)