### PR TITLE
fix(cli): add --copy-metadata to PyInstaller so treadstone --version works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,7 @@ jobs:
           uv run pyinstaller \
             --onefile \
             --name treadstone \
+            --copy-metadata treadstone-cli \
             treadstone_cli/__main__.py
 
       - name: Rename binary


### PR DESCRIPTION
## Summary

- Add `--copy-metadata treadstone-cli` to the PyInstaller build command so the `.dist-info` metadata is bundled into the binary.
- Without this flag, `click.version_option(package_name="treadstone-cli")` fails at runtime with `'treadstone-cli' is not installed` because `importlib.metadata` cannot find the package in the frozen bundle.

## Root Cause

`click.version_option(package_name=...)` calls `importlib.metadata.version("treadstone-cli")` at runtime. PyInstaller bundles Python source but does not include `.dist-info` directories by default. The `--copy-metadata` flag tells PyInstaller to copy the distribution metadata into the bundle so `importlib.metadata` works correctly.

## Test Plan

- [x] Locally built PyInstaller binary with `--copy-metadata` and verified `treadstone --version` returns `treadstone, version 0.1.0`


Made with [Cursor](https://cursor.com)