### PR TITLE
feat: per-env K8s namespaces, ALB HTTPS, prod defaults for CLI/SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ TREADSTONE_LOGTO_APP_ID=
 # Prod: "sandbox.example.com"  ->  {sandbox_id}.sandbox.example.com
 # Empty string disables subdomain routing.
 TREADSTONE_SANDBOX_DOMAIN=
-TREADSTONE_SANDBOX_NAMESPACE=treadstone
+# Must match the K8s namespace for this environment (treadstone-local / treadstone-demo / treadstone-prod)
+TREADSTONE_SANDBOX_NAMESPACE=treadstone-local
 TREADSTONE_SANDBOX_PORT=8080
 TREADSTONE_SANDBOX_PROXY_TIMEOUT=180.0

--- a/Makefile
+++ b/Makefile
@@ -88,14 +88,20 @@ clean: ## Remove build artifacts and caches
 
 ENV ?= local
 
+# Every environment gets its own namespace and Helm release name:
+# local → treadstone-local, demo → treadstone-demo, prod → treadstone-prod
+NS          := treadstone-$(ENV)
+APP_RELEASE := treadstone-$(ENV)
+RT_RELEASE  := sandbox-runtime-$(ENV)
+
 deploy-infra: ## Deploy agent-sandbox controller (once per cluster)
 	helm upgrade --install agent-sandbox deploy/agent-sandbox \
 		-f deploy/agent-sandbox/values-$(ENV).yaml \
 		--create-namespace
 
 deploy-runtime: ## Deploy sandbox templates + warmpool
-	helm upgrade --install sandbox-runtime deploy/sandbox-runtime \
-		-n treadstone -f deploy/sandbox-runtime/values-$(ENV).yaml \
+	helm upgrade --install $(RT_RELEASE) deploy/sandbox-runtime \
+		-n $(NS) -f deploy/sandbox-runtime/values-$(ENV).yaml \
 		--create-namespace
 
 deploy-app: ## Deploy Treadstone application (creates K8s secret from .env.<ENV>)
@@ -104,28 +110,28 @@ deploy-app: ## Deploy Treadstone application (creates K8s secret from .env.<ENV>
 		echo "Error: $$ENV_FILE not found. Run: cp .env.example .env.$(ENV)"; \
 		exit 1; \
 	fi; \
-	kubectl create namespace treadstone --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null; \
+	kubectl create namespace $(NS) --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null; \
 	kubectl create secret generic treadstone-secrets \
-		-n treadstone \
+		-n $(NS) \
 		--from-env-file="$$ENV_FILE" \
 		--dry-run=client -o yaml | kubectl apply -f -
-	helm upgrade --install treadstone deploy/treadstone \
-		-n treadstone -f deploy/treadstone/values-$(ENV).yaml \
+	helm upgrade --install $(APP_RELEASE) deploy/treadstone \
+		-n $(NS) -f deploy/treadstone/values-$(ENV).yaml \
 		--create-namespace
 
 deploy-all: deploy-infra deploy-runtime deploy-app ## Deploy everything (infra → runtime → app)
 
 restart-app: ## Rolling restart to pick up new env vars
-	kubectl rollout restart deployment/treadstone -n treadstone
+	kubectl rollout restart deployment/$(APP_RELEASE)-treadstone -n $(NS)
 
 port-forward: ## Port-forward treadstone service to localhost:8000
-	kubectl -n treadstone port-forward svc/treadstone-treadstone 8000:8000
+	kubectl -n $(NS) port-forward svc/$(APP_RELEASE)-treadstone 8000:8000
 
 undeploy-app: ## Undeploy Treadstone application
-	helm uninstall treadstone -n treadstone 2>/dev/null || true
+	helm uninstall $(APP_RELEASE) -n $(NS) 2>/dev/null || true
 
 undeploy-runtime: ## Undeploy sandbox runtime
-	helm uninstall sandbox-runtime -n treadstone 2>/dev/null || true
+	helm uninstall $(RT_RELEASE) -n $(NS) 2>/dev/null || true
 
 undeploy-all: undeploy-app undeploy-runtime ## Undeploy app + runtime (keeps infra)
 	@echo "Note: agent-sandbox controller left in place. Run 'helm uninstall agent-sandbox' to remove."

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -97,8 +97,9 @@ make deploy-app ENV=local       # App + Secret + Migration
 ### 4. Verify Deployment
 
 ```bash
-kubectl get pods -n treadstone
-kubectl -n treadstone rollout status deploy/treadstone-treadstone --timeout=60s
+# Replace <ENV> with local/demo/prod; namespace = treadstone-<ENV>
+kubectl get pods -n treadstone-local
+kubectl -n treadstone-local rollout status deploy/treadstone-local-treadstone --timeout=60s
 ```
 
 ## Accessing the Service
