### PR TITLE
feat: CLI help config summary, sandbox web URLs, Helm values

### DIFF
--- a/deploy/sandbox-runtime/values-demo.yaml
+++ b/deploy/sandbox-runtime/values-demo.yaml
@@ -1,4 +1,6 @@
 image: ghcr.io/agent-infra/sandbox:latest
+# For users in mainland China:
+# image: enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
 containerPort: 8080
 
 sandboxTemplates:
@@ -7,7 +9,7 @@ sandboxTemplates:
     description: "Lightweight sandbox for code execution and scripting"
     cpu: { requests: "250m", limits: "500m" }
     memory: { requests: "512Mi", limits: "1Gi" }
-    warmPool: { enabled: false, replicas: 1 }
+    warmPool: { enabled: true, replicas: 1 }
 
   - name: aio-sandbox-small
     displayName: "AIO Sandbox Small"

--- a/deploy/sandbox-runtime/values-local.yaml
+++ b/deploy/sandbox-runtime/values-local.yaml
@@ -1,3 +1,5 @@
+# image: ghcr.io/agent-infra/sandbox:latest
+# For users in mainland China:
 image: enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
 containerPort: 8080
 

--- a/deploy/sandbox-runtime/values-prod.yaml
+++ b/deploy/sandbox-runtime/values-prod.yaml
@@ -1,4 +1,6 @@
 image: ghcr.io/agent-infra/sandbox:latest
+# For users in mainland China:
+#image: enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
 containerPort: 8080
 
 sandboxTemplates:

--- a/tests/unit/test_sandbox_build_urls.py
+++ b/tests/unit/test_sandbox_build_urls.py
@@ -1,0 +1,48 @@
+"""Unit tests for sandbox API URL construction (web vs proxy links)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from treadstone.api.sandboxes import _build_urls, _web_port_suffix
+
+
+@pytest.mark.parametrize(
+    ("api_base", "expected_suffix"),
+    [
+        ("http://localhost/", ""),
+        ("http://localhost", ""),
+        ("https://localhost/", ""),
+        ("http://127.0.0.1/", ""),
+        ("http://localhost:80/", ""),
+        ("https://localhost:443/", ""),
+        ("http://localhost:8000/", ":8000"),
+        ("http://127.0.0.1:8080/", ":8080"),
+        ("https://api.example.com:8443/v1/", ":8443"),
+        ("http://[::1]:9090/", ":9090"),
+    ],
+)
+def test_web_port_suffix(api_base: str, expected_suffix: str) -> None:
+    assert _web_port_suffix(api_base) == expected_suffix
+
+
+def test_build_urls_web_omits_port_for_plain_localhost(monkeypatch) -> None:
+    monkeypatch.setattr("treadstone.api.sandboxes.settings", SimpleNamespace(sandbox_domain="sandbox.localhost"))
+    sb = SimpleNamespace(id="1", name="sbx")
+    urls = _build_urls(sb, "http://localhost/")
+    assert urls["web"] == "http://sbx.sandbox.localhost"
+    assert urls["proxy"] == "http://localhost/v1/sandboxes/1/proxy"
+
+
+def test_build_urls_web_includes_port_for_dev_server(monkeypatch) -> None:
+    monkeypatch.setattr("treadstone.api.sandboxes.settings", SimpleNamespace(sandbox_domain="sandbox.localhost"))
+    sb = SimpleNamespace(id="1", name="sbx")
+    urls = _build_urls(sb, "http://localhost:8000/")
+    assert urls["web"] == "http://sbx.sandbox.localhost:8000"
+
+
+def test_build_urls_web_includes_port_for_port_forward(monkeypatch) -> None:
+    monkeypatch.setattr("treadstone.api.sandboxes.settings", SimpleNamespace(sandbox_domain="sandbox.localhost"))
+    sb = SimpleNamespace(id="1", name="sbx")
+    urls = _build_urls(sb, "http://127.0.0.1:12345/")
+    assert urls["web"] == "http://sbx.sandbox.localhost:12345"

--- a/treadstone/api/sandboxes.py
+++ b/treadstone/api/sandboxes.py
@@ -1,5 +1,7 @@
 """Sandbox CRUD API router — control plane endpoints."""
 
+from urllib.parse import urlparse
+
 from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -22,19 +24,36 @@ from treadstone.services.sandbox_token import create_sandbox_token
 router = APIRouter(prefix="/v1/sandboxes", tags=["sandboxes"])
 
 
+def _web_port_suffix(api_base: str) -> str:
+    """Port to mirror on *.sandbox_domain web URLs, or empty if not needed.
+
+    When the API is reached on a non-default port (e.g. dev :8000, kubectl
+    port-forward), the browser-facing subdomain URL must use the same port.
+    When the URL uses the default port or omits it (e.g. local Ingress on
+    80/443), no suffix is added.
+    """
+    parsed = urlparse(str(api_base).rstrip("/"))
+    port = parsed.port
+    if port is None:
+        return ""
+    if parsed.scheme == "http" and port == 80:
+        return ""
+    if parsed.scheme == "https" and port == 443:
+        return ""
+    return f":{port}"
+
+
 def _build_urls(sb, base_url: str) -> dict:
     base = str(base_url).rstrip("/")
     proxy = f"{base}/v1/sandboxes/{sb.id}/proxy"
     web = None
     if settings.sandbox_domain:
-        scheme = "https" if base.startswith("https") else "http"
-        port_suffix = ""
-        if "localhost" in base:
-            try:
-                port_suffix = f":{base.rsplit(':', 1)[1].rstrip('/')}"
-            except (IndexError, ValueError):
-                pass
-        web = f"{scheme}://{sb.name}.{settings.sandbox_domain}{port_suffix}"
+        parsed = urlparse(base)
+        if parsed.scheme in ("http", "https"):
+            scheme = parsed.scheme
+        else:
+            scheme = "https" if base.startswith("https") else "http"
+        web = f"{scheme}://{sb.name}.{settings.sandbox_domain}{_web_port_suffix(base)}"
     return {"proxy": proxy, "web": web}
 
 

--- a/treadstone/cli/_client.py
+++ b/treadstone/cli/_client.py
@@ -5,6 +5,7 @@ Priority: CLI flags > environment variables > config file.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -36,6 +37,26 @@ def get_base_url(ctx: click.Context) -> str:
 
 def get_api_key(ctx: click.Context) -> str | None:
     return ctx.obj.get("api_key") or _read_config().get("api_key")
+
+
+def effective_base_url() -> tuple[str, str]:
+    """Return (url, source) without requiring a Click context.
+
+    Source is one of: 'env', 'file', 'default'.
+    Used for displaying configuration in help text.
+    """
+    env = os.environ.get("TREADSTONE_BASE_URL")
+    if env:
+        return env.rstrip("/"), "env"
+    cfg = _read_config().get("base_url")
+    if cfg:
+        return cfg.rstrip("/"), "file"
+    return _DEFAULT_BASE_URL, "default"
+
+
+def effective_api_key() -> str | None:
+    """Return API key without requiring a Click context."""
+    return os.environ.get("TREADSTONE_API_KEY") or _read_config().get("api_key")
 
 
 def build_client(ctx: click.Context) -> httpx.Client:

--- a/treadstone/cli/main.py
+++ b/treadstone/cli/main.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import click
 
-from treadstone.cli._client import build_client
+from treadstone.cli._client import build_client, effective_api_key, effective_base_url, get_base_url
 from treadstone.cli._output import friendly_exception_handler, handle_error, is_json_mode, print_json
 
-_EPILOG = """\b
+_STATIC_EPILOG = """\b
 Configuration (highest to lowest priority):
   CLI flags       --api-key, --base-url
   Env vars        TREADSTONE_API_KEY, TREADSTONE_BASE_URL
@@ -23,7 +23,24 @@ Examples:
 """
 
 
