### PR TITLE
fix: CLI __main__ double-wrap and demo Helm LoadBalancer

### DIFF
--- a/deploy/treadstone/values-demo.yaml
+++ b/deploy/treadstone/values-demo.yaml
@@ -7,6 +7,10 @@ image:
 
 envSecretRef: treadstone-secrets
 
+service:
+  type: LoadBalancer
+  port: 8000
+
 resources:
   limits:
     cpu: 500m
@@ -22,11 +26,4 @@ hpa:
   enabled: false
 
 ingress:
-  enabled: true
-  className: nginx
-  annotations: {}
-  hosts:
-    - host: demo.treadstone-ai.dev
-      paths:
-        - path: /
-          pathType: Prefix
+  enabled: false

--- a/treadstone/cli/__main__.py
+++ b/treadstone/cli/__main__.py
@@ -1,7 +1,6 @@
 """Entry point for `python -m treadstone.cli` and PyInstaller builds."""
 
-from treadstone.cli._output import friendly_exception_handler
 from treadstone.cli.main import cli
 
 if __name__ == "__main__":
-    friendly_exception_handler(cli)()
+    cli()


### PR DESCRIPTION
## Summary
- Fix `python -m treadstone.cli` / `python -m treadstone.cli` entrypoint: remove second `friendly_exception_handler(cli)` wrap so `config set` and other subcommands no longer raise `standalone_mode` duplicate keyword errors.
- Adjust `deploy/treadstone/values-demo.yaml` for clusters without nginx ingress (e.g. ACK with ALB only): expose the app via `LoadBalancer` and disable Ingress.

## Test plan
- [x] `make lint`
- [x] `make test`

Made with [Cursor](https://cursor.com)