### PR TITLE
feat: add K8s Watch-based incremental sync for sandbox state

### DIFF
--- a/tests/unit/test_k8s_sync.py
+++ b/tests/unit/test_k8s_sync.py
@@ -1,5 +1,7 @@
 """Unit tests for K8s Watch + Reconciliation — conditions-based status derivation."""
 
+import asyncio
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -7,7 +9,7 @@ from treadstone.core.database import Base
 from treadstone.models.sandbox import Sandbox, SandboxStatus
 from treadstone.models.user import User, utc_now
 from treadstone.services.k8s_client import FakeK8sClient
-from treadstone.services.k8s_sync import derive_status_from_sandbox_cr, handle_watch_event, reconcile
+from treadstone.services.k8s_sync import derive_status_from_sandbox_cr, handle_watch_event, reconcile, watch_loop
 
 
 @pytest.fixture
@@ -150,11 +152,12 @@ class TestReconcile:
         await k8s.create_sandbox_claim("test-sb", "aio-sandbox-tiny", "treadstone-local")
         k8s.simulate_sandbox_ready("test-sb", "treadstone-local")
 
-        await reconcile("treadstone-local", k8s, session_factory)
+        rv = await reconcile("treadstone-local", k8s, session_factory)
 
         async with session_factory() as session:
             sb = await session.get(Sandbox, "sb00000000test1234")
             assert sb.status == SandboxStatus.READY
+        assert rv != ""
 
     async def test_reconcile_missing_cr_marks_error(self, session_factory):
         await _create_sandbox(session_factory, status=SandboxStatus.READY)
@@ -175,3 +178,87 @@ class TestReconcile:
         async with session_factory() as session:
             sb = await session.get(Sandbox, "sb00000000test1234")
             assert sb.status == SandboxStatus.DELETED
+
+    async def test_reconcile_returns_resource_version(self, session_factory):
+        k8s = FakeK8sClient()
+        await k8s.create_sandbox_claim("some-sb", "aio-sandbox-tiny", "treadstone-local")
+        k8s.simulate_sandbox_ready("some-sb", "treadstone-local")
+
+        rv = await reconcile("treadstone-local", k8s, session_factory)
+        assert rv.isdigit()
+
+
+class TestWatchLoop:
+    async def test_watch_event_updates_db(self, session_factory):
+        """Watch MODIFIED event should transition sandbox from CREATING to READY."""
+        await _create_sandbox(session_factory)
+        k8s = FakeK8sClient()
+
+        cr = {
+            "metadata": {"name": "test-sb", "namespace": "treadstone-local", "resourceVersion": "50"},
+            "spec": {"replicas": 1},
+            "status": {
+                "conditions": [_cond("True", "DependenciesReady", "ok")],
+                "serviceFQDN": "test-sb.treadstone-local.svc.cluster.local",
+            },
+        }
+        k8s.enqueue_watch_event("MODIFIED", cr)
+        k8s.stop_watch()
+
+        await watch_loop("treadstone-local", k8s, session_factory, resource_version="1")
+
+        async with session_factory() as session:
+            sb = await session.get(Sandbox, "sb00000000test1234")
+            assert sb.status == SandboxStatus.READY
+            assert sb.k8s_resource_version == "50"
+
+    async def test_watch_multiple_events(self, session_factory):
+        """Multiple Watch events should be processed in order."""
+        await _create_sandbox(session_factory)
+        k8s = FakeK8sClient()
+
+        cr_ready = {
+            "metadata": {"name": "test-sb", "namespace": "treadstone-local", "resourceVersion": "10"},
+            "spec": {"replicas": 1},
+            "status": {"conditions": [_cond("True", "DependenciesReady", "ok")]},
+        }
+        cr_stopped = {
+            "metadata": {"name": "test-sb", "namespace": "treadstone-local", "resourceVersion": "11"},
+            "spec": {"replicas": 0},
+            "status": {"conditions": [_cond("True", "DependenciesReady", "scaled down")]},
+        }
+        k8s.enqueue_watch_event("MODIFIED", cr_ready)
+        k8s.enqueue_watch_event("MODIFIED", cr_stopped)
+        k8s.stop_watch()
+
+        await watch_loop("treadstone-local", k8s, session_factory, resource_version="1")
+
+        async with session_factory() as session:
+            sb = await session.get(Sandbox, "sb00000000test1234")
+            assert sb.status == SandboxStatus.STOPPED
+            assert sb.k8s_resource_version == "11"
+
+    async def test_watch_deleted_event(self, session_factory):
+        """Watch DELETED event for a DELETING sandbox should mark it DELETED."""
+        await _create_sandbox(session_factory, status=SandboxStatus.DELETING)
+        k8s = FakeK8sClient()
+
+        cr = {"metadata": {"name": "test-sb", "namespace": "treadstone-local", "resourceVersion": "99"}}
+        k8s.enqueue_watch_event("DELETED", cr)
+        k8s.stop_watch()
+
+        await watch_loop("treadstone-local", k8s, session_factory, resource_version="1")
+
+        async with session_factory() as session:
+            sb = await session.get(Sandbox, "sb00000000test1234")
+            assert sb.status == SandboxStatus.DELETED
+
+    async def test_watch_loop_completes_on_stream_end(self, session_factory):
+        """Watch loop should return gracefully when the stream ends."""
+        k8s = FakeK8sClient()
+        k8s.stop_watch()
+
+        await asyncio.wait_for(
+            watch_loop("treadstone-local", k8s, session_factory, resource_version="0"),
+            timeout=2.0,
+        )

