### PR TITLE
feat: add install scripts and release checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,16 @@ jobs:
           path: artifacts/
           merge-multiple: true
 
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum * > checksums.txt
+
+      - name: Add install scripts
+        run: |
+          cp scripts/install.sh  artifacts/install.sh
+          cp scripts/install.ps1 artifacts/install.ps1
+
       - name: Generate changelog
         id: changelog
         run: |
@@ -218,26 +228,37 @@ jobs:
             echo ""
             echo "## Install"
             echo ""
+            echo "**macOS / Linux — one-liner:**"
             echo '```bash'
-            echo "# Standalone binary (no Python required)"
-            echo "# macOS (Apple Silicon)"
-            echo "curl -L https://github.com/${{ github.repository }}/releases/download/v$VERSION/treadstone-darwin-arm64 -o treadstone && chmod +x treadstone"
+            echo "curl -fsSL https://github.com/${{ github.repository }}/releases/download/v$VERSION/install.sh | sh"
+            echo '```'
             echo ""
-            echo "# macOS (Intel)"
-            echo "curl -L https://github.com/${{ github.repository }}/releases/download/v$VERSION/treadstone-darwin-amd64 -o treadstone && chmod +x treadstone"
+            echo "**Windows — PowerShell:**"
+            echo '```powershell'
+            echo "irm https://github.com/${{ github.repository }}/releases/download/v$VERSION/install.ps1 | iex"
+            echo '```'
             echo ""
-            echo "# Linux"
-            echo "curl -L https://github.com/${{ github.repository }}/releases/download/v$VERSION/treadstone-linux-amd64 -o treadstone && chmod +x treadstone"
-            echo ""
-            echo "# Python / pip"
+            echo "**pip:**"
+            echo '```bash'
             echo "pip install treadstone==$VERSION"
+            echo '```'
             echo ""
-            echo "# SDK"
-            echo "pip install treadstone-sdk==$VERSION"
-            echo ""
-            echo "# Docker"
+            echo "**Docker:**"
+            echo '```bash'
             echo "docker pull ghcr.io/${{ github.repository_owner }}/treadstone:$VERSION"
             echo '```'
+            echo ""
+            echo "**Manual download:**"
+            echo '```bash'
+            echo "# macOS (Apple Silicon)"
+            echo "curl -fsSL https://github.com/${{ github.repository }}/releases/download/v$VERSION/treadstone-darwin-arm64 -o treadstone && chmod +x treadstone"
+            echo "# macOS (Intel)"
+            echo "curl -fsSL https://github.com/${{ github.repository }}/releases/download/v$VERSION/treadstone-darwin-amd64 -o treadstone && chmod +x treadstone"
+            echo "# Linux"
+            echo "curl -fsSL https://github.com/${{ github.repository }}/releases/download/v$VERSION/treadstone-linux-amd64 -o treadstone && chmod +x treadstone"
+            echo '```'
+            echo ""
+            echo "> SHA-256 checksums available in \`checksums.txt\`."
             echo "CHANGELOG_EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,85 @@