@@ -177,8 +178,8 @@ curl -s -X POST $BASE_URL/v1/sandboxes \
 After the Sandbox is running, you can reach its **Web UI** in a browser. The exact URL depends on your subdomain / DNS setup; with local Kind and Ingress, open `http://<sandbox-name>.sandbox.localhost/` (for example, `http://api-sb-1774074700.sandbox.localhost/`).
 
 ```bash
-# View K8s resources
-kubectl -n treadstone get sandboxclaims,sandboxes,pods
+# View K8s resources (replace treadstone-local with your namespace)
+kubectl -n treadstone-local get sandboxclaims,sandboxes,pods
 
 # Clean up
 curl -s -X DELETE $BASE_URL/v1/sandboxes/{sandbox_id} \
@@ -216,18 +217,36 @@ make kind-delete
 
 | Config | local | demo | prod |
 |--------|-------|------|------|
+| K8s Namespace | `treadstone-local` | `treadstone-demo` | `treadstone-prod` |
+| Helm release (app) | `treadstone-local` | `treadstone-demo` | `treadstone-prod` |
+| Helm release (runtime) | `sandbox-runtime-local` | `sandbox-runtime-demo` | `sandbox-runtime-prod` |
 | Image source | Local build | `ghcr.io/earayu/treadstone` | Specified by CI/CD |
 | Replicas | 1 | 1 | 2 |
 | HPA | Off | Off | On (2–10) |
 | Ingress | `localhost` | `demo.treadstone-ai.dev` | `api.treadstone-ai.dev` + TLS |
+| ALB Group | — | `treadstone` (order 2) | `treadstone` (order 1) |
 | DB migration | Auto (Helm hook) | Auto | Auto |
+
+### Multi-Environment Isolation
+
+Every environment runs in its own namespace (`treadstone-local` / `treadstone-demo` / `treadstone-prod`).
+Each namespace has its own independent Deployment, Service, and K8s Secret — deploying one environment never touches another.
+
+Both share a **single AWS ALB** via `alb.ingress.kubernetes.io/group.name: treadstone`.
+The ALB controller merges their Ingress rules into one load balancer with host-based routing:
+
+- `demo.treadstone-ai.dev` → Service in `treadstone-demo` namespace
+- `api.treadstone-ai.dev` → Service in `treadstone-prod` namespace (order 1 = higher priority)
+
+Before deploying prod, fill in `alb.ingress.kubernetes.io/certificate-arn` in `values-prod.yaml`
+with the ACM certificate ARN for `api.treadstone-ai.dev`.
 
 ## Troubleshooting
 
 | Symptom | Cause | Solution |
 |---------|-------|----------|
 | Templates API returns `python-dev` / `nodejs-dev` | `TREADSTONE_DEBUG=true` in `.env` | Set to `false` and recreate the Secret |
-| API returns 500 + `column "xxx" does not exist` | Database is missing new columns | Migration Job should run automatically; manual fix: `kubectl -n treadstone exec deploy/treadstone-treadstone -- uv run alembic upgrade head` |
+| API returns 500 + `column "xxx" does not exist` | Database is missing new columns | Migration Job should run automatically; manual fix: `kubectl -n treadstone-<ENV> exec deploy/treadstone-<ENV>-treadstone -- uv run alembic upgrade head` |
 | Pod stuck not Ready | Image pull failure | For local: run `kind load docker-image` first; for remote: check image registry permissions |
 | `curl localhost` connection refused | ingress-nginx not ready or port conflict | Rebuild cluster with `make kind-delete && make kind-create`, or use `make port-forward` |
 | 403 Forbidden in pod logs | Insufficient RBAC permissions | Confirm the Helm chart deployed ClusterRole + ClusterRoleBinding |

--- a/deploy/treadstone/values-demo.yaml
+++ b/deploy/treadstone/values-demo.yaml
@@ -25,7 +25,13 @@ ingress:
   enabled: true
   className: alb
   annotations:
-    alb.ingress.kubernetes.io/order: "1"
+    alb.ingress.kubernetes.io/group.name: treadstone
+    alb.ingress.kubernetes.io/order: "2"
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "true"
+    alb.ingress.kubernetes.io/certificate-id: "24059672-cn-hangzhou"
   hosts:
     - host: demo.treadstone-ai.dev
       paths:

--- a/deploy/treadstone/values-prod.yaml
+++ b/deploy/treadstone/values-prod.yaml
@@ -1,8 +1,8 @@
 replicaCount: 2
 
 image:
-  repository: ""
-  tag: ""
+  repository: ghcr.io/earayu/treadstone
+  tag: latest
   pullPolicy: Always
 
 envSecretRef: treadstone-secrets
@@ -26,14 +26,17 @@ hpa:
 
 ingress:
   enabled: true
-  className: ""
-  annotations: {}
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/group.name: treadstone
+    alb.ingress.kubernetes.io/order: "1"
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "true"
+    alb.ingress.kubernetes.io/certificate-id: "24064579-cn-hangzhou"
   hosts:
     - host: api.treadstone-ai.dev
       paths:
         - path: /
           pathType: Prefix
-  tls:
-    - secretName: treadstone-tls
-      hosts:
-        - api.treadstone-ai.dev

--- a/scripts/down.sh
+++ b/scripts/down.sh
@@ -6,7 +6,7 @@ ENV="${1:-local}"
 echo "=== Treadstone Down (ENV=$ENV) ==="
 echo ""
 
-make undeploy-all
+make undeploy-all ENV="$ENV"
 
 if [ "$ENV" = "local" ]; then
     echo ""

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -22,8 +22,10 @@ echo ""
 echo "Deploying Helm charts (ENV=$ENV) ..."
 make deploy-all ENV="$ENV"
 
+NS="treadstone-${ENV}"
+
 echo ""
 echo "Up complete (ENV=$ENV)."
 if [ "$ENV" = "local" ]; then
-    echo "Verify with: kubectl get pods -n treadstone"
+    echo "Verify with: kubectl get pods -n $NS"
 fi

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -5,17 +5,30 @@ A client library for accessing treadstone
 First, create a client:
 
 ```python
