### PR TITLE
fix: allow git tag pushes when checked out on main

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 #
-# Prevent direct pushes to the main branch.
-# All changes must go through Pull Requests.
+# Prevent direct pushes to the remote `main` branch.
+# All branch updates to main must go through Pull Requests.
+#
+# Tag pushes (e.g. git push origin v0.1.1) are allowed from any local branch.
 
-branch="$(git symbolic-ref --short HEAD 2>/dev/null)"
-
-if [ "$branch" = "main" ]; then
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -z "$remote_ref" ] && continue
+  if [[ "$remote_ref" == "refs/heads/main" ]]; then
     echo ""
-    echo "ERROR: Direct push to 'main' is not allowed."
+    echo "ERROR: Direct push to remote 'main' is not allowed."
     echo "       Please create a feature branch and open a Pull Request."
     echo ""
     exit 1
-fi
+  fi
+done


### PR DESCRIPTION
## Problem

`pre-push` blocked **any** `git push` when the current branch was `main`, including `git push origin v0.1.1` (tag-only pushes).

## Change

Read pre-push stdin and only block when `remote_ref` is `refs/heads/main`.

## Test plan

- [x] `git push origin v0.1.1` succeeds from `main` after merge

Made with [Cursor](https://cursor.com)