### PR TITLE
fix: harden leader election lease timestamps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ TREADSTONE_DATABASE_URL=postgresql+asyncpg://user:password@ep-xxx.region.aws.neo
 
 # === App ===
 TREADSTONE_DEBUG=false
+TREADSTONE_API_BASE_URL=http://localhost:8000
 TREADSTONE_AUTH_TYPE=cookie
 TREADSTONE_REGISTER_MODE=unlimited
 
@@ -31,6 +32,8 @@ TREADSTONE_LOGTO_APP_ID=
 # Prod: "sandbox.example.com"  ->  {sandbox_id}.sandbox.example.com
 # Empty string disables subdomain routing.
 TREADSTONE_SANDBOX_DOMAIN=
+# Required when TREADSTONE_SANDBOX_DOMAIN is public/non-local.
+# Set this to the public API origin for the current environment.
 # Must match the K8s namespace for this environment (treadstone-local / treadstone-demo / treadstone-prod)
 TREADSTONE_SANDBOX_NAMESPACE=treadstone-local
 TREADSTONE_SANDBOX_PORT=8080

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,6 +17,11 @@ def test_settings_override():
     assert s.debug is True
 
 
+def test_settings_api_base_url_default():
+    s = Settings(_env_file=None, database_url=DB_URL)
+    assert s.api_base_url == "http://localhost:8000"
+
+
 def test_auth_defaults():
     s = Settings(_env_file=None, database_url=DB_URL)
     assert s.auth_type == "cookie"

--- a/tests/unit/test_leader_election.py
+++ b/tests/unit/test_leader_election.py
@@ -1,11 +1,22 @@
 import copy
 from datetime import UTC, datetime, timedelta
 
-from treadstone.services.leader_election import K8sLeaseConflictError, LeaderElector, LeadershipState
+from treadstone.services.leader_election import (
+    K8sLeaseConflictError,
+    LeaderElector,
+    LeadershipState,
+    format_lease_time,
+)
 
 
 def _ts(dt: datetime) -> str:
-    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def test_format_lease_time_uses_microseconds():
+    now = datetime(2026, 3, 24, 4, 0, 1, 234567, tzinfo=UTC)
+
+    assert format_lease_time(now) == "2026-03-24T04:00:01.234567Z"
 
 
 class FakeLeaseStore:

--- a/treadstone/config.py
+++ b/treadstone/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     app_name: str = "treadstone"
     debug: bool = False
     database_url: str = "postgresql+asyncpg://user:pass@ep-xxx.us-east-2.aws.neon.tech/treadstone?sslmode=require"
+    # Public API origin used in browser bootstrap redirects and public sandbox Web UI flows.
     api_base_url: str = "http://localhost:8000"
 
     # Auth

--- a/treadstone/services/leader_election.py
+++ b/treadstone/services/leader_election.py
@@ -36,7 +36,7 @@ class LeaseStoreProtocol(Protocol):
 
 def format_lease_time(dt: datetime) -> str:
     """Format Lease timestamps as RFC3339."""
-    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
 def parse_lease_time(value: str | None) -> datetime | None:


### PR DESCRIPTION
## Summary
- format Kubernetes Lease timestamps with RFC3339 microseconds so leader election works on clusters that reject whole-second Lease times
- document `TREADSTONE_API_BASE_URL` in `Settings` and `.env.example`, with regression coverage for the runtime config expectations
- update local root `.env`, `.env.local`, `.env.demo`, and `.env.prod` in the workspace so future deploys can include the new setting without manual secret patching

## Test Plan
- [x] uv run pytest tests/unit/test_leader_election.py tests/unit/test_config.py
- [x] make test
- [x] make lint