--- a/treadstone/services/k8s_client.py
+++ b/treadstone/services/k8s_client.py
@@ -11,7 +11,9 @@ Two implementations:
 """
 
 import asyncio
+import json
 import logging
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Any, Protocol, runtime_checkable
 
@@ -23,6 +25,12 @@ SANDBOX_API_GROUP = "agents.x-k8s.io"
 SANDBOX_API_VERSION = "v1alpha1"
 TEMPLATE_API_GROUP = "extensions.agents.x-k8s.io"
 TEMPLATE_API_VERSION = "v1alpha1"
+
+WATCH_TIMEOUT_SECONDS = 300
+
+
+class WatchExpiredError(Exception):
+    """Raised when the K8s API returns 410 Gone for an expired resourceVersion."""
 
 
 def format_shutdown_time(dt: datetime) -> str:
@@ -58,6 +66,12 @@ class K8sClientProtocol(Protocol):
     async def get_sandbox(self, name: str, namespace: str) -> dict[str, Any] | None: ...
 
     async def list_sandboxes(self, namespace: str) -> list[dict[str, Any]]: ...
+
+    async def list_sandboxes_with_metadata(self, namespace: str) -> dict[str, Any]: ...
+
+    async def watch_sandboxes(
+        self, namespace: str, resource_version: str = ""
+    ) -> AsyncIterator[tuple[str, dict[str, Any]]]: ...
 
     async def scale_sandbox(self, name: str, namespace: str, replicas: int) -> bool: ...
 
@@ -189,6 +203,50 @@ class Kr8sClient:
             data = resp.json()
             return data.get("items", [])
 
+    async def list_sandboxes_with_metadata(self, namespace: str) -> dict[str, Any]:
+        """List sandboxes and return the full response including list-level metadata."""
+        api = await self._get_api()
+        url = f"/apis/{SANDBOX_API_GROUP}/{SANDBOX_API_VERSION}/namespaces/{namespace}/sandboxes"
+        async with api.call_api("GET", base=url, version="") as resp:
+            return resp.json()
+
+    async def watch_sandboxes(
+        self, namespace: str, resource_version: str = ""
+    ) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+        """Stream Watch events for Sandbox CRs. Raises WatchExpiredError on 410 Gone."""
+        api = await self._get_api()
+        url = f"/apis/{SANDBOX_API_GROUP}/{SANDBOX_API_VERSION}/namespaces/{namespace}/sandboxes"
+        params = {"watch": "true", "timeoutSeconds": str(WATCH_TIMEOUT_SECONDS)}
+        if resource_version:
+            params["resourceVersion"] = resource_version
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        watch_url = f"{url}?{query}"
+
+        logger.info("Starting K8s Watch on %s (rv=%s)", url, resource_version or "<latest>")
+        async with api.call_api("GET", base=watch_url, version="", stream=True) as resp:
+            async for line in resp.aiter_lines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("Malformed Watch event line, skipping: %s", line[:200])
+                    continue
+
+                event_type = event.get("type", "")
+                obj = event.get("object", {})
+
+                if event_type == "ERROR":
+                    code = obj.get("code", 0)
+                    if code == 410:
+                        raise WatchExpiredError(obj.get("message", "resourceVersion expired"))
+                    logger.error("Watch ERROR event: %s", obj.get("message", event))
+                    continue
+
+                if event_type in ("ADDED", "MODIFIED", "DELETED"):
+                    yield event_type, obj
+
     async def scale_sandbox(self, name: str, namespace: str, replicas: int) -> bool:
         api = await self._get_api()
         url = f"/apis/{SANDBOX_API_GROUP}/{SANDBOX_API_VERSION}/namespaces/{namespace}/sandboxes/{name}/scale"
@@ -288,6 +346,7 @@ class FakeK8sClient:
         self._templates: list[dict[str, Any]] = list(self._DEFAULT_TEMPLATES)
         self._claims: dict[str, dict[str, Any]] = {}
         self._sandboxes: dict[str, dict[str, Any]] = {}
+        self._watch_queue: asyncio.Queue[tuple[str, dict[str, Any]] | None] = asyncio.Queue()
 
     async def create_sandbox_claim(
         self, name: str, template_ref: str, namespace: str, shutdown_time: datetime | None = None
@@ -377,6 +436,33 @@ class FakeK8sClient:
 
     async def list_sandboxes(self, namespace: str) -> list[dict[str, Any]]:
         return [sb for key, sb in self._sandboxes.items() if key.startswith(f"{namespace}/")]
+
+    async def list_sandboxes_with_metadata(self, namespace: str) -> dict[str, Any]:
+        items = await self.list_sandboxes(namespace)
+        max_rv = "0"
+        for item in items:
+            rv = item.get("metadata", {}).get("resourceVersion", "0")
+            if int(rv) > int(max_rv):
+                max_rv = rv
+        return {"metadata": {"resourceVersion": max_rv}, "items": items}
+
+    async def watch_sandboxes(
+        self, namespace: str, resource_version: str = ""
+    ) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+        """Yield events from the test queue. Send None to stop the stream."""
+        while True:
+            event = await self._watch_queue.get()
+            if event is None:
+                return
+            yield event
+
+    def enqueue_watch_event(self, event_type: str, cr_object: dict[str, Any]) -> None:
+        """Inject a Watch event for testing."""
+        self._watch_queue.put_nowait((event_type, cr_object))
+
+    def stop_watch(self) -> None:
+        """Signal the fake watch stream to stop."""
+        self._watch_queue.put_nowait(None)
 
     async def scale_sandbox(self, name: str, namespace: str, replicas: int) -> bool:
         key = f"{namespace}/{name}"

--- a/treadstone/services/k8s_sync.py
+++ b/treadstone/services/k8s_sync.py
@@ -12,6 +12,7 @@ Status derivation from real Sandbox CR (agents.x-k8s.io):
 """
 
 import asyncio
