### PR TITLE
fix: demo values use ALB Ingress instead of LoadBalancer

### DIFF
--- a/deploy/treadstone/values-demo.yaml
+++ b/deploy/treadstone/values-demo.yaml
@@ -7,10 +7,6 @@ image:
 
 envSecretRef: treadstone-secrets
 
-service:
-  type: LoadBalancer
-  port: 8000
-
 resources:
   limits:
     cpu: 500m
@@ -26,4 +22,12 @@ hpa:
   enabled: false
 
 ingress:
-  enabled: false
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/order: "1"
+  hosts:
+    - host: demo.treadstone-ai.dev
+      paths:
+        - path: /
+          pathType: Prefix


### PR DESCRIPTION
## Summary
- Replace `Service: LoadBalancer` with standard `Ingress` + `ingressClassName: alb` for the demo environment on ACK
- Keeps architecture consistent across local (nginx), demo (alb), and prod (alb + TLS) — all use Ingress, only `className` and annotations differ
- Add `alb.ingress.kubernetes.io/order: "1"` annotation so treadstone rules take priority over the existing wildcard-host aperag Ingress on the shared ALB instance

## Test plan
- [x] Deployed to ACK and verified via `curl -H "Host: demo.treadstone-ai.dev" http://<ALB>/health` returns `{"status":"ok"}`
- [x] Full smoke test: login, list templates, API key creation all pass through ALB
- [x] Service confirmed as ClusterIP (no stale LoadBalancer)

Made with [Cursor](https://cursor.com)