### PR TITLE
feat: sandbox subdomain routing, ingress, and name validation

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -41,6 +41,8 @@ treadstone config set api_key ts_live_xxxxxxxxxxxx
 
 # Create a sandbox
 treadstone sandboxes create --template default --name my-sandbox
+# Name rules: 1-55 chars, lowercase letters/numbers/hyphens only,
+# and must start/end with a letter or number.
 
 # List sandboxes
 treadstone sb list
@@ -132,6 +134,9 @@ treadstone auth delete-user <user-id>    # Delete a user (admin)
 ### `sandboxes` (alias: `sb`)
 
 Create and manage sandboxes.
+
+Custom sandbox names must be 1-55 characters of lowercase letters, numbers, or hyphens. They must start and end
+with a letter or number. This keeps browser URLs like `sandbox-{name}.treadstone-ai.dev` within DNS label limits.
 
 ```bash
 treadstone sb create --template default --name my-box

--- a/cli/treadstone_cli/sandboxes.py
+++ b/cli/treadstone_cli/sandboxes.py
@@ -25,7 +25,15 @@ def sandboxes() -> None:
 
 @sandboxes.command("create")
 @click.option("--template", required=True, help="Sandbox template name.")
-@click.option("--name", default=None, help="Sandbox name (auto-generated if omitted).")
+@click.option(
+    "--name",
+    default=None,
+    help=(
+        "Sandbox name (auto-generated if omitted). Must be 1-55 characters of lowercase letters, "
+        "numbers, or hyphens; must start and end with a letter or number. "
+        "This keeps sandbox-{name} within DNS label limits."
+    ),
+)
 @click.option("--label", multiple=True, help="Labels in key:val format (repeatable).")
 @click.option("--persist", is_flag=True, default=False, help="Enable persistent storage.")
 @click.option("--storage-size", default="10Gi", help="PVC size when --persist is set.")
@@ -39,6 +47,10 @@ def create(
     storage_size: str,
 ) -> None:
     """Create a new sandbox from a template.
+
+    Custom names must be 1-55 characters of lowercase letters, numbers, or
+    hyphens, and must start and end with a letter or number. This keeps
+    browser URLs like sandbox-{name}.treadstone-ai.dev within DNS label limits.
 
     \b
     Examples:

--- a/deploy/treadstone/values-demo.yaml
+++ b/deploy/treadstone/values-demo.yaml
@@ -31,7 +31,12 @@ ingress:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "true"
-    alb.ingress.kubernetes.io/certificate-id: "24059672-cn-hangzhou"
+    alb.ingress.kubernetes.io/certificate-id: "24067085-cn-hangzhou"
+    alb.ingress.kubernetes.io/healthcheck-enabled: "true"
+    alb.ingress.kubernetes.io/healthcheck-method: GET
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+    alb.ingress.kubernetes.io/healthcheck-httpcode: http_2xx
   hosts:
     - host: demo.treadstone-ai.dev
       paths:

--- a/deploy/treadstone/values-prod.yaml
+++ b/deploy/treadstone/values-prod.yaml
@@ -34,9 +34,18 @@ ingress:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "true"
-    alb.ingress.kubernetes.io/certificate-id: "24064579-cn-hangzhou"
+    alb.ingress.kubernetes.io/certificate-id: "24067085-cn-hangzhou"
+    alb.ingress.kubernetes.io/healthcheck-enabled: "true"
+    alb.ingress.kubernetes.io/healthcheck-method: GET
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+    alb.ingress.kubernetes.io/healthcheck-httpcode: http_2xx
   hosts:
     - host: api.treadstone-ai.dev
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: "*.treadstone-ai.dev"
       paths:
         - path: /
           pathType: Prefix

--- a/tests/api/test_sandbox_subdomain_api.py
+++ b/tests/api/test_sandbox_subdomain_api.py
@@ -1,4 +1,4 @@
-"""API tests for subdomain-based sandbox routing."""
+"""API tests for subdomain-based sandbox routing (prefix-based)."""
 
 from unittest.mock import AsyncMock, patch
 
@@ -58,6 +58,7 @@ def _capture_mock():
 
 def _enable_subdomain(monkeypatch, domain: str = "sandbox.localhost"):
     monkeypatch.setenv("TREADSTONE_SANDBOX_DOMAIN", domain)
+    monkeypatch.setenv("TREADSTONE_SANDBOX_SUBDOMAIN_PREFIX", "sandbox-")
     monkeypatch.setenv("TREADSTONE_SANDBOX_NAMESPACE", "default")
     monkeypatch.setenv("TREADSTONE_SANDBOX_PORT", "8080")
     from treadstone.config import Settings
@@ -82,6 +83,7 @@ class TestSubdomainDisabled:
 
 class TestSubdomainRouting:
     async def test_subdomain_proxies_to_sandbox(self, client: AsyncClient, monkeypatch):
+        """sandbox-mybox.sandbox.localhost → mybox.default.svc.cluster.local"""
         _enable_subdomain(monkeypatch)
         mock_client, captured = _capture_mock()
 
@@ -89,11 +91,11 @@ class TestSubdomainRouting:
             with patch("treadstone.middleware.sandbox_subdomain.get_http_client", return_value=mock_client):
                 resp = await client.get(
                     "/v1/docs",
-                    headers={"Host": "sb-test.sandbox.localhost:8000"},
+                    headers={"Host": "sandbox-mybox.sandbox.localhost:8000"},
                 )
 
         assert resp.status_code == 200
-        assert "sb-test.default.svc.cluster.local:8080/v1/docs" in captured["url"]
+        assert "mybox.default.svc.cluster.local:8080/v1/docs" in captured["url"]
 
     async def test_subdomain_root_path(self, client: AsyncClient, monkeypatch):
         _enable_subdomain(monkeypatch)
@@ -103,10 +105,20 @@ class TestSubdomainRouting:
             with patch("treadstone.middleware.sandbox_subdomain.get_http_client", return_value=mock_client):
                 resp = await client.get(
                     "/",
-                    headers={"Host": "sb-test.sandbox.localhost:8000"},
+                    headers={"Host": "sandbox-mybox.sandbox.localhost:8000"},
                 )
 
         assert resp.status_code == 200
+
+    async def test_non_sandbox_subdomain_falls_through(self, client: AsyncClient, monkeypatch):
+        """api.sandbox.localhost does NOT have the sandbox- prefix → falls through."""
+        _enable_subdomain(monkeypatch)
+        resp = await client.get(
+            "/health",
+            headers={"Host": "api.sandbox.localhost:8000"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
 
     async def test_non_subdomain_falls_through(self, client: AsyncClient, monkeypatch):
         _enable_subdomain(monkeypatch)
@@ -137,7 +149,7 @@ class TestSubdomainRouting:
             with patch("treadstone.middleware.sandbox_subdomain.get_http_client", return_value=mock_client):
                 resp = await client.get(
                     "/",
-                    headers={"Host": "sb-down.sandbox.localhost:8000"},
+                    headers={"Host": "sandbox-down.sandbox.localhost:8000"},
                 )
 
         assert resp.status_code == 502

--- a/tests/api/test_sandboxes_api.py
+++ b/tests/api/test_sandboxes_api.py
@@ -98,6 +98,36 @@ class TestCreateSandbox:
         assert data["name"] == "persist-sb"
         assert data["status"] == "creating"
 
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "BadName",
+            "-leading-dash",
+            "trailing-dash-",
+            "has_underscore",
+            "has.dot",
+            "a" * 56,
+        ],
+    )
+    async def test_create_with_invalid_name_returns_422(self, auth_client, name):
+        resp = await auth_client.post(
+            "/v1/sandboxes",
+            json={"template": "aio-sandbox-tiny", "name": name},
+        )
+        assert resp.status_code == 422
+        data = resp.json()
+        assert data["error"]["code"] == "validation_error"
+        assert "Sandbox name must be 1-55 characters" in data["error"]["message"]
+
+    async def test_create_accepts_name_at_max_length(self, auth_client):
+        name = "a" * 55
+        resp = await auth_client.post(
+            "/v1/sandboxes",
+            json={"template": "aio-sandbox-tiny", "name": name},
+        )
+        assert resp.status_code == 202
+        assert resp.json()["name"] == name
+
 
 class TestListSandboxes:
     async def test_list_returns_own_sandboxes(self, auth_client):

--- a/tests/unit/test_sandbox_build_urls.py
+++ b/tests/unit/test_sandbox_build_urls.py
@@ -26,23 +26,44 @@ def test_web_port_suffix(api_base: str, expected_suffix: str) -> None:
     assert _web_port_suffix(api_base) == expected_suffix
 
 
+def _fake_settings(**overrides):
+    defaults = {"sandbox_domain": "sandbox.localhost", "sandbox_subdomain_prefix": "sandbox-"}
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
 def test_build_urls_web_omits_port_for_plain_localhost(monkeypatch) -> None:
-    monkeypatch.setattr("treadstone.api.sandboxes.settings", SimpleNamespace(sandbox_domain="sandbox.localhost"))
+    monkeypatch.setattr("treadstone.api.sandboxes.settings", _fake_settings())
     sb = SimpleNamespace(id="1", name="sbx")
     urls = _build_urls(sb, "http://localhost/")
-    assert urls["web"] == "http://sbx.sandbox.localhost"
+    assert urls["web"] == "http://sandbox-sbx.sandbox.localhost"
     assert urls["proxy"] == "http://localhost/v1/sandboxes/1/proxy"
 
 
 def test_build_urls_web_includes_port_for_dev_server(monkeypatch) -> None:
-    monkeypatch.setattr("treadstone.api.sandboxes.settings", SimpleNamespace(sandbox_domain="sandbox.localhost"))
+    monkeypatch.setattr("treadstone.api.sandboxes.settings", _fake_settings())
     sb = SimpleNamespace(id="1", name="sbx")
     urls = _build_urls(sb, "http://localhost:8000/")
-    assert urls["web"] == "http://sbx.sandbox.localhost:8000"
+    assert urls["web"] == "http://sandbox-sbx.sandbox.localhost:8000"
 
 
 def test_build_urls_web_includes_port_for_port_forward(monkeypatch) -> None:
-    monkeypatch.setattr("treadstone.api.sandboxes.settings", SimpleNamespace(sandbox_domain="sandbox.localhost"))
+    monkeypatch.setattr("treadstone.api.sandboxes.settings", _fake_settings())
     sb = SimpleNamespace(id="1", name="sbx")
     urls = _build_urls(sb, "http://127.0.0.1:12345/")
-    assert urls["web"] == "http://sbx.sandbox.localhost:12345"
+    assert urls["web"] == "http://sandbox-sbx.sandbox.localhost:12345"
+
+
+def test_build_urls_prod_domain(monkeypatch) -> None:
+    monkeypatch.setattr("treadstone.api.sandboxes.settings", _fake_settings(sandbox_domain="treadstone-ai.dev"))
+    sb = SimpleNamespace(id="sb123", name="my-project")
+    urls = _build_urls(sb, "https://api.treadstone-ai.dev/")
+    assert urls["web"] == "https://sandbox-my-project.treadstone-ai.dev"
+    assert urls["proxy"] == "https://api.treadstone-ai.dev/v1/sandboxes/sb123/proxy"
+
+
+def test_build_urls_web_none_when_domain_empty(monkeypatch) -> None:
+    monkeypatch.setattr("treadstone.api.sandboxes.settings", _fake_settings(sandbox_domain=""))
+    sb = SimpleNamespace(id="1", name="sbx")
+    urls = _build_urls(sb, "http://localhost/")
+    assert urls["web"] is None

--- a/tests/unit/test_sandbox_name_rules.py
+++ b/tests/unit/test_sandbox_name_rules.py
@@ -1,0 +1,24 @@
+"""Tests for sandbox name validation and documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from treadstone.api.schemas import CreateSandboxRequest
+
+
+def test_create_sandbox_schema_documents_name_rules() -> None:
+    name_schema = CreateSandboxRequest.model_json_schema()["properties"]["name"]
+
+    assert "1-55 characters" in name_schema["description"]
+    assert "lowercase letters, numbers, or hyphens" in name_schema["description"]
+    assert "sandbox-{name}" in name_schema["description"]
+
+
+def test_cli_source_documents_sandbox_name_rules() -> None:
+    source = (Path(__file__).resolve().parents[2] / "cli" / "treadstone_cli" / "sandboxes.py").read_text()
+
+    assert "1-55 characters" in source
+    assert "lowercase letters" in source
+    assert "numbers, or hyphens" in source
+    assert "sandbox-{name}" in source

--- a/tests/unit/test_sandbox_subdomain.py
+++ b/tests/unit/test_sandbox_subdomain.py
@@ -1,32 +1,49 @@
-"""Unit tests for sandbox subdomain extraction."""
+"""Unit tests for sandbox subdomain extraction (prefix-based)."""
 
-from treadstone.middleware.sandbox_subdomain import extract_sandbox_id
+from treadstone.middleware.sandbox_subdomain import extract_sandbox_name
 
 
-class TestExtractSandboxId:
-    def test_valid_subdomain(self):
-        assert extract_sandbox_id("sb-123.sandbox.localhost:8000", "sandbox.localhost") == "sb-123"
+class TestExtractSandboxName:
+    """extract_sandbox_name recognises the ``sandbox-`` prefix and strips it."""
 
-    def test_valid_subdomain_no_port(self):
-        assert extract_sandbox_id("sb-123.sandbox.example.com", "sandbox.example.com") == "sb-123"
+    def test_valid_sandbox_subdomain(self):
+        assert extract_sandbox_name("sandbox-foobar.treadstone-ai.dev", "treadstone-ai.dev") == "foobar"
+
+    def test_valid_with_port(self):
+        assert extract_sandbox_name("sandbox-foobar.sandbox.localhost:8000", "sandbox.localhost") == "foobar"
 
     def test_case_insensitive(self):
-        assert extract_sandbox_id("SB-123.Sandbox.Localhost:8000", "sandbox.localhost") == "sb-123"
+        assert extract_sandbox_name("Sandbox-Foobar.Sandbox.Localhost:8000", "sandbox.localhost") == "foobar"
 
-    def test_no_match_different_domain(self):
-        assert extract_sandbox_id("sb-123.other.localhost:8000", "sandbox.localhost") is None
+    def test_hyphenated_name(self):
+        assert extract_sandbox_name("sandbox-my-cool-box.treadstone-ai.dev", "treadstone-ai.dev") == "my-cool-box"
+
+    def test_api_subdomain_ignored(self):
+        assert extract_sandbox_name("api.treadstone-ai.dev", "treadstone-ai.dev") is None
+
+    def test_www_subdomain_ignored(self):
+        assert extract_sandbox_name("www.treadstone-ai.dev", "treadstone-ai.dev") is None
+
+    def test_docs_subdomain_ignored(self):
+        assert extract_sandbox_name("docs.treadstone-ai.dev", "treadstone-ai.dev") is None
+
+    def test_demo_subdomain_ignored(self):
+        assert extract_sandbox_name("demo.treadstone-ai.dev", "treadstone-ai.dev") is None
+
+    def test_bare_prefix_no_name(self):
+        assert extract_sandbox_name("sandbox-.treadstone-ai.dev", "treadstone-ai.dev") is None
 
     def test_no_match_exact_domain(self):
-        assert extract_sandbox_id("sandbox.localhost:8000", "sandbox.localhost") is None
+        assert extract_sandbox_name("treadstone-ai.dev", "treadstone-ai.dev") is None
+
+    def test_no_match_different_domain(self):
+        assert extract_sandbox_name("sandbox-foo.other.dev", "treadstone-ai.dev") is None
 
     def test_no_match_nested_subdomain(self):
-        assert extract_sandbox_id("a.b.sandbox.localhost:8000", "sandbox.localhost") is None
+        assert extract_sandbox_name("a.sandbox-foo.treadstone-ai.dev", "treadstone-ai.dev") is None
 
-    def test_no_match_regular_host(self):
-        assert extract_sandbox_id("localhost:8000", "sandbox.localhost") is None
+    def test_custom_prefix(self):
+        assert extract_sandbox_name("sb-test.sandbox.localhost:8000", "sandbox.localhost", prefix="sb-") == "test"
 
-    def test_hyphenated_sandbox_id(self):
-        assert (
-            extract_sandbox_id("sandbox-claim-test-01.sandbox.localhost:8000", "sandbox.localhost")
-            == "sandbox-claim-test-01"
-        )
+    def test_custom_prefix_no_match(self):
+        assert extract_sandbox_name("sandbox-foo.treadstone-ai.dev", "treadstone-ai.dev", prefix="sb-") is None

--- a/treadstone/api/sandboxes.py
+++ b/treadstone/api/sandboxes.py
@@ -53,7 +53,9 @@ def _build_urls(sb, base_url: str) -> dict:
             scheme = parsed.scheme
         else:
             scheme = "https" if base.startswith("https") else "http"
-        web = f"{scheme}://{sb.name}.{settings.sandbox_domain}{_web_port_suffix(base)}"
+        web = (
+            f"{scheme}://{settings.sandbox_subdomain_prefix}{sb.name}.{settings.sandbox_domain}{_web_port_suffix(base)}"
+        )
     return {"proxy": proxy, "web": web}
 
 

--- a/treadstone/api/schemas.py
+++ b/treadstone/api/schemas.py
@@ -6,16 +6,29 @@ generate rich OpenAPI specs with examples.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+SANDBOX_NAME_MAX_LENGTH = 55
+SANDBOX_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,53}[a-z0-9])?$")
+SANDBOX_NAME_RULE = (
+    "Sandbox name must be 1-55 characters of lowercase letters, numbers, or hyphens, "
+    "and must start and end with a letter or number."
+)
+SANDBOX_NAME_DESCRIPTION = (
+    "Optional custom sandbox name. "
+    f"{SANDBOX_NAME_RULE} "
+    "This keeps browser URLs like `sandbox-{name}.treadstone-ai.dev` within DNS label limits."
+)
 
 # ── Sandbox ──────────────────────────────────────────────────────────────────
 
 
 class CreateSandboxRequest(BaseModel):
     template: str = Field(..., examples=["aio-sandbox-tiny"])
-    name: str | None = Field(default=None, examples=["my-sandbox"])
+    name: str | None = Field(default=None, examples=["my-sandbox"], description=SANDBOX_NAME_DESCRIPTION)
     labels: dict = Field(default_factory=dict, examples=[{"env": "dev"}])
     auto_stop_interval: int = Field(
         default=15, examples=[15], description="Minutes of inactivity before the sandbox is automatically stopped."
@@ -31,6 +44,15 @@ class CreateSandboxRequest(BaseModel):
         examples=["10Gi"],
         description="Persistent volume size (only effective when persist=true).",
     )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not SANDBOX_NAME_PATTERN.fullmatch(value):
+            raise ValueError(SANDBOX_NAME_RULE)
+        return value
 
 
 class SandboxUrls(BaseModel):

--- a/treadstone/config.py
+++ b/treadstone/config.py
@@ -32,10 +32,15 @@ class Settings(BaseSettings):
     sandbox_proxy_timeout: float = 180.0
 
     # Subdomain-based sandbox routing (for browser Web UI access)
-    # Dev: "sandbox.localhost"  →  {name}.sandbox.localhost[:port] when the API URL has a non-default port
-    # Prod: "sandbox.example.com"  →  {name}.sandbox.example.com
+    # Dev: "sandbox.localhost"  →  sandbox-{name}.sandbox.localhost[:port]
+    # Prod: "treadstone-ai.dev" →  sandbox-{name}.treadstone-ai.dev
     # Empty string disables subdomain routing.
     sandbox_domain: str = ""
+
+    # Only subdomains starting with this prefix are treated as sandbox Web UI
+    # traffic.  Non-matching subdomains (api, www, docs, …) pass through to
+    # the normal FastAPI app.  Override via TREADSTONE_SANDBOX_SUBDOMAIN_PREFIX.
+    sandbox_subdomain_prefix: str = "sandbox-"
 
     model_config = {"env_prefix": "TREADSTONE_", "env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/treadstone/middleware/sandbox_subdomain.py
+++ b/treadstone/middleware/sandbox_subdomain.py
@@ -1,12 +1,13 @@
 """
 ASGI middleware for subdomain-based sandbox routing.
 
-When sandbox_domain is configured (e.g. "sandbox.localhost"), requests to
-  {sandbox_id}.sandbox.localhost
+When sandbox_domain is configured (e.g. "treadstone-ai.dev"), requests to
+  sandbox-{name}.treadstone-ai.dev
 are transparently proxied to the corresponding sandbox pod, supporting
 both HTTP and WebSocket.
 
-Requests to other hosts pass through to the normal FastAPI app unchanged.
+Only subdomains that start with ``sandbox_subdomain_prefix`` (default
+``sandbox-``) are intercepted; all other hosts pass through unchanged.
 """
 
 from __future__ import annotations
@@ -30,11 +31,15 @@ from treadstone.services.sandbox_proxy import (
 logger = logging.getLogger(__name__)
 
 
-def extract_sandbox_id(host: str, sandbox_domain: str) -> str | None:
-    """Extract sandbox_id from Host header.
+def extract_sandbox_name(host: str, sandbox_domain: str, prefix: str = "sandbox-") -> str | None:
+    """Return the sandbox name from a Host header, or None.
 
-    "sb-123.sandbox.localhost:8000" with domain "sandbox.localhost"
-    → returns "sb-123"
+    "sandbox-foobar.treadstone-ai.dev" with domain "treadstone-ai.dev"
+    → returns "foobar"
+
+    Only subdomains that start with *prefix* are recognised.  Subdomains
+    like "api.treadstone-ai.dev" or "www.treadstone-ai.dev" are ignored
+    because they don't carry the prefix.
     """
     host_no_port = host.split(":")[0].lower()
     domain = sandbox_domain.lower()
@@ -42,14 +47,17 @@ def extract_sandbox_id(host: str, sandbox_domain: str) -> str | None:
     if not host_no_port.endswith(f".{domain}"):
         return None
 
-    prefix = host_no_port[: -(len(domain) + 1)]
-    if not prefix or "." in prefix:
+    subdomain = host_no_port[: -(len(domain) + 1)]
+    if not subdomain or "." in subdomain:
         return None
-    return prefix
+    if not subdomain.startswith(prefix):
+        return None
+    name = subdomain[len(prefix) :]
+    return name if name else None
 
 
 class SandboxSubdomainMiddleware:
-    """ASGI middleware that intercepts requests to *.sandbox_domain and proxies them."""
+    """ASGI middleware that intercepts requests to {prefix}*.sandbox_domain and proxies them."""
 
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
@@ -64,16 +72,18 @@ class SandboxSubdomainMiddleware:
             return
 
         host = self._get_host(scope)
-        sandbox_id = extract_sandbox_id(host, settings.sandbox_domain) if host else None
+        sandbox_name = (
+            extract_sandbox_name(host, settings.sandbox_domain, settings.sandbox_subdomain_prefix) if host else None
+        )
 
-        if sandbox_id is None:
+        if sandbox_name is None:
             await self.app(scope, receive, send)
             return
 
         if scope["type"] == "http":
-            await self._handle_http(scope, receive, send, sandbox_id)
+            await self._handle_http(scope, receive, send, sandbox_name)
         else:
-            await self._handle_websocket(scope, receive, send, sandbox_id)
+            await self._handle_websocket(scope, receive, send, sandbox_name)
 
     @staticmethod
     def _get_host(scope: Scope) -> str | None:
@@ -82,7 +92,7 @@ class SandboxSubdomainMiddleware:
                 return value.decode("latin-1")
         return None
 
-    async def _handle_http(self, scope: Scope, receive: Receive, send: Send, sandbox_id: str) -> None:
+    async def _handle_http(self, scope: Scope, receive: Receive, send: Send, sandbox_name: str) -> None:
         request = Request(scope, receive)
         path = scope.get("path", "/")
         query_string = scope.get("query_string", b"").decode("latin-1")
@@ -97,8 +107,8 @@ class SandboxSubdomainMiddleware:
         body = b"".join(body_parts)
 
         full_path = f"{path}?{query_string}" if query_string else path
-        target_url = build_sandbox_url(sandbox_id, full_path)
-        logger.info("Subdomain proxy %s %s → %s", request.method, sandbox_id, target_url)
+        target_url = build_sandbox_url(sandbox_name, full_path)
+        logger.info("Subdomain proxy %s %s → %s", request.method, sandbox_name, target_url)
 
         client = await get_http_client()
         outgoing = _filter_request_headers(headers)
@@ -119,20 +129,20 @@ class SandboxSubdomainMiddleware:
         )
         await streaming(scope, receive, send)
 
-    async def _handle_websocket(self, scope: Scope, receive: Receive, send: Send, sandbox_id: str) -> None:
+    async def _handle_websocket(self, scope: Scope, receive: Receive, send: Send, sandbox_name: str) -> None:
         websocket = WebSocket(scope, receive, send)
         path = scope.get("path", "/")
         query_string = scope.get("query_string", b"").decode("latin-1")
         if query_string:
             path = f"{path}?{query_string}"
-        logger.info("Subdomain WS proxy %s → %s", sandbox_id, path)
+        logger.info("Subdomain WS proxy %s → %s", sandbox_name, path)
 
         await websocket.accept()
 
         try:
             await proxy_websocket(
                 client_ws=websocket,
-                sandbox_id=sandbox_id,
+                sandbox_id=sandbox_name,
                 path=path,
             )
         except Exception:


### PR DESCRIPTION
## Summary
- **Subdomain routing**: Web UI URLs use `sandbox-{name}.{apex}` with configurable `sandbox-` prefix; middleware strips prefix and proxies by sandbox name.
- **Ingress / ALB**: Wildcard host `*.treadstone-ai.dev`, Cloudflare Origin cert ID, explicit GET `/health` health checks for prod/demo values.
- **Validation**: API enforces DNS-1123-style sandbox names (1–55 chars); CLI/README document the rules.

## Test Plan
- [x] `make test`
- [x] `make lint`

Made with [Cursor](https://cursor.com)