-from treadstone_sdk import Client
+from treadstone_sdk import AuthenticatedClient, TREADSTONE_API_URL
 
-client = Client(base_url="https://api.example.com")
+client = AuthenticatedClient(base_url=TREADSTONE_API_URL, token="ts_live_xxxxxxxxxxxx")
 ```
 
-If the endpoints you're going to hit require authentication, use `AuthenticatedClient` instead:
+`TREADSTONE_API_URL` points to the production endpoint (`https://api.treadstone-ai.dev`).
+You can override it with any URL:
 
 ```python
 from treadstone_sdk import AuthenticatedClient
 
-client = AuthenticatedClient(base_url="https://api.example.com", token="SuperSecretToken")
+# Demo environment
+client = AuthenticatedClient(base_url="https://demo.treadstone-ai.dev", token="ts_live_xxxxxxxxxxxx")
+
+# Local development
+client = AuthenticatedClient(base_url="http://localhost:8000", token="ts_live_xxxxxxxxxxxx")
+```
+
+For unauthenticated endpoints (e.g. `/health`), use the plain `Client`:
+
+```python
+from treadstone_sdk import Client, TREADSTONE_API_URL
+
+client = Client(base_url=TREADSTONE_API_URL)
 ```
 
 Now call your endpoint and use your models:

--- a/sdk/python/treadstone_sdk/__init__.py
+++ b/sdk/python/treadstone_sdk/__init__.py
@@ -2,7 +2,10 @@
 
 from .client import AuthenticatedClient, Client
 
+TREADSTONE_API_URL = "https://api.treadstone-ai.dev"
+
 __all__ = (
     "AuthenticatedClient",
     "Client",
+    "TREADSTONE_API_URL",
 )

--- a/tests/unit/test_k8s_client.py
+++ b/tests/unit/test_k8s_client.py
@@ -7,7 +7,7 @@ from treadstone.services.k8s_client import FakeK8sClient, format_shutdown_time
 
 async def test_list_sandbox_templates():
     client = FakeK8sClient()
-    templates = await client.list_sandbox_templates("treadstone")
+    templates = await client.list_sandbox_templates("treadstone-local")
     assert len(templates) == 5
     names = [t["name"] for t in templates]
     assert "aio-sandbox-tiny" in names
