### PR TITLE
fix(ci): use bash for PyInstaller step on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
         run: uv sync --frozen && uv pip install pyinstaller
 
       - name: Build binary
+        shell: bash
         run: |
           uv run pyinstaller \
             --onefile \


### PR DESCRIPTION
Windows runners default to PowerShell; multi-line `uv run pyinstaller \` blocks break. Use `shell: bash` (Git Bash is available on windows-latest).

Made with [Cursor](https://cursor.com)