+# Treadstone CLI installer for Windows
+# Usage (PowerShell):
+#   irm https://github.com/earayu/treadstone/releases/latest/download/install.ps1 | iex
+#
+# Environment variables:
+#   $env:TREADSTONE_VERSION     Override version (e.g. "v0.1.4"). Default: latest release.
+#   $env:TREADSTONE_INSTALL_DIR Override install directory. Default: $env:LOCALAPPDATA\treadstone
+
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+
+$ErrorActionPreference = "Stop"
+
+$Repo    = "earayu/treadstone"
+$Artifact = "treadstone-windows-amd64.exe"
+$BinaryName = "treadstone.exe"
+
+# ── Resolve version / URL ────────────────────────────────────────────────────
+
+$Version = if ($env:TREADSTONE_VERSION) { $env:TREADSTONE_VERSION } else { "latest" }
+
+if ($Version -eq "latest") {
+    $BaseUrl = "https://github.com/$Repo/releases/latest/download"
+} else {
+    $BaseUrl = "https://github.com/$Repo/releases/download/$Version"
+}
+
+# ── Resolve install dir ──────────────────────────────────────────────────────
+
+$InstallDir = if ($env:TREADSTONE_INSTALL_DIR) {
+    $env:TREADSTONE_INSTALL_DIR
+} else {
+    Join-Path $env:LOCALAPPDATA "treadstone"
+}
+
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir | Out-Null
+}
+
+$InstallPath = Join-Path $InstallDir $BinaryName
+
+# ── Download ─────────────────────────────────────────────────────────────────
+
+Write-Host "Downloading $Artifact from $BaseUrl ..."
+Invoke-WebRequest -Uri "$BaseUrl/$Artifact" -OutFile $InstallPath -UseBasicParsing
+
+# ── Checksum verification (best-effort) ──────────────────────────────────────
+
+$ChecksumsUrl = "$BaseUrl/checksums.txt"
+$TmpChecksums = Join-Path $env:TEMP "treadstone-checksums.txt"
+
+try {
+    Invoke-WebRequest -Uri $ChecksumsUrl -OutFile $TmpChecksums -UseBasicParsing -ErrorAction Stop
+    $Lines = Get-Content $TmpChecksums
+    $Expected = ($Lines | Where-Object { $_ -match $Artifact }) -replace "\s+.*", ""
+    if ($Expected) {
+        $Actual = (Get-FileHash -Path $InstallPath -Algorithm SHA256).Hash.ToLower()
+        if ($Expected.ToLower() -eq $Actual) {
+            Write-Host "Checksum verified."
+        } else {
+            Write-Error "Checksum mismatch! Removing download."
+            Remove-Item $InstallPath -Force
+            exit 1
+        }
+    }
+} catch {
+    Write-Host "Note: checksum file not available, skipping verification."
+} finally {
+    if (Test-Path $TmpChecksums) { Remove-Item $TmpChecksums -Force }
+}
+
+# ── Add to PATH (current user, permanent) ────────────────────────────────────
+
+$UserPath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
+if ($UserPath -notlike "*$InstallDir*") {
+    [System.Environment]::SetEnvironmentVariable("PATH", "$UserPath;$InstallDir", "User")
+    Write-Host "Added $InstallDir to your PATH."
+    Write-Host "Restart your terminal for the change to take effect."
+}
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "treadstone installed to $InstallPath"
+Write-Host ""
+Write-Host "Run: treadstone --help"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# Treadstone CLI installer for macOS and Linux
+# Usage:
+#   curl -fsSL https://github.com/earayu/treadstone/releases/latest/download/install.sh | sh
+#
+# Environment variables:
+#   TREADSTONE_VERSION     Override version (e.g. "v0.1.4"). Default: latest release.
+#   TREADSTONE_INSTALL_DIR Override install directory. Default: /usr/local/bin (falls back to ~/.local/bin).
+
+set -e
+
+REPO="earayu/treadstone"
+BINARY_NAME="treadstone"
+
+# ── Platform detection ───────────────────────────────────────────────────────
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+  Darwin)
+    case "$ARCH" in
+      arm64)           ARTIFACT="treadstone-darwin-arm64" ;;
+      x86_64)          ARTIFACT="treadstone-darwin-amd64" ;;
+      *)               echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+    esac
+    ;;
+  Linux)
+    case "$ARCH" in
+      x86_64 | amd64)  ARTIFACT="treadstone-linux-amd64" ;;
+      *)               echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+    esac
+    ;;
+  *)
+    echo "Unsupported OS: $OS" >&2
+    echo "For Windows, run in PowerShell:" >&2
+    echo "  irm https://github.com/$REPO/releases/latest/download/install.ps1 | iex" >&2
+    exit 1
+    ;;
+esac
+
+# ── Resolve download URL ─────────────────────────────────────────────────────
+
+VERSION="${TREADSTONE_VERSION:-latest}"
+
+if [ "$VERSION" = "latest" ]; then
+  BASE_URL="https://github.com/$REPO/releases/latest/download"
+else
+  BASE_URL="https://github.com/$REPO/releases/download/$VERSION"
+fi
+
+# ── Resolve install dir ──────────────────────────────────────────────────────
+
+if [ -n "$TREADSTONE_INSTALL_DIR" ]; then
+  INSTALL_DIR="$TREADSTONE_INSTALL_DIR"
+elif [ -w "/usr/local/bin" ]; then
+  INSTALL_DIR="/usr/local/bin"
+else
+  INSTALL_DIR="$HOME/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+fi
+
+INSTALL_PATH="$INSTALL_DIR/$BINARY_NAME"
+
+# ── Download ─────────────────────────────────────────────────────────────────
+
+echo "Downloading $ARTIFACT from $BASE_URL ..."
+curl -fsSL "$BASE_URL/$ARTIFACT" -o "$INSTALL_PATH"
+chmod +x "$INSTALL_PATH"
+
+# ── Checksum verification (best-effort) ──────────────────────────────────────
+
+TMP_CHECKSUMS=$(mktemp)
+if curl -fsSL "$BASE_URL/checksums.txt" -o "$TMP_CHECKSUMS" 2>/dev/null; then
+  EXPECTED=$(grep "$ARTIFACT" "$TMP_CHECKSUMS" | awk '{print $1}')
+  if [ -n "$EXPECTED" ]; then
+    if command -v sha256sum >/dev/null 2>&1; then
+      ACTUAL=$(sha256sum "$INSTALL_PATH" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+      ACTUAL=$(shasum -a 256 "$INSTALL_PATH" | awk '{print $1}')
+    else
+      ACTUAL=""
+    fi
+
+    if [ -n "$ACTUAL" ]; then
+      if [ "$EXPECTED" = "$ACTUAL" ]; then
+        echo "Checksum verified."
+      else
+        echo "Checksum mismatch! Removing download." >&2
+        rm -f "$INSTALL_PATH"
+        rm -f "$TMP_CHECKSUMS"
+        exit 1
+      fi
+    fi
+  fi
+fi
+rm -f "$TMP_CHECKSUMS"
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "treadstone installed to $INSTALL_PATH"
+
+if ! echo ":$PATH:" | grep -q ":$INSTALL_DIR:"; then
+  echo ""
+  echo "NOTE: $INSTALL_DIR is not in your PATH. Add the following to your shell profile:"
+  echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
+fi
+
+echo ""
+echo "Run: treadstone --help"


### PR DESCRIPTION
## Summary

- Add `scripts/install.sh` — one-liner installer for macOS and Linux: detects OS/arch, downloads the right binary, verifies SHA-256 checksum, installs to `/usr/local/bin` (falls back to `~/.local/bin`)
- Add `scripts/install.ps1` — PowerShell installer for Windows: downloads `treadstone-windows-amd64.exe`, verifies SHA-256 checksum, installs to `%LOCALAPPDATA%\treadstone` and adds it to `PATH`
- Update `release.yml` (`github-release` job):
  - Generate `checksums.txt` (SHA-256 for all binaries) and upload as a Release asset
  - Upload `install.sh` and `install.ps1` as Release assets
  - Rewrite Release body to feature the one-liner install commands at the top

## Usage after this change

macOS / Linux:
```bash
curl -fsSL https://github.com/earayu/treadstone/releases/latest/download/install.sh | sh
```

Windows (PowerShell):
```powershell
irm https://github.com/earayu/treadstone/releases/latest/download/install.ps1 | iex
```

## Test Plan

- [x] `make lint` passes
- [x] `make test` passes
- [ ] Release assets verified on next tag push (`install.sh`, `install.ps1`, `checksums.txt` appear in Release)

Made with [Cursor](https://cursor.com)