@@ -16,60 +16,60 @@ async def test_list_sandbox_templates():
 
 async def test_create_and_get_sandbox_claim():
     client = FakeK8sClient()
-    claim = await client.create_sandbox_claim("my-sb", "aio-sandbox-tiny", "treadstone")
+    claim = await client.create_sandbox_claim("my-sb", "aio-sandbox-tiny", "treadstone-local")
     assert claim["kind"] == "SandboxClaim"
     assert claim["spec"]["sandboxTemplateRef"]["name"] == "aio-sandbox-tiny"
     assert claim["status"]["sandbox"]["Name"] == "my-sb"
 
-    fetched = await client.get_sandbox_claim("my-sb", "treadstone")
+    fetched = await client.get_sandbox_claim("my-sb", "treadstone-local")
     assert fetched is not None
 
 
 async def test_create_claim_also_creates_sandbox():
     client = FakeK8sClient()
-    await client.create_sandbox_claim("my-sb", "aio-sandbox-tiny", "treadstone")
-    sb = await client.get_sandbox("my-sb", "treadstone")
+    await client.create_sandbox_claim("my-sb", "aio-sandbox-tiny", "treadstone-local")
+    sb = await client.get_sandbox("my-sb", "treadstone-local")
     assert sb is not None
     assert sb["kind"] == "Sandbox"
-    assert sb["status"]["serviceFQDN"] == "my-sb.treadstone.svc.cluster.local"
+    assert sb["status"]["serviceFQDN"] == "my-sb.treadstone-local.svc.cluster.local"
 
 
 async def test_delete_sandbox_claim_removes_sandbox():
     client = FakeK8sClient()
-    await client.create_sandbox_claim("del-sb", "aio-sandbox-tiny", "treadstone")
-    result = await client.delete_sandbox_claim("del-sb", "treadstone")
+    await client.create_sandbox_claim("del-sb", "aio-sandbox-tiny", "treadstone-local")
+    result = await client.delete_sandbox_claim("del-sb", "treadstone-local")
     assert result is True
-    assert await client.get_sandbox_claim("del-sb", "treadstone") is None
-    assert await client.get_sandbox("del-sb", "treadstone") is None
+    assert await client.get_sandbox_claim("del-sb", "treadstone-local") is None
+    assert await client.get_sandbox("del-sb", "treadstone-local") is None
 
 
 async def test_list_sandboxes():
     client = FakeK8sClient()
-    await client.create_sandbox_claim("sb-1", "aio-sandbox-tiny", "treadstone")
-    await client.create_sandbox_claim("sb-2", "aio-sandbox-tiny", "treadstone")
-    sbs = await client.list_sandboxes("treadstone")
+    await client.create_sandbox_claim("sb-1", "aio-sandbox-tiny", "treadstone-local")
+    await client.create_sandbox_claim("sb-2", "aio-sandbox-tiny", "treadstone-local")
+    sbs = await client.list_sandboxes("treadstone-local")
     assert len(sbs) == 2
 
 
 async def test_scale_sandbox_stop_and_start():
     client = FakeK8sClient()
-    await client.create_sandbox_claim("sb-scale", "aio-sandbox-tiny", "treadstone")
-    client.simulate_sandbox_ready("sb-scale", "treadstone")
+    await client.create_sandbox_claim("sb-scale", "aio-sandbox-tiny", "treadstone-local")
+    client.simulate_sandbox_ready("sb-scale", "treadstone-local")
 
-    await client.scale_sandbox("sb-scale", "treadstone", 0)
-    sb = await client.get_sandbox("sb-scale", "treadstone")
+    await client.scale_sandbox("sb-scale", "treadstone-local", 0)
+    sb = await client.get_sandbox("sb-scale", "treadstone-local")
     assert sb["spec"]["replicas"] == 0
     assert sb["status"]["replicas"] == 0
 
-    await client.scale_sandbox("sb-scale", "treadstone", 1)
-    sb = await client.get_sandbox("sb-scale", "treadstone")
+    await client.scale_sandbox("sb-scale", "treadstone-local", 1)
+    sb = await client.get_sandbox("sb-scale", "treadstone-local")
     assert sb["spec"]["replicas"] == 1
 
 
 async def test_create_with_shutdown_time():
     client = FakeK8sClient()
     dt = datetime.now(UTC) + timedelta(hours=1)
