### PR TITLE
fix(ci): use macos-15-intel for darwin-amd64 release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,8 @@ jobs:
             artifact_name: treadstone-linux-amd64
           - os: macos-latest
             artifact_name: treadstone-darwin-arm64
-          - os: macos-13
+          # macos-13 retired Dec 2025; Intel macOS builds use macos-15-intel (x86_64).
+          - os: macos-15-intel
             artifact_name: treadstone-darwin-amd64
           - os: windows-latest
             artifact_name: treadstone-windows-amd64.exe


### PR DESCRIPTION
## Problem

`build-binaries (macos-13, treadstone-darwin-amd64)` fails: GitHub no longer supports the `macos-13` hosted runner image.

## Change

Use `macos-15-intel` for Intel (x86_64) macOS PyInstaller artifacts per GitHub’s current runner guidance.

## Test plan

- [ ] Merge and re-tag `v0.1.1` to re-run the Release workflow; confirm all four `build-binaries` jobs succeed.

Made with [Cursor](https://cursor.com)