### PR TITLE
chore: add release workflow and update CD Docker tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,8 +46,8 @@ jobs:
         with:
           images: ${{ env.TREADSTONE_IMAGE }}
           tags: |
-            type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=main
+            type=sha,prefix=main-
 
       - uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,153 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+env:
+  REGISTRY: ghcr.io
+  TREADSTONE_IMAGE: ghcr.io/${{ github.repository_owner }}/treadstone
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  # ── Gate: lint + test must pass before any publishing ──
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --frozen
+      - run: make lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --frozen
+      - run: uv run pytest tests/ -v
+        env:
+          TREADSTONE_DATABASE_URL: "postgresql+asyncpg://fake:fake@localhost/fake?sslmode=require"
+
+  # ── Docker image → GHCR ──
+  docker:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.TREADSTONE_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # ── CLI (treadstone) → PyPI ──
+  publish-cli:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
+
+      - run: uv build
+      - run: uv publish --token "$PYPI_API_TOKEN"
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+  # ── SDK (treadstone-sdk) → PyPI ──
+  publish-sdk:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: pip install poetry-core
+
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" sdk/python/pyproject.toml
+
+      - name: Build SDK
+        working-directory: sdk/python
+        run: uv build
+
+      - name: Publish SDK
+        working-directory: sdk/python
+        run: uv publish --token "$PYPI_API_TOKEN"
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+  # ── GitHub Release ──
+  github-release:
+    needs: [docker, publish-cli, publish-sdk]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git tag --sort=-v:refname | head -2 | tail -1)
+          if [ -z "$PREV_TAG" ] || [ "$PREV_TAG" = "$GITHUB_REF_NAME" ]; then
+            LOG=$(git log --oneline --no-decorate -20)
+          else
+            LOG=$(git log --oneline --no-decorate "$PREV_TAG".."$GITHUB_REF_NAME")
+          fi
+          VERSION="${GITHUB_REF_NAME#v}"
+          {
+            echo "body<<CHANGELOG_EOF"
+            echo "## What's Changed"
+            echo ""
+            echo "$LOG" | sed 's/^/- /'
+            echo ""
+            echo "## Install"
+            echo ""
+            echo '```bash'
+            echo "# CLI"
+            echo "pip install treadstone==$VERSION"
+            echo ""
+            echo "# SDK"
+            echo "pip install treadstone-sdk==$VERSION"
+            echo ""
+            echo "# Docker"
+            echo "docker pull ghcr.io/${{ github.repository_owner }}/treadstone:$VERSION"
+            echo '```'
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.changelog.outputs.body }}
+          generate_release_notes: false

--- a/Makefile
+++ b/Makefile
@@ -147,3 +147,13 @@ ship: ## AI commit & push: make ship MSG="feat: add user model"
 	git add -A
 	git commit -m "$(MSG)"
 	git push
+
+# ── Release ─────────────────────────────────────────────────────────────────
+
+release: ## Tag a release: make release V=0.2.0
+	@if [ -z "$(V)" ]; then echo "Usage: make release V=0.2.0"; exit 1; fi
+	@if [ "$$(git symbolic-ref --short HEAD)" != "main" ]; then echo "Error: Must be on main to release."; exit 1; fi
+	@echo "Tagging v$(V) and pushing — this will trigger Docker + PyPI + GitHub Release..."
+	git tag "v$(V)"
+	git push origin "v$(V)"
+	@echo "✓ Release v$(V) triggered. Watch: gh run watch"


### PR DESCRIPTION
## Summary
- **cd.yml**: Main branch Docker tags changed from `latest` to `main` + `main-<sha>`, separating dev channel from release channel
- **release.yml**: New tag-triggered workflow (`v*`) that publishes Docker image (GHCR), CLI (PyPI), SDK (PyPI), and creates GitHub Release with changelog
- **Makefile**: Added `make release V=x.y.z` convenience target

## How it works

### Main branch (every merge)
```
push to main → cd.yml → ghcr.io/.../treadstone:main + :main-abc1234
```

### Release (manual tag)
```
make release V=0.2.0
  → git tag v0.2.0 && git push origin v0.2.0
  → release.yml:
    1. lint + test (gate)
    2. Docker → ghcr.io/.../treadstone:0.2.0 + :0.2 + :latest
    3. CLI   → PyPI treadstone==0.2.0
    4. SDK   → PyPI treadstone-sdk==0.2.0
    5. GitHub Release with changelog
```

## Prerequisites
- [x] `PYPI_API_TOKEN` secret configured
- [ ] GitHub environment `pypi` created (optional, for deployment protection)

## Test Plan
- [x] `make lint` passes
- [x] `make test` — 150 tests pass
- [ ] Verify after merge: `make release V=0.2.0` triggers all jobs


Made with [Cursor](https://cursor.com)