### PR TITLE
feat(cli): friendly errors, local config, and CLI docs

### DIFF
--- a/treadstone/cli/README.md
+++ b/treadstone/cli/README.md
@@ -1,0 +1,212 @@
+# Treadstone CLI
+
+Command-line interface for the Treadstone sandbox service.
+
+## Installation
+
+### From PyPI
+
+```bash
+pip install treadstone
+```
+
+### Pre-built binary
+
+Download the latest release from [GitHub Releases](https://github.com/earayu/treadstone/releases). The binary is self-contained and does not require Python.
+
+```bash
+# macOS / Linux
+chmod +x treadstone
+sudo mv treadstone /usr/local/bin/
+```
+
+## Quick start
+
+```bash
+# Check that the server is reachable
+treadstone health
+
+# Register an account (first time only)
+treadstone auth register
+
+# Log in
+treadstone auth login
+
+# Create an API key for non-interactive use
+treadstone api-keys create --name my-key
+# Save the key — it is shown only once
+
+# Store the key in config so you don't have to pass it every time
+treadstone config set api_key ts_live_xxxxxxxxxxxx
+
+# Create a sandbox
+treadstone sandboxes create --template default --name my-sandbox
+
+# List sandboxes
+treadstone sb list
+```
+
+## Configuration
+
+The CLI reads configuration from three sources, in order of priority:
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 (highest) | CLI flags | `--base-url https://... --api-key ts_...` |
+| 2 | Environment variables | `TREADSTONE_BASE_URL`, `TREADSTONE_API_KEY` |
+| 3 (lowest) | Config file | `~/.config/treadstone/config.toml` |
+
+### Config file
+
+Location: `~/.config/treadstone/config.toml`
+
+```toml
+[default]
+base_url = "https://your-server.example.com"
+api_key  = "ts_live_xxxxxxxxxxxx"
+```
+
+You can manage this file with the `config` subcommand:
+
+```bash
+# Set a value
+treadstone config set base_url https://your-server.example.com
+treadstone config set api_key ts_live_xxxxxxxxxxxx
+
+# View current settings (api_key is partially masked)
+treadstone config get
+
+# View a single key
+treadstone config get base_url
+
+# Remove a value
+treadstone config unset api_key
+
+# Show config file path
+treadstone config path
+```
+
+### Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TREADSTONE_BASE_URL` | Base URL of the Treadstone server | `http://localhost:8000` |
+| `TREADSTONE_API_KEY` | API key for authentication | (none) |
+
+### Global flags
+
+| Flag | Description |
+|------|-------------|
+| `--base-url URL` | Override the server URL |
+| `--api-key KEY` | Override the API key |
+| `--json` | Output responses as JSON (useful for scripting) |
+| `--version` | Show CLI version |
+| `--help` | Show help message |
+
+## Commands
+
+### `health`
+
+Check if the server is reachable and healthy.
+
+```bash
+treadstone health
+# Server is healthy
+```
+
+### `auth`
+
+Authentication and user management.
+
+```bash
+treadstone auth register                 # Create a new account
+treadstone auth login                    # Log in interactively
+treadstone auth logout                   # Log out
+treadstone auth whoami                   # Show current user info
+treadstone auth change-password          # Change your password
+treadstone auth invite --email user@example.com   # Invite a user (admin)
+treadstone auth users                    # List all users (admin)
+treadstone auth delete-user <user-id>    # Delete a user (admin)
+```
+
+### `sandboxes` (alias: `sb`)
+
+Create and manage sandboxes.
+
+```bash
+treadstone sb create --template default --name my-box
+treadstone sb create --template python --label env:dev --persist
+treadstone sb list
+treadstone sb list --label env:prod --limit 10
+treadstone sb get <sandbox-id>
+treadstone sb start <sandbox-id>
+treadstone sb stop <sandbox-id>
+treadstone sb delete <sandbox-id>
+treadstone sb token <sandbox-id>                    # Get an access token
+treadstone sb token <sandbox-id> --expires-in 7200  # Custom TTL
+```
+
+### `templates`
+
+List available sandbox templates.
+
+```bash
+treadstone templates list
+```
+
+### `api-keys`
+
+Manage long-lived API keys.
+
+```bash
+treadstone api-keys create --name ci-bot
+treadstone api-keys create --name temp --expires-in 86400  # 24h
+treadstone api-keys list
+treadstone api-keys delete <key-id>
+```
+
+### `config`
+
+Manage local CLI configuration.
+
+```bash
+treadstone config set base_url https://...
+treadstone config set api_key ts_...
+treadstone config get
+treadstone config get base_url
+treadstone config unset api_key
+treadstone config path
+```
+
+## JSON output
+
+Pass `--json` before any command to get machine-readable JSON output:
+
+```bash
+treadstone --json sb list
+treadstone --json health
+treadstone --json api-keys list
+```
+
+## Error handling
+
+The CLI displays user-friendly error messages instead of stack traces:
+
+```
+Error: Connection refused.
+  Possible causes:
+    - The Treadstone server is not running
+    - The --base-url or TREADSTONE_BASE_URL is incorrect
+    - A firewall or proxy is blocking the connection
+  Detail: ...
+```
+
+Common errors:
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Connection refused | Server not running or wrong URL | Check `treadstone config get base_url` |
+| Request timed out | Server slow or unreachable | Retry, or check network |
+| No API key configured | Missing authentication | `treadstone config set api_key <key>` |
+| HTTP 401 | Invalid or expired API key | Create a new key with `treadstone api-keys create` |
+| HTTP 404 | Resource not found | Verify the ID is correct |

--- a/treadstone/cli/__main__.py
+++ b/treadstone/cli/__main__.py
@@ -1,6 +1,7 @@
 """Entry point for `python -m treadstone.cli` and PyInstaller builds."""
 
+from treadstone.cli._output import friendly_exception_handler
 from treadstone.cli.main import cli
 
 if __name__ == "__main__":
-    cli()
+    friendly_exception_handler(cli)()

--- a/treadstone/cli/_output.py
+++ b/treadstone/cli/_output.py
@@ -7,10 +7,60 @@ import sys
 from typing import Any
 
 import click
+import httpx
 from rich.console import Console
 from rich.table import Table
 
 console = Console()
+
+
+def friendly_exception_handler(cli_main: click.Group) -> click.Group:
+    """Wrap a Click group so unhandled exceptions print user-friendly messages instead of tracebacks."""
+    original_main = cli_main.main
+
+    def _patched_main(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return original_main(*args, standalone_mode=False, **kwargs)
+        except click.exceptions.Abort:
+            click.echo("\nAborted.", err=True)
+            sys.exit(130)
+        except click.exceptions.Exit as exc:
+            sys.exit(exc.exit_code)
+        except click.UsageError as exc:
+            exc.show()
+            sys.exit(exc.exit_code if exc.exit_code is not None else 2)
+        except SystemExit:
+            raise
+        except KeyboardInterrupt:
+            click.echo("\nInterrupted.", err=True)
+            sys.exit(130)
+        except httpx.ConnectError as exc:
+            _print_network_hint(str(exc), "Connection refused")
+            sys.exit(1)
+        except httpx.TimeoutException:
+            click.echo("Error: Request timed out. The server may be slow or unreachable.", err=True)
+            sys.exit(1)
+        except httpx.HTTPStatusError as exc:
+            click.echo(f"Error: HTTP {exc.response.status_code} — {exc.response.text[:200]}", err=True)
+            sys.exit(1)
+        except httpx.HTTPError as exc:
+            click.echo(f"Error: {type(exc).__name__} — {exc}", err=True)
+            sys.exit(1)
+        except Exception as exc:
+            click.echo(f"Error: {exc}", err=True)
+            sys.exit(1)
+
+    cli_main.main = _patched_main  # type: ignore[assignment]
+    return cli_main
+
+
+def _print_network_hint(detail: str, summary: str) -> None:
+    click.echo(f"Error: {summary}.", err=True)
+    click.echo("  Possible causes:", err=True)
+    click.echo("    - The Treadstone server is not running", err=True)
+    click.echo("    - The --base-url or TREADSTONE_BASE_URL is incorrect", err=True)
+    click.echo("    - A firewall or proxy is blocking the connection", err=True)
+    click.echo(f"  Detail: {detail}", err=True)
 
 
 def is_json_mode(ctx: click.Context) -> bool:

--- a/treadstone/cli/api_keys.py
+++ b/treadstone/cli/api_keys.py
@@ -10,7 +10,16 @@ from treadstone.cli._output import handle_error, is_json_mode, print_json, print
 
 @click.group()
 def api_keys() -> None:
-    """Manage API keys."""
+    """Manage API keys.
+
+    API keys provide long-lived authentication tokens for programmatic access.
+
+    \b
+    Examples:
+      treadstone api-keys create --name ci-bot
+      treadstone api-keys list
+      treadstone api-keys delete <key-id>
+    """
 
 
 @api_keys.command("create")
@@ -18,7 +27,10 @@ def api_keys() -> None:
 @click.option("--expires-in", default=None, type=int, help="Key lifetime in seconds.")
 @click.pass_context
 def create_key(ctx: click.Context, name: str, expires_in: int | None) -> None:
-    """Create a new API key."""
+    """Create a new API key.
+
+    The full key is shown only once — store it securely.
+    """
     client = require_auth(ctx)
     body: dict = {"name": name}
     if expires_in is not None:
@@ -37,7 +49,7 @@ def create_key(ctx: click.Context, name: str, expires_in: int | None) -> None:
 @api_keys.command("list")
 @click.pass_context
 def list_keys(ctx: click.Context) -> None:
-    """List API keys."""
+    """List all API keys for the current user."""
     client = require_auth(ctx)
     resp = client.get("/v1/auth/api-keys")
     handle_error(resp)
@@ -54,7 +66,7 @@ def list_keys(ctx: click.Context) -> None:
 @click.argument("key_id")
 @click.pass_context
 def delete_key(ctx: click.Context, key_id: str) -> None:
-    """Delete an API key."""
+    """Revoke and delete an API key."""
     client = require_auth(ctx)
     resp = client.delete(f"/v1/auth/api-keys/{key_id}")
     handle_error(resp)

--- a/treadstone/cli/auth.py
+++ b/treadstone/cli/auth.py
@@ -10,7 +10,16 @@ from treadstone.cli._output import handle_error, is_json_mode, print_detail, pri
 
 @click.group()
 def auth() -> None:
-    """Authentication and user management."""
+    """Authentication and user management.
+
+    Register, log in, manage users, and change passwords.
+
+    \b
+    Quick start:
+      treadstone auth register          Create a new account
+      treadstone auth login             Log in (saves session)
+      treadstone auth whoami            Verify current identity
+    """
 
 
 @auth.command("login")
@@ -18,7 +27,10 @@ def auth() -> None:
 @click.option("--password", required=True, prompt=True, hide_input=True, help="Account password.")
 @click.pass_context
 def login(ctx: click.Context, email: str, password: str) -> None:
-    """Log in with email and password."""
+    """Log in with email and password.
+
+    If --email or --password are not provided, you will be prompted interactively.
+    """
     client = build_client(ctx)
     resp = client.post("/v1/auth/login", json={"email": email, "password": password})
     handle_error(resp)
@@ -48,7 +60,10 @@ def logout(ctx: click.Context) -> None:
 @click.option("--invitation-token", default=None, help="Invitation token (required in invitation mode).")
 @click.pass_context
 def register(ctx: click.Context, email: str, password: str, invitation_token: str | None) -> None:
-    """Register a new account."""
+    """Register a new account.
+
+    In invitation-only mode, an --invitation-token is required.
+    """
     client = build_client(ctx)
     body: dict = {"email": email, "password": password}
     if invitation_token:
@@ -98,7 +113,7 @@ def change_password(ctx: click.Context, old_password: str, new_password: str) ->
 @click.option("--role", default="ro", help="Role for the invitee (admin or ro).")
 @click.pass_context
 def invite(ctx: click.Context, email: str, role: str) -> None:
-    """Invite a new user (admin only)."""
+    """Generate an invitation token for a new user (admin only)."""
     client = require_auth(ctx)
     resp = client.post("/v1/auth/invite", json={"email": email, "role": role})
     handle_error(resp)
@@ -114,7 +129,7 @@ def invite(ctx: click.Context, email: str, role: str) -> None:
 @click.option("--offset", default=0, type=int, help="Skip N results.")
 @click.pass_context
 def list_users(ctx: click.Context, limit: int, offset: int) -> None:
-    """List users."""
+    """List all registered users (admin only)."""
     client = require_auth(ctx)
     resp = client.get("/v1/auth/users", params={"limit": limit, "offset": offset})
     handle_error(resp)

--- a/treadstone/cli/config_cmd.py
+++ b/treadstone/cli/config_cmd.py
@@ -1,27 +1,157 @@
-"""Config commands."""
+"""Local CLI configuration commands.
+
+Manages ~/.config/treadstone/config.toml which stores defaults for
+base_url, api_key, and other settings so they don't need to be passed
+as flags or env vars every time.
+"""
 
 from __future__ import annotations
 
 import click
 
-from treadstone.cli._client import build_client
-from treadstone.cli._output import handle_error, is_json_mode, print_detail, print_json
+from treadstone.cli._client import CONFIG_DIR, CONFIG_FILE, _read_config
+
+
+def _write_config(data: dict[str, dict[str, str]]) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    for section, kvs in data.items():
+        lines.append(f"[{section}]")
+        for k, v in kvs.items():
+            lines.append(f'{k} = "{v}"')
+        lines.append("")
+    CONFIG_FILE.write_text("\n".join(lines))
+
+
+_VALID_KEYS = ("base_url", "api_key")
 
 
 @click.group()
 def config() -> None:
-    """Server configuration."""
+    """Manage local CLI configuration.
+
+    Configuration is stored in ~/.config/treadstone/config.toml and provides
+    default values for --base-url and --api-key so they don't need to be
+    repeated on every command invocation.
+
+    \b
+    Priority (highest to lowest):
+      1. CLI flags   (--base-url, --api-key)
+      2. Env vars    (TREADSTONE_BASE_URL, TREADSTONE_API_KEY)
+      3. Config file (~/.config/treadstone/config.toml)
+    """
 
 
-@config.command("show")
-@click.pass_context
-def show(ctx: click.Context) -> None:
-    """Show server configuration."""
-    client = build_client(ctx)
-    resp = client.get("/v1/config")
-    handle_error(resp)
-    data = resp.json()
-    if is_json_mode(ctx):
-        print_json(data)
+@config.command("set")
+@click.argument("key", type=click.Choice(_VALID_KEYS, case_sensitive=False))
+@click.argument("value")
+def set_value(key: str, value: str) -> None:
+    """Set a configuration value.
+
+    \b
+    Available keys:
+      base_url   Base URL of the Treadstone server
+      api_key    Default API key for authentication
+
+    \b
+    Examples:
+      treadstone config set base_url https://my-server.example.com
+      treadstone config set api_key ts_live_xxxxxxxxxxxx
+    """
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    raw: dict[str, dict[str, str]] = {}
+    if CONFIG_FILE.exists():
+        with open(CONFIG_FILE, "rb") as f:
+            raw = tomllib.load(f)  # type: ignore[assignment]
+
+    section = raw.setdefault("default", {})
+    section[key] = value
+    _write_config(raw)
+    click.echo(f"Set {key} = {value}")
+
+
+@config.command("get")
+@click.argument("key", required=False, default=None)
+def get_value(key: str | None) -> None:
+    """Get a configuration value (or all values if no key given).
+
+    \b
+    Examples:
+      treadstone config get              Show all config values
+      treadstone config get base_url     Show only base_url
+    """
+    data = _read_config()
+    if not data:
+        click.echo("No configuration set. Run 'treadstone config set <key> <value>' to get started.")
+        return
+
+    if key is not None:
+        if key not in _VALID_KEYS:
+            click.echo(f"Error: Unknown key '{key}'. Valid keys: {', '.join(_VALID_KEYS)}", err=True)
+            raise SystemExit(1)
+        val = data.get(key)
+        if val is None:
+            click.echo(f"{key} is not set.")
+        else:
+            display = _mask_secret(key, val)
+            click.echo(f"{key} = {display}")
     else:
-        print_detail(data.get("auth", data), title="Server Config")
+        for k in _VALID_KEYS:
+            val = data.get(k)
+            if val is not None:
+                click.echo(f"{k} = {_mask_secret(k, val)}")
+
+
+@config.command("unset")
+@click.argument("key", type=click.Choice(_VALID_KEYS, case_sensitive=False))
+def unset_value(key: str) -> None:
+    """Remove a configuration value.
+
+    \b
+    Example:
+      treadstone config unset api_key
+    """
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    if not CONFIG_FILE.exists():
+        click.echo(f"{key} is not set.")
+        return
+
+    with open(CONFIG_FILE, "rb") as f:
+        raw: dict[str, dict[str, str]] = tomllib.load(f)  # type: ignore[assignment]
+
+    section = raw.get("default", {})
+    if key not in section:
+        click.echo(f"{key} is not set.")
+        return
+
+    del section[key]
+    _write_config(raw)
+    click.echo(f"Unset {key}.")
+
+
+@config.command("path")
+def show_path() -> None:
+    """Print the path to the configuration file.
+
+    \b
+    Example:
+      treadstone config path
+    """
+    exists = CONFIG_FILE.exists()
+    click.echo(str(CONFIG_FILE))
+    if not exists:
+        click.echo("  (file does not exist yet)")
+
+
+def _mask_secret(key: str, value: str) -> str:
+    if key == "api_key" and len(value) > 8:
+        return value[:8] + "..." + value[-4:]
+    return value

--- a/treadstone/cli/main.py
+++ b/treadstone/cli/main.py
@@ -5,22 +5,46 @@ from __future__ import annotations
 import click
 
 from treadstone.cli._client import build_client
-from treadstone.cli._output import handle_error, is_json_mode, print_json
+from treadstone.cli._output import friendly_exception_handler, handle_error, is_json_mode, print_json
+
+_EPILOG = """\b
+Configuration (highest to lowest priority):
+  CLI flags       --api-key, --base-url
+  Env vars        TREADSTONE_API_KEY, TREADSTONE_BASE_URL
+  Config file     ~/.config/treadstone/config.toml
+
+  Run 'treadstone config --help' to manage the config file.
+
+Examples:
+  treadstone health                         Check server status
+  treadstone sandboxes list                 List running sandboxes
+  treadstone sb create --template default   Create a sandbox
+  treadstone auth login                     Log in with email/password
+"""
 
 
-@click.group()
+@click.group(epilog=_EPILOG)
 @click.option("--json", "json_output", is_flag=True, default=False, help="Output in JSON format.")
-@click.option("--api-key", envvar="TREADSTONE_API_KEY", default=None, help="API key for authentication.")
+@click.option(
+    "--api-key",
+    envvar="TREADSTONE_API_KEY",
+    default=None,
+    help="API key for authentication (env: TREADSTONE_API_KEY).",
+)
 @click.option(
     "--base-url",
     envvar="TREADSTONE_BASE_URL",
     default=None,
-    help="Base URL of the Treadstone server.",
+    help="Base URL of the Treadstone server (env: TREADSTONE_BASE_URL).",
 )
 @click.version_option(package_name="treadstone")
 @click.pass_context
 def cli(ctx: click.Context, json_output: bool, api_key: str | None, base_url: str | None) -> None:
-    """Treadstone — Agent-native sandbox service."""
+    """Treadstone CLI — manage sandboxes, templates, and API keys.
+
+    An agent-native sandbox service. Run code, build projects, and deploy
+    environments via the command line.
+    """
     ctx.ensure_object(dict)
     ctx.obj["json_output"] = json_output
     if api_key:
@@ -32,7 +56,7 @@ def cli(ctx: click.Context, json_output: bool, api_key: str | None, base_url: st
 @cli.command()
 @click.pass_context
 def health(ctx: click.Context) -> None:
-    """Check server health."""
+    """Check if the Treadstone server is reachable and healthy."""
     client = build_client(ctx)
     resp = client.get("/health")
     handle_error(resp)
@@ -56,3 +80,5 @@ cli.add_command(sandboxes)
 cli.add_command(sandboxes, "sb")
 cli.add_command(templates)
 cli.add_command(config)
+
+friendly_exception_handler(cli)

--- a/treadstone/cli/sandboxes.py
+++ b/treadstone/cli/sandboxes.py
@@ -10,7 +10,17 @@ from treadstone.cli._output import handle_error, is_json_mode, print_detail, pri
 
 @click.group()
 def sandboxes() -> None:
-    """Manage sandboxes."""
+    """Manage sandboxes.
+
+    Create, list, start, stop, and delete sandboxes. Use 'sb' as a shorthand.
+
+    \b
+    Examples:
+      treadstone sandboxes create --template default --name my-box
+      treadstone sb list
+      treadstone sb get <sandbox-id>
+      treadstone sb delete <sandbox-id>
+    """
 
 
 @sandboxes.command("create")
@@ -28,7 +38,14 @@ def create(
     persist: bool,
     storage_size: str,
 ) -> None:
-    """Create a new sandbox."""
+    """Create a new sandbox from a template.
+
+    \b
+    Examples:
+      treadstone sb create --template default
+      treadstone sb create --template python --name dev-box --label env:dev
+      treadstone sb create --template node --persist --storage-size 20Gi
+    """
     client = require_auth(ctx)
     labels = {}
     for lbl in label:
@@ -55,7 +72,13 @@ def create(
 @click.option("--offset", default=0, type=int, help="Skip N results.")
 @click.pass_context
 def list_sandboxes(ctx: click.Context, label: str | None, limit: int, offset: int) -> None:
-    """List sandboxes."""
+    """List sandboxes with optional filtering.
+
+    \b
+    Examples:
+      treadstone sb list
+      treadstone sb list --label env:prod --limit 10
+    """
     client = require_auth(ctx)
     params: dict = {"limit": limit, "offset": offset}
     if label:
@@ -75,7 +98,7 @@ def list_sandboxes(ctx: click.Context, label: str | None, limit: int, offset: in
 @click.argument("sandbox_id")
 @click.pass_context
 def get_sandbox(ctx: click.Context, sandbox_id: str) -> None:
-    """Get sandbox details."""
+    """Show detailed information about a sandbox."""
     client = require_auth(ctx)
     resp = client.get(f"/v1/sandboxes/{sandbox_id}")
     handle_error(resp)
@@ -132,7 +155,11 @@ def stop_sandbox(ctx: click.Context, sandbox_id: str) -> None:
 @click.option("--expires-in", default=3600, type=int, help="Token lifetime in seconds.")
 @click.pass_context
 def create_token(ctx: click.Context, sandbox_id: str, expires_in: int) -> None:
-    """Create an access token for a sandbox."""
+    """Create a short-lived access token for a sandbox.
+
+    The token can be used to connect to the sandbox directly (e.g. via
+    WebSocket) without needing the main API key.
+    """
     client = require_auth(ctx)
     resp = client.post(f"/v1/sandboxes/{sandbox_id}/token", json={"expires_in": expires_in})
     handle_error(resp)

--- a/treadstone/cli/templates.py
+++ b/treadstone/cli/templates.py
@@ -10,13 +10,20 @@ from treadstone.cli._output import handle_error, is_json_mode, print_json, print
 
 @click.group()
 def templates() -> None:
-    """Manage sandbox templates."""
+    """Manage sandbox templates.
+
+    Templates define the runtime environment (image, CPU, memory) for sandboxes.
+
+    \b
+    Examples:
+      treadstone templates list
+    """
 
 
 @templates.command("list")
 @click.pass_context
 def list_templates(ctx: click.Context) -> None:
-    """List available sandbox templates."""
+    """List all available sandbox templates with resource specs."""
     client = require_auth(ctx)
     resp = client.get("/v1/sandbox-templates")
     handle_error(resp)


### PR DESCRIPTION
## Summary
- Wrap Click entry with `friendly_exception_handler` so network/timeout/HTTP errors and interrupts show short messages instead of tracebacks (pip + PyInstaller).
- Replace `config show` (server `/v1/config`) with local-only commands: `config set|get|unset|path` for `~/.config/treadstone/config.toml` (mask API keys in `get`).
- Expand root `--help` epilog and subcommand docstrings; add [treadstone/cli/README.md](treadstone/cli/README.md) for install, env vars, and examples.

## Test plan
- [x] `uv run ruff check treadstone/cli/`
- [x] `uv run ruff format treadstone/cli/`

Made with [Cursor](https://cursor.com)