-@click.group(epilog=_EPILOG)
+class _TreadstoneGroup(click.Group):
+    """Custom group that appends a live config summary to the help output."""
+
+    def format_epilog(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        super().format_epilog(ctx, formatter)
+        url, source = effective_base_url()
+        api_key = effective_api_key()
+        api_key_status = "configured" if api_key else "not set"
+        with formatter.section("Active configuration"):
+            formatter.write_dl(
+                [
+                    ("Base URL", f"{url}  [{source}]"),
+                    ("API key", api_key_status),
+                ]
+            )
+
+
+@click.group(cls=_TreadstoneGroup, epilog=_STATIC_EPILOG)
 @click.option("--json", "json_output", is_flag=True, default=False, help="Output in JSON format.")
 @click.option(
     "--api-key",
@@ -58,6 +75,9 @@ def cli(ctx: click.Context, json_output: bool, api_key: str | None, base_url: st
 def health(ctx: click.Context) -> None:
     """Check if the Treadstone server is reachable and healthy."""
     client = build_client(ctx)
+    base_url = get_base_url(ctx)
+    if not is_json_mode(ctx):
+        click.echo(f"Connecting to {base_url} ...")
     resp = client.get("/health")
     handle_error(resp)
     data = resp.json()

--- a/treadstone/config.py
+++ b/treadstone/config.py
@@ -32,8 +32,8 @@ class Settings(BaseSettings):
     sandbox_proxy_timeout: float = 180.0
 
     # Subdomain-based sandbox routing (for browser Web UI access)
-    # Dev: "sandbox.localhost"  →  {sandbox_id}.sandbox.localhost:8000
-    # Prod: "sandbox.example.com"  →  {sandbox_id}.sandbox.example.com
+    # Dev: "sandbox.localhost"  →  {name}.sandbox.localhost[:port] when the API URL has a non-default port
+    # Prod: "sandbox.example.com"  →  {name}.sandbox.example.com
     # Empty string disables subdomain routing.
     sandbox_domain: str = ""
 


### PR DESCRIPTION
## Summary
- Sandbox API: build `urls.web` using parsed API base URL; append `:port` only for non-default ports (fixes Ingress on 80/443 and port-forward on arbitrary hosts).
- CLI: `--help` shows active base URL with source (env/file/default) and API key status; `effective_base_url` / `effective_api_key` in `_client.py`.
- Helm `sandbox-runtime` values: optional mainland China image comments, demo warmPool enabled, local/prod tweaks.

## Test plan
- [x] `make lint`
- [x] `make test`

Made with [Cursor](https://cursor.com)