### PR TITLE
fix: add RBAC permissions for direct Sandbox CR path and validate template before creation

### DIFF
--- a/deploy/treadstone/templates/clusterrole.yaml
+++ b/deploy/treadstone/templates/clusterrole.yaml
@@ -26,7 +26,8 @@ rules:
       - get
       - list
       - watch
-  # Sandbox CRs: watch for state sync, patch for replicas (start/stop)
+  # Sandbox CRs: create/delete for direct path (persist=true),
+  # watch for state sync, patch for replicas (start/stop)
   - apiGroups:
       - agents.x-k8s.io
     resources:
@@ -35,6 +36,8 @@ rules:
       - get
       - list
       - watch
+      - create
+      - delete
       - patch
   # Sandbox status: read for Watch events
   - apiGroups:

--- a/tests/api/test_sandboxes_api.py
+++ b/tests/api/test_sandboxes_api.py
@@ -80,6 +80,24 @@ class TestCreateSandbox:
             resp = await client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny"})
         assert resp.status_code == 401
 
+    async def test_create_with_invalid_template_returns_404(self, auth_client):
+        resp = await auth_client.post(
+            "/v1/sandboxes",
+            json={"template": "nonexistent-template", "name": "bad-tmpl-sb"},
+        )
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == "template_not_found"
+
+    async def test_create_with_persist_returns_202(self, auth_client):
+        resp = await auth_client.post(
+            "/v1/sandboxes",
+            json={"template": "aio-sandbox-tiny", "name": "persist-sb", "persist": True, "storage_size": "5Gi"},
+        )
+        assert resp.status_code == 202
+        data = resp.json()
+        assert data["name"] == "persist-sb"
+        assert data["status"] == "creating"
+
 
 class TestListSandboxes:
     async def test_list_returns_own_sandboxes(self, auth_client):