-    claim = await client.create_sandbox_claim("sb-expiry", "aio-sandbox-tiny", "treadstone", shutdown_time=dt)
+    claim = await client.create_sandbox_claim("sb-expiry", "aio-sandbox-tiny", "treadstone-local", shutdown_time=dt)
     assert "lifecycle" in claim["spec"]
     assert claim["spec"]["lifecycle"]["shutdownTime"] == format_shutdown_time(dt)
 
@@ -81,13 +81,13 @@ def test_format_shutdown_time():
 
 async def test_simulate_sandbox_ready():
     client = FakeK8sClient()
-    await client.create_sandbox_claim("sb-ready", "aio-sandbox-tiny", "treadstone")
-    sb = await client.get_sandbox("sb-ready", "treadstone")
+    await client.create_sandbox_claim("sb-ready", "aio-sandbox-tiny", "treadstone-local")
+    sb = await client.get_sandbox("sb-ready", "treadstone-local")
     ready_cond = [c for c in sb["status"]["conditions"] if c["type"] == "Ready"][0]
     assert ready_cond["status"] == "False"
 
-    client.simulate_sandbox_ready("sb-ready", "treadstone")
-    sb = await client.get_sandbox("sb-ready", "treadstone")
+    client.simulate_sandbox_ready("sb-ready", "treadstone-local")
+    sb = await client.get_sandbox("sb-ready", "treadstone-local")
     ready_cond = [c for c in sb["status"]["conditions"] if c["type"] == "Ready"][0]
     assert ready_cond["status"] == "True"
 