+import contextlib
 import logging
 from datetime import UTC, datetime
 
@@ -20,11 +21,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from treadstone.config import settings
 from treadstone.models.sandbox import Sandbox, SandboxStatus, is_valid_transition
-from treadstone.services.k8s_client import K8sClientProtocol
+from treadstone.services.k8s_client import K8sClientProtocol, WatchExpiredError
 
 logger = logging.getLogger(__name__)
 
 RECONCILE_INTERVAL = 300  # 5 minutes
+WATCH_RESTART_BACKOFF = 5  # seconds to wait before restarting Watch after unexpected failure
 
 
 def derive_status_from_sandbox_cr(cr: dict) -> tuple[str, str]:
@@ -147,11 +149,17 @@ async def reconcile(
     namespace: str,
     k8s_client: K8sClientProtocol,
     session_factory: async_sessionmaker[AsyncSession],
-) -> None:
-    """One-shot List + DB comparison for drift correction."""
+) -> str:
+    """One-shot List + DB comparison for drift correction.
+
+    Returns the list-level resourceVersion, which can be used as a starting point for Watch.
+    """
     logger.info("Starting reconciliation for namespace %s", namespace)
 
-    sandbox_crs = await k8s_client.list_sandboxes(namespace)
+    list_response = await k8s_client.list_sandboxes_with_metadata(namespace)
+    list_rv = list_response.get("metadata", {}).get("resourceVersion", "")
+    sandbox_crs = list_response.get("items", [])
+
     cr_map: dict[str, dict] = {}
     for cr in sandbox_crs:
         name = cr.get("metadata", {}).get("name")
