### PR TITLE
fix(ci): unblock release workflow (Docker, Windows, PyPI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
   publish-cli:
     needs: [lint, test]
     runs-on: ubuntu-latest
+    continue-on-error: true
     environment: pypi
     steps:
       - uses: actions/checkout@v4
@@ -85,6 +86,7 @@ jobs:
   publish-sdk:
     needs: [lint, test]
     runs-on: ubuntu-latest
+    continue-on-error: true
     environment: pypi
     steps:
       - uses: actions/checkout@v4
@@ -130,10 +132,14 @@ jobs:
       - name: Set version from tag
         shell: python
         run: |
-          import re, pathlib, os
+          import os
+          import re
+          from pathlib import Path
+
           ver = os.environ["GITHUB_REF_NAME"].lstrip("v")
-          p = pathlib.Path("pyproject.toml")
-          p.write_text(re.sub(r"(?m)^version = .*", f'version = "{ver}"', p.read_text()))
+          p = Path("pyproject.toml")
+          text = p.read_text(encoding="utf-8")
+          p.write_text(re.sub(r"(?m)^version = .*", f'version = "{ver}"', text), encoding="utf-8")
 
       - name: Install dependencies + PyInstaller
         run: uv sync --frozen && uv pip install pyinstaller

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 
 RUN pip install --no-cache-dir uv
 
-COPY pyproject.toml uv.lock ./
+# hatchling validates readme from pyproject.toml during the install phase
+COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --frozen --no-dev
 
 COPY treadstone/ treadstone/


### PR DESCRIPTION
## Summary

- **Docker**: copy `README.md` before `uv sync` — hatchling validates `readme` from `pyproject.toml` during install.
- **build-binaries (Windows)**: bump version with `read_text`/`write_text` using **UTF-8** (default cp1252 breaks on non-ASCII in `pyproject.toml`).
- **PyPI jobs**: `continue-on-error: true` so a duplicate upload (e.g. re-pushing the same version tag) or transient PyPI issues do not block **GitHub Release** and standalone binaries.

## Test plan

- [ ] Merge, delete + recreate `v0.1.1` tag (or tag `v0.1.2`) and confirm Release workflow completes with `github-release` + four binary assets.

Made with [Cursor](https://cursor.com)