@@ -99,7 +99,7 @@ async def test_create_sandbox_direct():
     client = FakeK8sClient()
     sb = await client.create_sandbox(
         name="direct-sb",
-        namespace="treadstone",
+        namespace="treadstone-local",
         image="ghcr.io/agent-infra/sandbox:latest",
         container_port=8080,
         resources={"requests": {"cpu": "250m", "memory": "512Mi"}},
@@ -116,9 +116,9 @@ async def test_create_sandbox_direct():
     assert sb["kind"] == "Sandbox"
     assert sb["metadata"]["name"] == "direct-sb"
     assert sb["spec"]["volumeClaimTemplates"] is not None
-    assert sb["status"]["serviceFQDN"] == "direct-sb.treadstone.svc.cluster.local"
+    assert sb["status"]["serviceFQDN"] == "direct-sb.treadstone-local.svc.cluster.local"
 
-    fetched = await client.get_sandbox("direct-sb", "treadstone")
+    fetched = await client.get_sandbox("direct-sb", "treadstone-local")
     assert fetched is not None
 
 
@@ -126,7 +126,7 @@ async def test_create_sandbox_direct_without_storage():
     client = FakeK8sClient()
     sb = await client.create_sandbox(
         name="no-storage-sb",
-        namespace="treadstone",
+        namespace="treadstone-local",
         image="ghcr.io/agent-infra/sandbox:latest",
         container_port=8080,
         resources={"requests": {"cpu": "250m", "memory": "512Mi"}},
@@ -139,25 +139,25 @@ async def test_delete_sandbox_direct():
     client = FakeK8sClient()
     await client.create_sandbox(
         name="del-direct",
-        namespace="treadstone",
+        namespace="treadstone-local",
         image="ghcr.io/agent-infra/sandbox:latest",
         container_port=8080,
         resources={"requests": {"cpu": "250m", "memory": "512Mi"}},
     )
-    result = await client.delete_sandbox("del-direct", "treadstone")
+    result = await client.delete_sandbox("del-direct", "treadstone-local")
     assert result is True
-    assert await client.get_sandbox("del-direct", "treadstone") is None
+    assert await client.get_sandbox("del-direct", "treadstone-local") is None
 
 
 async def test_direct_sandbox_in_list():
     client = FakeK8sClient()
-    await client.create_sandbox_claim("claim-sb", "aio-sandbox-tiny", "treadstone")
+    await client.create_sandbox_claim("claim-sb", "aio-sandbox-tiny", "treadstone-local")
     await client.create_sandbox(
         name="direct-sb",
-        namespace="treadstone",
+        namespace="treadstone-local",
         image="ghcr.io/agent-infra/sandbox:latest",
         container_port=8080,
         resources={"requests": {"cpu": "1", "memory": "2Gi"}},
     )
-    sbs = await client.list_sandboxes("treadstone")
+    sbs = await client.list_sandboxes("treadstone-local")
     assert len(sbs) == 2

--- a/tests/unit/test_k8s_sync.py
+++ b/tests/unit/test_k8s_sync.py
@@ -44,7 +44,7 @@ async def _create_sandbox(factory, **overrides) -> Sandbox:
         "endpoints": {},
         "k8s_sandbox_claim_name": "test-sb",
         "k8s_sandbox_name": "test-sb",
-        "k8s_namespace": "treadstone",
+        "k8s_namespace": "treadstone-local",
         "gmt_created": utc_now(),
     }
     defaults.update(overrides)
@@ -101,11 +101,11 @@ class TestHandleWatchEvent:
     async def test_modified_creating_to_ready(self, session_factory):
         await _create_sandbox(session_factory)
         cr = {
-            "metadata": {"name": "test-sb", "namespace": "treadstone", "resourceVersion": "100"},
+            "metadata": {"name": "test-sb", "namespace": "treadstone-local", "resourceVersion": "100"},
             "spec": {"replicas": 1},
             "status": {
                 "conditions": [{"type": "Ready", "status": "True", "reason": "DependenciesReady", "message": "ok"}],
-                "serviceFQDN": "test-sb.treadstone.svc.cluster.local",
+                "serviceFQDN": "test-sb.treadstone-local.svc.cluster.local",
             },
         }
         await handle_watch_event("MODIFIED", cr, session_factory)
@@ -118,7 +118,7 @@ class TestHandleWatchEvent:
 
     async def test_deleted_from_deleting_marks_deleted(self, session_factory):
         await _create_sandbox(session_factory, status=SandboxStatus.DELETING)
-        cr = {"metadata": {"name": "test-sb", "namespace": "treadstone", "resourceVersion": "200"}}
+        cr = {"metadata": {"name": "test-sb", "namespace": "treadstone-local", "resourceVersion": "200"}}
         await handle_watch_event("DELETED", cr, session_factory)
 
         async with session_factory() as session:
@@ -127,7 +127,7 @@ class TestHandleWatchEvent:
 
     async def test_deleted_from_ready_marks_error(self, session_factory):
         await _create_sandbox(session_factory, status=SandboxStatus.READY)
-        cr = {"metadata": {"name": "test-sb", "namespace": "treadstone", "resourceVersion": "300"}}
+        cr = {"metadata": {"name": "test-sb", "namespace": "treadstone-local", "resourceVersion": "300"}}
         await handle_watch_event("DELETED", cr, session_factory)
 
         async with session_factory() as session:
@@ -136,7 +136,7 @@ class TestHandleWatchEvent:
 
     async def test_unknown_cr_ignored(self, session_factory):
         cr = {
-            "metadata": {"name": "unknown-cr", "namespace": "treadstone", "resourceVersion": "500"},
+            "metadata": {"name": "unknown-cr", "namespace": "treadstone-local", "resourceVersion": "500"},
             "spec": {"replicas": 1},
             "status": {"conditions": [_cond("True", "DependenciesReady")]},
         }
@@ -147,10 +147,10 @@ class TestReconcile:
     async def test_reconcile_updates_drift(self, session_factory):
         await _create_sandbox(session_factory, k8s_resource_version="old")
         k8s = FakeK8sClient()
-        await k8s.create_sandbox_claim("test-sb", "aio-sandbox-tiny", "treadstone")
-        k8s.simulate_sandbox_ready("test-sb", "treadstone")
+        await k8s.create_sandbox_claim("test-sb", "aio-sandbox-tiny", "treadstone-local")
+        k8s.simulate_sandbox_ready("test-sb", "treadstone-local")
 
-        await reconcile("treadstone", k8s, session_factory)
+        await reconcile("treadstone-local", k8s, session_factory)
 
         async with session_factory() as session:
             sb = await session.get(Sandbox, "sb00000000test1234")
@@ -160,7 +160,7 @@ class TestReconcile:
         await _create_sandbox(session_factory, status=SandboxStatus.READY)
         k8s = FakeK8sClient()
 
-        await reconcile("treadstone", k8s, session_factory)
+        await reconcile("treadstone-local", k8s, session_factory)
 
         async with session_factory() as session:
             sb = await session.get(Sandbox, "sb00000000test1234")
@@ -170,7 +170,7 @@ class TestReconcile:
         await _create_sandbox(session_factory, status=SandboxStatus.DELETING)
         k8s = FakeK8sClient()
 
-        await reconcile("treadstone", k8s, session_factory)
+        await reconcile("treadstone-local", k8s, session_factory)
 
         async with session_factory() as session:
             sb = await session.get(Sandbox, "sb00000000test1234")

--- a/tests/unit/test_sandbox_service.py
+++ b/tests/unit/test_sandbox_service.py
@@ -22,7 +22,7 @@ def _make_sandbox(**overrides) -> Sandbox:
         "endpoints": {},
         "k8s_sandbox_claim_name": "test-sandbox",
         "k8s_sandbox_name": "test-sandbox",
-        "k8s_namespace": "treadstone",
+        "k8s_namespace": "treadstone-local",
     }
     defaults.update(overrides)
     sb = Sandbox()
