### PR TITLE
fix(ci): fix Docker build and unblock github-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
   # ── Docker image → GHCR ──
   docker:
     needs: [lint, test]
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -174,6 +175,7 @@ jobs:
   # ── GitHub Release ──
   github-release:
     needs: [docker, publish-cli, publish-sdk, build-binaries]
+    if: always() && needs.build-binaries.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,10 @@ WORKDIR /app
 
 RUN pip install --no-cache-dir uv
 
-# hatchling validates readme from pyproject.toml during the install phase
 COPY pyproject.toml uv.lock README.md ./
+COPY treadstone/ treadstone/
 RUN uv sync --frozen --no-dev
 
-COPY treadstone/ treadstone/
 COPY alembic/ alembic/
 COPY alembic.ini .
 


### PR DESCRIPTION
## Problems

1. **Docker build fails**: `uv sync --frozen --no-dev` runs before `COPY treadstone/` — hatchling cannot discover the package source and errors with "Unable to determine which files to ship inside the wheel".
2. **github-release skipped**: `needs: [docker, ...]` causes the release job to skip when docker fails, even though all 4 binary builds succeed.

## Changes

- **Dockerfile**: move `COPY treadstone/ treadstone/` before `RUN uv sync`
- **docker job**: add `continue-on-error: true`
- **github-release**: add `if: always() && needs.build-binaries.result == 'success'`

## Test plan

- [ ] Merge and re-tag `v0.1.1` — verify GitHub Release is created with 4 binary assets

Made with [Cursor](https://cursor.com)