--- a/tests/e2e/05-sandbox-dual-path.hurl
+++ b/tests/e2e/05-sandbox-dual-path.hurl
@@ -1,0 +1,129 @@
+# Sandbox Dual-Path: claim (default) vs direct (persist=true) provisioning
+# Also covers invalid template rejection.
+# Self-contained: registers its own user, no external dependencies.
+
+# ── Setup: Register + Login + API Key ────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/register
+Content-Type: application/json
+{
+    "email": "e2e-05-{{unique}}@test.treadstone.dev",
+    "password": "{{test_password}}"
+}
+HTTP 201
+
+POST {{base_url}}/v1/auth/login
+[FormParams]
+username: e2e-05-{{unique}}@test.treadstone.dev
+password: {{test_password}}
+HTTP *
+[Asserts]
+status < 300
+
+POST {{base_url}}/v1/auth/api-keys
+Content-Type: application/json
+{"name": "e2e-dual-path-key"}
+HTTP 201
+[Captures]
+api_key: jsonpath "$.key"
+api_key_id: jsonpath "$.id"
+
+
+# ── List Templates (get a valid name) ────────────────────────────────────────
+
+GET {{base_url}}/v1/sandbox-templates
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Captures]
+template_name: jsonpath "$.items[0].name"
+[Asserts]
+jsonpath "$.items" count >= 1
+
+
+# ── Invalid Template → 404 ───────────────────────────────────────────────────
+
+POST {{base_url}}/v1/sandboxes
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+{
+    "template": "nonexistent-template-xyz",
+    "name": "e2e-bad-tmpl-{{unique}}"
+}
+HTTP 404
+[Asserts]
+jsonpath "$.error.code" == "template_not_found"
+
+
+# ── Claim Path (persist=false, default) ──────────────────────────────────────
+
+POST {{base_url}}/v1/sandboxes
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+{
+    "template": "{{template_name}}",
+    "name": "e2e-claim-{{unique}}"
+}
+HTTP 202
+[Captures]
+claim_sandbox_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.name" == "e2e-claim-{{unique}}"
+jsonpath "$.status" == "creating"
+
+GET {{base_url}}/v1/sandboxes/{{claim_sandbox_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.persist" == false
+jsonpath "$.storage_size" == null
+
+
+# ── Direct Path (persist=true) ───────────────────────────────────────────────
+
+POST {{base_url}}/v1/sandboxes
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+{
+    "template": "{{template_name}}",
+    "name": "e2e-direct-{{unique}}",
+    "persist": true,
+    "storage_size": "5Gi"
+}
+HTTP 202
+[Captures]
+direct_sandbox_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.name" == "e2e-direct-{{unique}}"
+jsonpath "$.status" == "creating"
+
+GET {{base_url}}/v1/sandboxes/{{direct_sandbox_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.persist" == true
+jsonpath "$.storage_size" == "5Gi"
+
+
+# ── List: both sandboxes visible ─────────────────────────────────────────────
+
+GET {{base_url}}/v1/sandboxes
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.total" >= 2
+
+
+# ── Cleanup ──────────────────────────────────────────────────────────────────
+
+DELETE {{base_url}}/v1/sandboxes/{{claim_sandbox_id}}
+Authorization: Bearer {{api_key}}
+HTTP 204
+
+DELETE {{base_url}}/v1/sandboxes/{{direct_sandbox_id}}
+Authorization: Bearer {{api_key}}
+HTTP 204
+
+DELETE {{base_url}}/v1/auth/api-keys/{{api_key_id}}
+HTTP 204

--- a/tests/unit/test_sandbox_service.py
+++ b/tests/unit/test_sandbox_service.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from treadstone.core.errors import InvalidTransitionError
+from treadstone.core.errors import InvalidTransitionError, TemplateNotFoundError
 from treadstone.models.sandbox import Sandbox, SandboxStatus
 
 
@@ -273,3 +273,56 @@ class TestDualPathProvisioning:
         await service.delete(sandbox_id="sb1234567890abcdef", owner_id="user1234567890abcd")
         k8s.delete_sandbox.assert_called_once()
         k8s.delete_sandbox_claim.assert_not_called()
+
+
+class TestTemplateValidation:
+    async def test_claim_path_rejects_invalid_template(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        session.delete = AsyncMock()
+        k8s = _mock_k8s_client()
+        service = SandboxService(session=session, k8s_client=k8s)
+
+        with pytest.raises(TemplateNotFoundError):
+            await service.create(
+                owner_id="user1234567890abcd",
+                template="nonexistent-template",
+                persist=False,
+            )
+
+        k8s.create_sandbox_claim.assert_not_called()
+
+    async def test_direct_path_rejects_invalid_template(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        session.delete = AsyncMock()
+        k8s = _mock_k8s_client()
+        service = SandboxService(session=session, k8s_client=k8s)
+
+        with pytest.raises(TemplateNotFoundError):
+            await service.create(
+                owner_id="user1234567890abcd",
+                template="nonexistent-template",
+                persist=True,
+            )
+
+        k8s.create_sandbox.assert_not_called()
+
+    async def test_invalid_template_cleans_up_db_record(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        session.delete = AsyncMock()
+        k8s = _mock_k8s_client()
+        service = SandboxService(session=session, k8s_client=k8s)
+
+        with pytest.raises(TemplateNotFoundError):
+            await service.create(
+                owner_id="user1234567890abcd",
+                template="nonexistent-template",
+                persist=False,
+            )
+
+        session.delete.assert_called_once()

--- a/treadstone/services/sandbox_service.py
+++ b/treadstone/services/sandbox_service.py
@@ -103,6 +103,10 @@ class SandboxService:
                 await self._create_direct(sandbox, template, storage_size)
             else:
                 await self._create_via_claim(sandbox, template)
+        except TemplateNotFoundError:
+            await self.session.delete(sandbox)
+            await self.session.commit()
+            raise
         except Exception:
             logger.exception("Failed to create K8s resource for sandbox %s", sandbox_id)
             sandbox.status = SandboxStatus.ERROR
@@ -113,7 +117,16 @@ class SandboxService:
 
         return sandbox
 
+    async def _resolve_template(self, namespace: str, template: str) -> dict:
+        templates = await self.k8s.list_sandbox_templates(namespace=namespace)
+        tmpl = next((t for t in templates if t["name"] == template), None)
+        if tmpl is None:
+            raise TemplateNotFoundError(template)
+        return tmpl
+
     async def _create_via_claim(self, sandbox: Sandbox, template: str) -> None:
+        await self._resolve_template(sandbox.k8s_namespace, template)
+
         logger.info("Creating SandboxClaim %s (template=%s, ns=%s)", sandbox.name, template, sandbox.k8s_namespace)
         await self.k8s.create_sandbox_claim(
             name=sandbox.name,
@@ -122,10 +135,7 @@ class SandboxService:
         )
 
     async def _create_direct(self, sandbox: Sandbox, template: str, storage_size: str) -> None:
-        templates = await self.k8s.list_sandbox_templates(namespace=sandbox.k8s_namespace)
-        tmpl = next((t for t in templates if t["name"] == template), None)
-        if tmpl is None:
-            raise TemplateNotFoundError(template)
+        tmpl = await self._resolve_template(sandbox.k8s_namespace, template)
 
         image = tmpl.get("image", "")
         if not image:


### PR DESCRIPTION
## Summary
- Add `create` and `delete` verbs to ClusterRole for `sandboxes` resource (`agents.x-k8s.io`), required by the direct Sandbox CR path (`persist=true`)
- Validate template name against K8s SandboxTemplates before creating SandboxClaim (claim path was missing this check)
- Return 404 immediately for invalid template names instead of creating an error-state sandbox record
- Add E2E test covering dual-path provisioning (claim vs direct) and invalid template rejection

## Test Plan
- [x] `make test` — 150 passed
- [x] `make lint` — all checks passed
- [x] `make test-e2e` — 5/5 files, 36 requests, 100% success


Made with [Cursor](https://cursor.com)