@@ -189,7 +197,41 @@ async def reconcile(
             elif cr_rv != sandbox.k8s_resource_version:
                 await _update_sync_metadata(session, sandbox.id, cr_rv, message)
 
-    logger.info("Reconciliation complete. %d unmanaged CRs in K8s.", len(cr_map))
+    logger.info("Reconciliation complete. %d unmanaged CRs in K8s. list_rv=%s", len(cr_map), list_rv)
+    return list_rv
+
+
+async def watch_loop(
+    namespace: str,
+    k8s_client: K8sClientProtocol,
+    session_factory: async_sessionmaker[AsyncSession],
+    resource_version: str,
+) -> None:
+    """Consume Watch events and update DB in real time. Raises WatchExpiredError on 410."""
+    logger.info("Watch loop starting from rv=%s", resource_version)
+    async for event_type, cr_object in k8s_client.watch_sandboxes(namespace, resource_version):
+        try:
+            await handle_watch_event(event_type, cr_object, session_factory)
+        except Exception:
+            logger.exception("Error handling Watch event for %s", cr_object.get("metadata", {}).get("name"))
+        rv = cr_object.get("metadata", {}).get("resourceVersion", "")
+        if rv:
+            resource_version = rv
+    logger.info("Watch stream ended (server closed connection)")
+
+
+async def _periodic_reconcile(
+    namespace: str,
+    k8s_client: K8sClientProtocol,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Periodic reconciliation as a safety net alongside Watch."""
+    while True:
+        await asyncio.sleep(RECONCILE_INTERVAL)
+        try:
+            await reconcile(namespace, k8s_client, session_factory)
+        except Exception:
+            logger.exception("Periodic reconciliation failed")
 
 
 async def start_sync_loop(
@@ -197,14 +239,35 @@ async def start_sync_loop(
     k8s_client: K8sClientProtocol,
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Run periodic reconciliation. Watch integration is deferred to real K8s client."""
+    """Run Watch + periodic reconciliation concurrently.
+
+    On startup and after each Watch failure: reconcile (List) to get a consistent
+    resourceVersion, then start Watch from that point. Periodic reconciliation
+    runs as a safety net to catch any missed Watch events.
+    """
     try:
         while True:
             try:
-                await reconcile(namespace, k8s_client, session_factory)
+                list_rv = await reconcile(namespace, k8s_client, session_factory)
             except Exception:
-                logger.exception("Reconciliation failed")
-            await asyncio.sleep(RECONCILE_INTERVAL)
+                logger.exception("Initial reconciliation failed, retrying in %ds", WATCH_RESTART_BACKOFF)
+                await asyncio.sleep(WATCH_RESTART_BACKOFF)
+                continue
+
+            reconcile_task = asyncio.create_task(_periodic_reconcile(namespace, k8s_client, session_factory))
+            try:
+                await watch_loop(namespace, k8s_client, session_factory, list_rv)
+                # Watch stream ended normally (server timeout) — restart
+                logger.info("Watch stream ended, restarting")
+            except WatchExpiredError:
+                logger.info("Watch resourceVersion expired (410), re-listing")
+            except Exception:
+                logger.exception("Watch loop failed, restarting in %ds", WATCH_RESTART_BACKOFF)
+                await asyncio.sleep(WATCH_RESTART_BACKOFF)
+            finally:
+                reconcile_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await reconcile_task
     except asyncio.CancelledError:
         logger.info("Sync loop shutting down")
 


### PR DESCRIPTION
## Summary

- Implement real-time K8s Watch stream for Sandbox CRs alongside the existing periodic reconciliation, reducing state sync latency from 5 minutes to near-instant.
- Add `watch_sandboxes` and `list_sandboxes_with_metadata` to `K8sClientProtocol` / `Kr8sClient`, with streaming JSON line parsing and 410 Gone (expired resourceVersion) handling.
- Rewrite `start_sync_loop` to run Watch + periodic reconcile concurrently: on startup, List to get a consistent resourceVersion, then Watch from that point; periodic reconcile continues as a safety net.
- Extend `FakeK8sClient` with `enqueue_watch_event` / `stop_watch` for deterministic testing of Watch event processing.

## Test Plan

- [x] `make test` — 168 tests pass (4 new TestWatchLoop tests + 1 new TestReconcile test)
- [x] `make lint` — clean

Made with [Cursor](https://cursor.com)