### PR TITLE
fix(ci): sync release versions across packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set versions from tag
+        run: python scripts/set_release_versions.py "${{ github.ref_name }}"
 
       - uses: docker/login-action@v3
         with:
@@ -70,11 +72,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
 
-      - name: Set version from tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-          sed -i "s/^version = .*/version = \"$VERSION\"/" cli/pyproject.toml
+      - name: Set versions from tag
+        run: python scripts/set_release_versions.py "${{ github.ref_name }}"
 
       - name: Build CLI
         working-directory: cli
@@ -103,11 +102,8 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: pip install poetry-core
 
-      - name: Set version from tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-          sed -i "s/^version = .*/version = \"$VERSION\"/" sdk/python/pyproject.toml
+      - name: Set versions from tag
+        run: python scripts/set_release_versions.py "${{ github.ref_name }}"
 
       - name: Build SDK
         working-directory: sdk/python
@@ -146,17 +142,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
 
-      - name: Set version from tag
-        shell: python
-        run: |
-          import os
-          import re
-          from pathlib import Path
-
-          ver = os.environ["GITHUB_REF_NAME"].lstrip("v")
-          p = Path("cli/pyproject.toml")
-          text = p.read_text(encoding="utf-8")
-          p.write_text(re.sub(r"(?m)^version = .*", f'version = "{ver}"', text), encoding="utf-8")
+      - name: Set versions from tag
+        run: python scripts/set_release_versions.py "${{ github.ref_name }}"
 
       - name: Install CLI dependencies + PyInstaller
         working-directory: cli

--- a/cli/README.md
+++ b/cli/README.md
@@ -7,7 +7,7 @@ Command-line interface for the Treadstone sandbox service.
 ### From PyPI
 
 ```bash
-pip install treadstone
+pip install treadstone-cli
 ```
 
 ### Pre-built binary
@@ -147,6 +147,8 @@ treadstone sb get <sandbox-id>
 treadstone sb start <sandbox-id>
 treadstone sb stop <sandbox-id>
 treadstone sb delete <sandbox-id>
+```
+
 ### `templates`
 
 List available sandbox templates.

--- a/scripts/set_release_versions.py
+++ b/scripts/set_release_versions.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+TARGETS = (
+    ("pyproject.toml", "[project]"),
+    ("cli/pyproject.toml", "[project]"),
+    ("sdk/python/pyproject.toml", "[tool.poetry]"),
+)
+
+
+def _update_version_in_section(content: str, section: str, version: str, file_label: str) -> str:
+    section_pattern = re.compile(rf"(?ms)^({re.escape(section)}\n)(.*?)(?=^\[|\Z)")
+    match = section_pattern.search(content)
+    if match is None:
+        raise ValueError(f"{file_label}: missing section {section}")
+
+    body = match.group(2)
+    updated_body, count = re.subn(r'(?m)^version = ".*"$', f'version = "{version}"', body, count=1)
+    if count != 1:
+        raise ValueError(f"{file_label}: missing version entry in {section}")
+
+    return f"{content[:match.start(2)]}{updated_body}{content[match.end(2):]}"
+
+
+def set_release_versions(root: Path, version: str) -> list[Path]:
+    normalized_version = version.lstrip("v")
+    updated_paths: list[Path] = []
+
+    for relative_path, section in TARGETS:
+        path = root / relative_path
+        if not path.exists():
+            raise FileNotFoundError(relative_path)
+
+        content = path.read_text(encoding="utf-8")
+        updated = _update_version_in_section(content, section, normalized_version, relative_path)
+        path.write_text(updated, encoding="utf-8")
+        updated_paths.append(path)
+
+    return updated_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Set release versions across all publishable packages.")
+    parser.add_argument("version", help="Release version, with or without the leading v.")
+    parser.add_argument("--root", default=".", help="Repository root. Defaults to the current directory.")
+    args = parser.parse_args()
+
+    try:
+        updated_paths = set_release_versions(Path(args.root).resolve(), args.version)
+    except (FileNotFoundError, ValueError) as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    for path in updated_paths:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_release_versioning.py
+++ b/tests/unit/test_release_versioning.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "set_release_versions.py"
+
+
+def _write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_set_release_versions_updates_server_cli_and_sdk_versions(tmp_path: Path) -> None:
+    _write_file(
+        tmp_path / "pyproject.toml",
+        """
+[project]
+name = "treadstone"
+version = "0.1.0"
+""".strip(),
+    )
+    _write_file(
+        tmp_path / "cli" / "pyproject.toml",
+        """
+[project]
+name = "treadstone-cli"
+version = "0.1.0"
+""".strip(),
+    )
+    _write_file(
+        tmp_path / "sdk" / "python" / "pyproject.toml",
+        """
+[tool.poetry]
+name = "treadstone-sdk"
+version = "0.1.0"
+""".strip(),
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "0.3.4", "--root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert 'version = "0.3.4"' in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "0.3.4"' in (tmp_path / "cli" / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "0.3.4"' in (tmp_path / "sdk" / "python" / "pyproject.toml").read_text(encoding="utf-8")
+
+
+def test_set_release_versions_fails_when_a_target_file_is_missing(tmp_path: Path) -> None:
+    _write_file(
+        tmp_path / "pyproject.toml",
+        """
+[project]
+name = "treadstone"
+version = "0.1.0"
+""".strip(),
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "0.3.4", "--root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "cli/pyproject.toml" in result.stderr


### PR DESCRIPTION
## Summary
- centralize release version rewriting in a shared script used by Docker, CLI, SDK, and binary jobs
- add a unit test that guards release version sync across all publishable packages
- fix the CLI README PyPI package name and close a broken code fence

## Test Plan
- [x] uv run pytest tests/unit/test_release_versioning.py -v
- [x] make lint

## Notes
- No release was triggered in this change.
- Node.js 20 deprecation warnings in GitHub Actions remain a separate non-blocking follow-up.