@@ -172,7 +172,7 @@ class TestSandboxServiceStartStop:
 
         result = await service.start(sandbox_id="sb1234567890abcdef", owner_id="user1234567890abcd")
         assert result.status == SandboxStatus.CREATING
-        k8s.scale_sandbox.assert_called_once_with(name="test-sandbox", namespace="treadstone", replicas=1)
+        k8s.scale_sandbox.assert_called_once_with(name="test-sandbox", namespace="treadstone-local", replicas=1)
 
     async def test_stop_calls_scale_sandbox_0(self):
         from treadstone.services.sandbox_service import SandboxService
@@ -184,7 +184,7 @@ class TestSandboxServiceStartStop:
 
         result = await service.stop(sandbox_id="sb1234567890abcdef", owner_id="user1234567890abcd")
         assert result.status == SandboxStatus.STOPPED
-        k8s.scale_sandbox.assert_called_once_with(name="test-sandbox", namespace="treadstone", replicas=0)
+        k8s.scale_sandbox.assert_called_once_with(name="test-sandbox", namespace="treadstone-local", replicas=0)
 
     async def test_start_from_ready_raises(self):
         from treadstone.services.sandbox_service import SandboxService

--- a/treadstone/cli/README.md
+++ b/treadstone/cli/README.md
@@ -90,7 +90,7 @@ treadstone config path
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `TREADSTONE_BASE_URL` | Base URL of the Treadstone server | `http://localhost:8000` |
+| `TREADSTONE_BASE_URL` | Base URL of the Treadstone server | `https://api.treadstone-ai.dev` |
 | `TREADSTONE_API_KEY` | API key for authentication | (none) |
 
 ### Global flags

--- a/treadstone/cli/_client.py
+++ b/treadstone/cli/_client.py
@@ -15,7 +15,7 @@ import httpx
 CONFIG_DIR = Path.home() / ".config" / "treadstone"
 CONFIG_FILE = CONFIG_DIR / "config.toml"
 
-_DEFAULT_BASE_URL = "http://localhost:8000"
+_DEFAULT_BASE_URL = "https://api.treadstone-ai.dev"
 
 
 def _read_config() -> dict[str, str]:

--- a/treadstone/config.py
+++ b/treadstone/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     logto_app_id: str = ""
 
     # Sandbox proxy defaults (overridable per-request via X-Sandbox-* headers)
-    sandbox_namespace: str = "treadstone"
+    sandbox_namespace: str = "treadstone-local"
     sandbox_port: int = 8080
     sandbox_proxy_timeout: float = 180.0
 

--- a/treadstone/main.py
+++ b/treadstone/main.py
@@ -43,7 +43,16 @@ async def lifespan(app: FastAPI):
 
 logging.basicConfig(level=logging.DEBUG if settings.debug else logging.WARNING)
 
-app = FastAPI(title=settings.app_name, generate_unique_id_function=custom_generate_unique_id, lifespan=lifespan)
+app = FastAPI(
+    title=settings.app_name,
+    generate_unique_id_function=custom_generate_unique_id,
+    lifespan=lifespan,
+    servers=[
+        {"url": "https://api.treadstone-ai.dev", "description": "Production"},
+        {"url": "https://demo.treadstone-ai.dev", "description": "Demo"},
+        {"url": "http://localhost:8000", "description": "Local development"},
+    ],
+)
 
 
 @app.exception_handler(TreadstoneError)


### PR DESCRIPTION
Release prep for v0.2.0: Helm env-scoped namespaces, ALB ingress/HTTPS docs, CLI/SDK prod default URL, OpenAPI servers.

Made with [Cursor](https://cursor.com)