### PR TITLE
feat(cli): improve agent-friendly workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 **Agent-Native sandbox.** Run code, build projects, deploy environments.
 
 > [!NOTE]
-> Treadstone is in early development. The vision and CLI examples below reflect
-> the direction we are building toward — not all features are implemented yet.
-> See [Status](#status) for what works today.
+> Treadstone is in early development. The CLI commands in this README reflect
+> what works today. Future ergonomic commands are called out explicitly when
+> they are still part of the product vision.
 
 ## Why Treadstone?
 
@@ -37,13 +37,17 @@ pip install git+https://github.com/earayu/treadstone.git
 ### CLI
 
 ```bash
-# Register and get an API key
+# Check that the server is reachable
+treadstone system health
+
+# Register and log in
 treadstone auth register --email you@example.com --password YourPass123!
 treadstone auth login --email you@example.com --password YourPass123!
-treadstone api-keys create --name my-key
 
-# Set your API key
-export TREADSTONE_API_KEY="sk-..."
+# Create and save an API key for non-interactive use
+treadstone api-keys create --name my-key --save
+
+# Optional: override the server URL explicitly
 export TREADSTONE_BASE_URL="http://localhost:8000"
 
 # List available templates
@@ -56,6 +60,9 @@ treadstone sandboxes create --template aio-sandbox-tiny --name my-sandbox
 treadstone sandboxes list
 treadstone sandboxes get <sandbox_id>
 
+# Generate a browser hand-off URL for a human
+treadstone sandboxes web enable <sandbox_id>
+
 # Create a persistent sandbox with storage
 treadstone sandboxes create --template aio-sandbox-large --persist --storage-size 20Gi
 
@@ -63,6 +70,10 @@ treadstone sandboxes create --template aio-sandbox-large --persist --storage-siz
 treadstone sandboxes stop <sandbox_id>
 treadstone sandboxes start <sandbox_id>
 treadstone sandboxes delete <sandbox_id>
+
+# Print the built-in AI usage guide
+treadstone guide agent
+treadstone --skills
 
 # All commands support JSON output for automation
 treadstone --json sandboxes list
@@ -83,9 +94,14 @@ client = Client(base_url="http://localhost:8000")
 
 Treadstone currently uses two credential types:
 
-- **Session Cookie** authenticates browser-oriented control plane flows.
+- **Session Cookie** authenticates browser-oriented control plane flows. In the
+  CLI, `treadstone auth login` saves the session locally for the active base
+  URL.
 - **API Key** authenticates programmatic access across both the **control plane**
   and **data plane**.
+
+For protected CLI commands, API keys take precedence. If no API key is set, the
+CLI falls back to the saved login session for the active base URL.
 
 API keys default to full user access, but can now be narrowed with coarse
 scopes:
@@ -111,11 +127,20 @@ maintain, no marketplace to curate.
 | `aio-sandbox-large` | 2 cores | 4 Gi | Full-featured + browser automation |
 | `aio-sandbox-xlarge` | 4 cores | 8 Gi | Heavy workloads |
 
-```bash
-# Quick code execution (ephemeral, WarmPool-accelerated)
-treadstone run --template aio-sandbox-tiny "import math; print(math.pi)"
+Current CLI examples:
 
-# Full development environment with persistent storage
+```bash
+# Lightweight sandbox
+treadstone sandboxes create --template aio-sandbox-tiny --name quick-demo
+
+# Persistent development environment
+treadstone sandboxes create --template aio-sandbox-large --name dev-box --persist --storage-size 20Gi
+```
+
+Future ergonomic goal (not implemented yet):
+
+```bash
+treadstone run --template aio-sandbox-tiny "import math; print(math.pi)"
 treadstone create --template aio-sandbox-large --persist --storage 20Gi
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -24,28 +24,31 @@ sudo mv treadstone /usr/local/bin/
 
 ```bash
 # Check that the server is reachable
-treadstone health
+treadstone system health
 
 # Register an account (first time only)
 treadstone auth register
 
-# Log in
+# Log in and save a local session for the active base URL
 treadstone auth login
 
-# Create an API key for non-interactive use
-treadstone api-keys create --name my-key
-# Save the key — it is shown only once
-
-# Store the key in config so you don't have to pass it every time
-treadstone config set api_key ts_live_xxxxxxxxxxxx
+# Create an API key for non-interactive use and save it locally
+treadstone api-keys create --name my-key --save
 
 # Create a sandbox
-treadstone sandboxes create --template default --name my-sandbox
+treadstone sandboxes create --template aio-sandbox-tiny --name my-sandbox
 # Name rules: 1-55 chars, lowercase letters/numbers/hyphens only,
 # and must start/end with a letter or number.
 
 # List sandboxes
-treadstone sb list
+treadstone sandboxes list
+
+# Create a browser hand-off URL for a human
+treadstone sandboxes web enable <sandbox-id>
+
+# Print the AI-oriented usage guide
+treadstone guide agent
+treadstone --skills
 ```
 
 ## Configuration
@@ -57,6 +60,9 @@ The CLI reads configuration from three sources, in order of priority:
 | 1 (highest) | CLI flags | `--base-url https://... --api-key ts_...` |
 | 2 | Environment variables | `TREADSTONE_BASE_URL`, `TREADSTONE_API_KEY` |
 | 3 (lowest) | Config file | `~/.config/treadstone/config.toml` |
+
+Saved login sessions are stored separately in `~/.config/treadstone/session.json`
+and are only used when no API key is configured for the active base URL.
 
 ### Config file
 
@@ -102,17 +108,18 @@ treadstone config path
 | `--base-url URL` | Override the server URL |
 | `--api-key KEY` | Override the API key |
 | `--json` | Output responses as JSON (useful for scripting) |
+| `--skills` | Print the built-in AI usage guide |
 | `--version` | Show CLI version |
 | `--help` | Show help message |
 
 ## Commands
 
-### `health`
+### `system`
 
-Check if the server is reachable and healthy.
+Inspect server reachability and other platform-wide state.
 
 ```bash
-treadstone health
+treadstone system health
 # Server is healthy
 ```
 
@@ -122,12 +129,12 @@ Authentication and user management.
 
 ```bash
 treadstone auth register                 # Create a new account
-treadstone auth login                    # Log in interactively
-treadstone auth logout                   # Log out
-treadstone auth whoami                   # Show current user info
+treadstone auth login                    # Log in and save a local session
+treadstone auth logout                   # Clear the saved session for this base URL
+treadstone auth whoami                   # Show the current user via API key or session
 treadstone auth change-password          # Change your password
 treadstone auth invite --email user@example.com   # Invite a user (admin)
-treadstone auth users                    # List all users (admin)
+treadstone auth users                    # Admins see all users; non-admins see themselves
 treadstone auth delete-user <user-id>    # Delete a user (admin)
 ```
 
@@ -139,14 +146,17 @@ Custom sandbox names must be 1-55 characters of lowercase letters, numbers, or h
 with a letter or number. This keeps browser URLs like `sandbox-{name}.treadstone-ai.dev` within DNS label limits.
 
 ```bash
-treadstone sb create --template default --name my-box
-treadstone sb create --template python --label env:dev --persist
-treadstone sb list
-treadstone sb list --label env:prod --limit 10
-treadstone sb get <sandbox-id>
-treadstone sb start <sandbox-id>
-treadstone sb stop <sandbox-id>
-treadstone sb delete <sandbox-id>
+treadstone sandboxes create --template aio-sandbox-tiny --name my-box
+treadstone sandboxes create --template aio-sandbox-medium --label env:dev --persist
+treadstone sandboxes list
+treadstone sandboxes list --label env:prod --label team:agent --limit 10
+treadstone sandboxes get <sandbox-id>
+treadstone sandboxes start <sandbox-id>
+treadstone sandboxes stop <sandbox-id>
+treadstone sandboxes delete <sandbox-id>
+treadstone sandboxes web enable <sandbox-id>
+treadstone sandboxes web status <sandbox-id>
+treadstone sandboxes web disable <sandbox-id>
 ```
 
 ### `templates`
@@ -163,6 +173,7 @@ Manage long-lived API keys.
 
 ```bash
 treadstone api-keys create --name ci-bot
+treadstone api-keys create --name ci-bot --save
 treadstone api-keys create --name temp --expires-in 86400  # 24h
 treadstone api-keys create --no-control-plane --data-plane selected --sandbox-id sb123
 treadstone api-keys list
@@ -188,8 +199,9 @@ treadstone config path
 Pass `--json` before any command to get machine-readable JSON output:
 
 ```bash
-treadstone --json sb list
-treadstone --json health
+treadstone --json sandboxes list
+treadstone --json system health
+treadstone --json sandboxes web enable <sandbox-id>
 treadstone --json api-keys list
 ```
 
@@ -212,6 +224,6 @@ Common errors:
 |-------|-------|-----|
 | Connection refused | Server not running or wrong URL | Check `treadstone config get base_url` |
 | Request timed out | Server slow or unreachable | Retry, or check network |
-| No API key configured | Missing authentication | `treadstone config set api_key <key>` |
+| No authentication configured | Missing API key and no saved session | `treadstone auth login` or `treadstone config set api_key <key>` |
 | HTTP 401 | Invalid or expired API key | Create a new key with `treadstone api-keys create` |
-| HTTP 404 | Resource not found | Verify the ID is correct |
+| HTTP 404 | Resource not found | Verify the resource ID is correct; sandbox names are not accepted where `SANDBOX_ID` is required |

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.1.0"
+version = "0.3.7"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/cli/treadstone_cli/_client.py
+++ b/cli/treadstone_cli/_client.py
@@ -1,10 +1,13 @@
-"""HTTP client factory for CLI commands.
+"""HTTP client factory and local state helpers for the CLI.
 
-Priority: CLI flags > environment variables > config file.
+Priority for API keys: CLI flags > environment variables > config file.
+Saved sessions are stored separately and are only used when no API key is
+available for the active base URL.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -14,8 +17,13 @@ import httpx
 
 CONFIG_DIR = Path.home() / ".config" / "treadstone"
 CONFIG_FILE = CONFIG_DIR / "config.toml"
+SESSION_FILE = CONFIG_DIR / "session.json"
 
 _DEFAULT_BASE_URL = "https://api.treadstone-ai.dev"
+
+
+def _normalize_base_url(url: str) -> str:
+    return url.rstrip("/")
 
 
 def _read_config() -> dict[str, str]:
@@ -30,9 +38,92 @@ def _read_config() -> dict[str, str]:
     return data.get("default", {})
 
 
+def _write_config(data: dict[str, dict[str, str]]) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    for section, kvs in data.items():
+        lines.append(f"[{section}]")
+        for key, value in kvs.items():
+            lines.append(f'{key} = "{value}"')
+        lines.append("")
+    CONFIG_FILE.write_text("\n".join(lines))
+
+
+def set_config_value(key: str, value: str) -> None:
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    raw: dict[str, dict[str, str]] = {}
+    if CONFIG_FILE.exists():
+        with open(CONFIG_FILE, "rb") as f:
+            raw = tomllib.load(f)  # type: ignore[assignment]
+
+    section = raw.setdefault("default", {})
+    section[key] = value
+    _write_config(raw)
+
+
+def unset_config_value(key: str) -> bool:
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    if not CONFIG_FILE.exists():
+        return False
+
+    with open(CONFIG_FILE, "rb") as f:
+        raw: dict[str, dict[str, str]] = tomllib.load(f)  # type: ignore[assignment]
+
+    section = raw.get("default", {})
+    if key not in section:
+        return False
+
+    del section[key]
+    _write_config(raw)
+    return True
+
+
+def _read_session_store() -> dict[str, str]:
+    if not SESSION_FILE.exists():
+        return {}
+    return json.loads(SESSION_FILE.read_text())
+
+
+def _write_session_store(data: dict[str, str]) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    SESSION_FILE.write_text(json.dumps(data, indent=2, sort_keys=True))
+    try:
+        os.chmod(SESSION_FILE, 0o600)
+    except OSError:
+        pass
+
+
+def save_session(base_url: str, token: str) -> None:
+    sessions = _read_session_store()
+    sessions[_normalize_base_url(base_url)] = token
+    _write_session_store(sessions)
+
+
+def clear_session(base_url: str) -> bool:
+    sessions = _read_session_store()
+    normalized = _normalize_base_url(base_url)
+    if normalized not in sessions:
+        return False
+    del sessions[normalized]
+    _write_session_store(sessions)
+    return True
+
+
+def get_saved_session(base_url: str) -> str | None:
+    return _read_session_store().get(_normalize_base_url(base_url))
+
+
 def get_base_url(ctx: click.Context) -> str:
     url = ctx.obj.get("base_url") or _read_config().get("base_url") or _DEFAULT_BASE_URL
-    return url.rstrip("/")
+    return _normalize_base_url(url)
 
 
 def get_api_key(ctx: click.Context) -> str | None:
@@ -47,10 +138,10 @@ def effective_base_url() -> tuple[str, str]:
     """
     env = os.environ.get("TREADSTONE_BASE_URL")
     if env:
-        return env.rstrip("/"), "env"
+        return _normalize_base_url(env), "env"
     cfg = _read_config().get("base_url")
     if cfg:
-        return cfg.rstrip("/"), "file"
+        return _normalize_base_url(cfg), "file"
     return _DEFAULT_BASE_URL, "default"
 
 
@@ -59,19 +150,40 @@ def effective_api_key() -> str | None:
     return os.environ.get("TREADSTONE_API_KEY") or _read_config().get("api_key")
 
 
+def effective_session(base_url: str | None = None) -> bool:
+    active_base_url = _normalize_base_url(base_url or effective_base_url()[0])
+    return get_saved_session(active_base_url) is not None
+
+
+def get_session_token(ctx: click.Context) -> str | None:
+    return get_saved_session(get_base_url(ctx))
+
+
+def build_session_client(base_url: str, session_token: str) -> httpx.Client:
+    return httpx.Client(base_url=_normalize_base_url(base_url), cookies={"session": session_token}, timeout=30.0)
+
+
 def build_client(ctx: click.Context) -> httpx.Client:
     base_url = get_base_url(ctx)
     api_key = get_api_key(ctx)
     headers: dict[str, str] = {}
+    cookies: dict[str, str] = {}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
-    return httpx.Client(base_url=base_url, headers=headers, timeout=30.0)
+    else:
+        session_token = get_session_token(ctx)
+        if session_token:
+            cookies["session"] = session_token
+    return httpx.Client(base_url=base_url, headers=headers, cookies=cookies, timeout=30.0)
 
 
 def require_auth(ctx: click.Context) -> httpx.Client:
-    """Build client and abort if no API key is configured."""
+    """Build client and abort if no API key or saved session is available."""
     client = build_client(ctx)
-    if "Authorization" not in client.headers:
-        click.echo("Error: No API key configured. Set TREADSTONE_API_KEY or use --api-key.", err=True)
+    if "Authorization" not in client.headers and not get_session_token(ctx):
+        click.echo(
+            "Error: No authentication configured. Run 'treadstone auth login' or set TREADSTONE_API_KEY / --api-key.",
+            err=True,
+        )
         sys.exit(1)
     return client

--- a/cli/treadstone_cli/_guide_text.py
+++ b/cli/treadstone_cli/_guide_text.py
@@ -1,0 +1,65 @@
+"""Static guide text for agent-oriented CLI usage."""
+
+from __future__ import annotations
+
+AGENT_GUIDE = """Treadstone Agent Guide
+
+Purpose
+  Treadstone CLI manages control-plane access, sandboxes, templates, and API keys.
+  This guide only describes commands that exist today.
+
+Canonical command tree
+  treadstone system health
+  treadstone auth register
+  treadstone auth login
+  treadstone auth whoami
+  treadstone api-keys create|list|update|delete
+  treadstone sandboxes create|list|get|start|stop|delete
+  treadstone sandboxes web enable|status|disable
+  treadstone templates list
+  treadstone config set|get|unset|path
+  treadstone guide agent
+
+Authentication rules
+  1. Protected commands use an API key first if one is provided by flag, env var, or local config.
+  2. If no API key is available, protected commands fall back to the saved login session for the active base URL.
+  3. `treadstone auth login` saves a local session. `treadstone auth logout` clears that saved session.
+  4. `treadstone api-keys create --save` stores the new key in local config for later non-interactive use.
+
+Identifier rules
+  - SANDBOX_ID arguments always require the sandbox ID, not the sandbox name.
+  - Use `treadstone --json sandboxes list` or `treadstone --json sandboxes create ...` to read sandbox IDs.
+  - KEY_ID arguments always require the API key ID.
+
+Common workflows
+  1. First-time interactive onboarding
+     treadstone system health
+     treadstone auth register --email you@example.com --password YourPass123!
+     treadstone auth login --email you@example.com --password YourPass123!
+     treadstone auth whoami
+
+  2. Create and save a reusable API key
+     treadstone api-keys create --name automation --save
+
+  3. Create a sandbox and inspect it
+     treadstone templates list
+     treadstone sandboxes create --template aio-sandbox-tiny --name demo
+     treadstone sandboxes list
+     treadstone sandboxes get SANDBOX_ID
+
+  4. Generate a browser hand-off URL for a human
+     treadstone sandboxes web enable SANDBOX_ID
+     Read the `open_link` field from JSON output or the "open_link" row in human output.
+
+JSON usage
+  - Pass `--json` before the command, for example: `treadstone --json sandboxes list`
+  - Useful fields:
+    - sandboxes create/get: `id`, `urls.proxy`, `urls.web`
+    - sandboxes web enable: `open_link`, `web_url`, `expires_at`
+    - api-keys create: `key`, `id`, `saved_to_config`
+
+Failure recovery
+  - If a protected command says no authentication is configured, run `treadstone auth login` or provide an API key.
+  - If a sandbox command fails with not found, verify the value is a sandbox ID from `sandboxes list`, not the name.
+  - If you need a fresh browser hand-off URL, run `treadstone sandboxes web enable SANDBOX_ID` again.
+"""

--- a/cli/treadstone_cli/api_keys.py
+++ b/cli/treadstone_cli/api_keys.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 from click.core import ParameterSource
 
-from treadstone_cli._client import require_auth
+from treadstone_cli._client import CONFIG_FILE, require_auth, set_config_value
 from treadstone_cli._output import handle_error, is_json_mode, print_json, print_table
 
 
@@ -14,10 +14,13 @@ def api_keys() -> None:
     """Manage API keys.
 
     API keys provide long-lived authentication tokens for programmatic access.
+    Use them when you need a reusable non-interactive credential instead of a
+    saved login session.
 
     \b
     Examples:
       treadstone api-keys create --name ci-bot
+      treadstone api-keys create --name agent --save
       treadstone api-keys create --no-control-plane --data-plane selected --sandbox-id sb123
       treadstone api-keys list
       treadstone api-keys update <key-id> --data-plane none
@@ -55,6 +58,12 @@ def _build_scope(control_plane: bool | None, data_plane: str | None, sandbox_ids
     help="Configure data plane access.",
 )
 @click.option("--sandbox-id", "sandbox_ids", multiple=True, help="Allowlist sandbox ID when --data-plane selected.")
+@click.option(
+    "--save",
+    is_flag=True,
+    default=False,
+    help="Save the new key as the default api_key in local CLI config.",
+)
 @click.pass_context
 def create_key(
     ctx: click.Context,
@@ -63,10 +72,12 @@ def create_key(
     control_plane: bool | None,
     data_plane: str | None,
     sandbox_ids: tuple[str, ...],
+    save: bool,
 ) -> None:
     """Create a new API key.
 
-    The full key is shown only once — store it securely.
+    The full key is shown only once. Use --save to store it as the default
+    local api_key for future commands.
     """
     client = require_auth(ctx)
     body: dict = {"name": name}
@@ -78,12 +89,16 @@ def create_key(
     resp = client.post("/v1/auth/api-keys", json=body)
     handle_error(resp)
     data = resp.json()
+    if save:
+        set_config_value("api_key", data["key"])
     if is_json_mode(ctx):
-        print_json(data)
+        print_json({**data, "saved_to_config": save, "config_file": str(CONFIG_FILE) if save else None})
     else:
         click.echo(f"API Key created: {data['key']}")
         click.echo(f"  ID: {data['id']}  Name: {data['name']}")
         click.echo("  Store this key securely — it won't be shown again.")
+        if save:
+            click.echo(f"  Saved as the default api_key in {CONFIG_FILE}.")
 
 
 @api_keys.command("list")

--- a/cli/treadstone_cli/auth.py
+++ b/cli/treadstone_cli/auth.py
@@ -3,8 +3,17 @@
 from __future__ import annotations
 
 import click
+import httpx
 
-from treadstone_cli._client import build_client, require_auth
+from treadstone_cli._client import (
+    build_client,
+    build_session_client,
+    clear_session,
+    get_base_url,
+    get_session_token,
+    require_auth,
+    save_session,
+)
 from treadstone_cli._output import handle_error, is_json_mode, print_detail, print_json, print_table
 
 
@@ -12,13 +21,15 @@ from treadstone_cli._output import handle_error, is_json_mode, print_detail, pri
 def auth() -> None:
     """Authentication and user management.
 
-    Register, log in, manage users, and change passwords.
+    Register, log in, manage users, and change passwords. Successful logins
+    save a local control-plane session for the active base URL.
 
     \b
     Quick start:
-      treadstone auth register          Create a new account
-      treadstone auth login             Log in (saves session)
-      treadstone auth whoami            Verify current identity
+      treadstone auth register                        Create a new account
+      treadstone auth login                           Save a local session
+      treadstone auth whoami                          Verify current identity
+      treadstone api-keys create --name agent --save Create a reusable API key
     """
 
 
@@ -29,29 +40,49 @@ def auth() -> None:
 def login(ctx: click.Context, email: str, password: str) -> None:
     """Log in with email and password.
 
-    If --email or --password are not provided, you will be prompted interactively.
+    If --email or --password are not provided, you will be prompted
+    interactively. On success, the CLI stores the returned session cookie and
+    reuses it for future control-plane commands until you run logout.
     """
     client = build_client(ctx)
     resp = client.post("/v1/auth/login", json={"email": email, "password": password})
     handle_error(resp)
     data = resp.json()
+    session_token = resp.cookies.get("session")
+    if not session_token:
+        raise click.ClickException("Login succeeded but no session cookie was returned.")
+    base_url = get_base_url(ctx)
+    save_session(base_url, session_token)
     if is_json_mode(ctx):
-        print_json(data)
+        print_json({**data, "base_url": base_url, "session_saved": True})
     else:
-        click.echo("Login successful.")
+        click.echo(f"Login successful. Saved session for {base_url}.")
 
 
 @auth.command("logout")
 @click.pass_context
 def logout(ctx: click.Context) -> None:
-    """Log out (clear session cookie)."""
-    client = build_client(ctx)
-    resp = client.post("/v1/auth/logout")
-    handle_error(resp)
-    if is_json_mode(ctx):
-        print_json(resp.json())
+    """Log out and clear the saved local session for the active base URL."""
+    base_url = get_base_url(ctx)
+    session_token = get_session_token(ctx)
+    if session_token:
+        client = build_session_client(base_url, session_token)
+        try:
+            resp = client.post("/v1/auth/logout")
+            handle_error(resp)
+            data = resp.json()
+        except httpx.HTTPError:
+            data = {"detail": "Logout successful"}
     else:
-        click.echo("Logged out.")
+        data = {"detail": "Logout successful"}
+    session_cleared = clear_session(base_url)
+    if is_json_mode(ctx):
+        print_json({**data, "base_url": base_url, "session_cleared": session_cleared})
+    else:
+        if session_cleared:
+            click.echo(f"Logged out. Cleared saved session for {base_url}.")
+        else:
+            click.echo(f"No saved session for {base_url}.")
 
 
 @auth.command("register")
@@ -80,7 +111,7 @@ def register(ctx: click.Context, email: str, password: str, invitation_token: st
 @auth.command("whoami")
 @click.pass_context
 def whoami(ctx: click.Context) -> None:
-    """Show current user info."""
+    """Show the current user resolved from the active API key or saved session."""
     client = require_auth(ctx)
     resp = client.get("/v1/auth/user")
     handle_error(resp)
@@ -98,7 +129,7 @@ def whoami(ctx: click.Context) -> None:
 )
 @click.pass_context
 def change_password(ctx: click.Context, old_password: str, new_password: str) -> None:
-    """Change your password."""
+    """Change your password for the current account."""
     client = require_auth(ctx)
     resp = client.post("/v1/auth/change-password", json={"old_password": old_password, "new_password": new_password})
     handle_error(resp)
@@ -129,7 +160,10 @@ def invite(ctx: click.Context, email: str, role: str) -> None:
 @click.option("--offset", default=0, type=int, help="Skip N results.")
 @click.pass_context
 def list_users(ctx: click.Context, limit: int, offset: int) -> None:
-    """List all registered users (admin only)."""
+    """List users visible to the current account.
+
+    Admin accounts can see all users. Non-admin accounts only see themselves.
+    """
     client = require_auth(ctx)
     resp = client.get("/v1/auth/users", params={"limit": limit, "offset": offset})
     handle_error(resp)
@@ -146,7 +180,7 @@ def list_users(ctx: click.Context, limit: int, offset: int) -> None:
 @click.argument("user_id")
 @click.pass_context
 def delete_user(ctx: click.Context, user_id: str) -> None:
-    """Delete a user (admin only)."""
+    """Delete a user by user ID (admin only)."""
     client = require_auth(ctx)
     resp = client.delete(f"/v1/auth/users/{user_id}")
     handle_error(resp)

--- a/cli/treadstone_cli/config_cmd.py
+++ b/cli/treadstone_cli/config_cmd.py
@@ -9,19 +9,7 @@ from __future__ import annotations
 
 import click
 
-from treadstone_cli._client import CONFIG_DIR, CONFIG_FILE, _read_config
-
-
-def _write_config(data: dict[str, dict[str, str]]) -> None:
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    lines: list[str] = []
-    for section, kvs in data.items():
-        lines.append(f"[{section}]")
-        for k, v in kvs.items():
-            lines.append(f'{k} = "{v}"')
-        lines.append("")
-    CONFIG_FILE.write_text("\n".join(lines))
-
+import treadstone_cli._client as client_state
 
 _VALID_KEYS = ("base_url", "api_key")
 
@@ -32,7 +20,8 @@ def config() -> None:
 
     Configuration is stored in ~/.config/treadstone/config.toml and provides
     default values for --base-url and --api-key so they don't need to be
-    repeated on every command invocation.
+    repeated on every command invocation. Saved login sessions live in a
+    separate local state file and are not managed by this command group.
 
     \b
     Priority (highest to lowest):
@@ -58,19 +47,7 @@ def set_value(key: str, value: str) -> None:
       treadstone config set base_url https://my-server.example.com
       treadstone config set api_key ts_live_xxxxxxxxxxxx
     """
-    try:
-        import tomllib
-    except ModuleNotFoundError:
-        import tomli as tomllib  # type: ignore[no-redef]
-
-    raw: dict[str, dict[str, str]] = {}
-    if CONFIG_FILE.exists():
-        with open(CONFIG_FILE, "rb") as f:
-            raw = tomllib.load(f)  # type: ignore[assignment]
-
-    section = raw.setdefault("default", {})
-    section[key] = value
-    _write_config(raw)
+    client_state.set_config_value(key, value)
     click.echo(f"Set {key} = {value}")
 
 
@@ -84,7 +61,7 @@ def get_value(key: str | None) -> None:
       treadstone config get              Show all config values
       treadstone config get base_url     Show only base_url
     """
-    data = _read_config()
+    data = client_state._read_config()
     if not data:
         click.echo("No configuration set. Run 'treadstone config set <key> <value>' to get started.")
         return
@@ -115,26 +92,10 @@ def unset_value(key: str) -> None:
     Example:
       treadstone config unset api_key
     """
-    try:
-        import tomllib
-    except ModuleNotFoundError:
-        import tomli as tomllib  # type: ignore[no-redef]
-
-    if not CONFIG_FILE.exists():
+    if client_state.unset_config_value(key):
+        click.echo(f"Unset {key}.")
+    else:
         click.echo(f"{key} is not set.")
-        return
-
-    with open(CONFIG_FILE, "rb") as f:
-        raw: dict[str, dict[str, str]] = tomllib.load(f)  # type: ignore[assignment]
-
-    section = raw.get("default", {})
-    if key not in section:
-        click.echo(f"{key} is not set.")
-        return
-
-    del section[key]
-    _write_config(raw)
-    click.echo(f"Unset {key}.")
 
 
 @config.command("path")
@@ -145,8 +106,8 @@ def show_path() -> None:
     Example:
       treadstone config path
     """
-    exists = CONFIG_FILE.exists()
-    click.echo(str(CONFIG_FILE))
+    exists = client_state.CONFIG_FILE.exists()
+    click.echo(str(client_state.CONFIG_FILE))
     if not exists:
         click.echo("  (file does not exist yet)")
 

--- a/cli/treadstone_cli/guide.py
+++ b/cli/treadstone_cli/guide.py
@@ -1,0 +1,24 @@
+"""Guide commands for humans and agents."""
+
+from __future__ import annotations
+
+import click
+
+from treadstone_cli._guide_text import AGENT_GUIDE
+
+
+@click.group()
+def guide() -> None:
+    """Usage guides for humans and agents.
+
+    \b
+    Examples:
+      treadstone guide agent
+      treadstone --skills
+    """
+
+
+@guide.command("agent")
+def agent_guide() -> None:
+    """Print the agent-oriented usage guide."""
+    click.echo(AGENT_GUIDE.rstrip())

--- a/cli/treadstone_cli/main.py
+++ b/cli/treadstone_cli/main.py
@@ -1,47 +1,98 @@
-"""Treadstone CLI — agent-native sandbox management."""
+"""Treadstone CLI entrypoint."""
 
 from __future__ import annotations
 
 import click
 
-from treadstone_cli._client import build_client, effective_api_key, effective_base_url, get_base_url
-from treadstone_cli._output import friendly_exception_handler, handle_error, is_json_mode, print_json
+from treadstone_cli._client import effective_api_key, effective_base_url, effective_session
+from treadstone_cli._guide_text import AGENT_GUIDE
+from treadstone_cli._output import friendly_exception_handler
 
-_STATIC_EPILOG = """\b
-Configuration (highest to lowest priority):
-  CLI flags       --api-key, --base-url
-  Env vars        TREADSTONE_API_KEY, TREADSTONE_BASE_URL
-  Config file     ~/.config/treadstone/config.toml
 
-  Run 'treadstone config --help' to manage the config file.
+def _print_skills(ctx: click.Context, param: click.Parameter, value: bool) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(AGENT_GUIDE.rstrip())
+    ctx.exit()
 
-Examples:
-  treadstone health                         Check server status
-  treadstone sandboxes list                 List running sandboxes
-  treadstone sb create --template default   Create a sandbox
-  treadstone auth login                     Log in with email/password
-"""
+
+def _active_base_url(ctx: click.Context) -> tuple[str, str]:
+    base_url = ctx.params.get("base_url")
+    if base_url:
+        return base_url.rstrip("/"), "flag"
+    return effective_base_url()
+
+
+def _active_api_key_status(ctx: click.Context) -> str:
+    if ctx.params.get("api_key"):
+        return "configured [flag]"
+    if effective_api_key():
+        return "configured"
+    return "not set"
+
+
+def _active_auth_mode(api_key_present: bool, session_present: bool) -> str:
+    if api_key_present and session_present:
+        return "API key (takes precedence over saved session)"
+    if api_key_present:
+        return "API key"
+    if session_present:
+        return "saved session"
+    return "none"
 
 
 class _TreadstoneGroup(click.Group):
-    """Custom group that appends a live config summary to the help output."""
+    """Custom root group with richer help sections."""
 
     def format_epilog(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        super().format_epilog(ctx, formatter)
-        url, source = effective_base_url()
-        api_key = effective_api_key()
-        api_key_status = "configured" if api_key else "not set"
+        base_url, source = _active_base_url(ctx)
+        api_key_present = _active_api_key_status(ctx) != "not set"
+        session_present = effective_session(base_url)
+
+        with formatter.section("Authentication"):
+            formatter.write_text(
+                "Protected commands use an API key first. If no API key is configured, they fall back to the saved "
+                "login session for the active base URL."
+            )
+            formatter.write_text(
+                "Use 'treadstone auth login' for interactive control-plane access, "
+                "'treadstone api-keys create --save' for reusable automation, and "
+                "'treadstone config --help' to manage local defaults."
+            )
+
+        with formatter.section("Common workflows"):
+            formatter.write_dl(
+                [
+                    ("Check connectivity", "treadstone system health"),
+                    ("Sign in interactively", "treadstone auth login"),
+                    ("List templates", "treadstone templates list"),
+                    ("Create a sandbox", "treadstone sandboxes create --template aio-sandbox-tiny"),
+                    ("Get a browser hand-off URL", "treadstone sandboxes web enable SANDBOX_ID"),
+                    ("Read the AI guide", "treadstone guide agent  or  treadstone --skills"),
+                ]
+            )
+
         with formatter.section("Active configuration"):
             formatter.write_dl(
                 [
-                    ("Base URL", f"{url}  [{source}]"),
-                    ("API key", api_key_status),
+                    ("Base URL", f"{base_url}  [{source}]"),
+                    ("API key", _active_api_key_status(ctx)),
+                    ("Saved session", "available" if session_present else "not set"),
+                    ("Auth used by protected commands", _active_auth_mode(api_key_present, session_present)),
                 ]
             )
 
 
-@click.group(cls=_TreadstoneGroup, epilog=_STATIC_EPILOG)
-@click.option("--json", "json_output", is_flag=True, default=False, help="Output in JSON format.")
+@click.group(cls=_TreadstoneGroup)
+@click.option("--json", "json_output", is_flag=True, default=False, help="Output command results in JSON format.")
+@click.option(
+    "--skills",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=_print_skills,
+    help="Print the agent-oriented usage guide.",
+)
 @click.option(
     "--api-key",
     envvar="TREADSTONE_API_KEY",
@@ -57,10 +108,16 @@ class _TreadstoneGroup(click.Group):
 @click.version_option(package_name="treadstone-cli")
 @click.pass_context
 def cli(ctx: click.Context, json_output: bool, api_key: str | None, base_url: str | None) -> None:
-    """Treadstone CLI — manage sandboxes, templates, and API keys.
+    """Treadstone CLI - manage system access, sandboxes, templates, and API keys.
 
-    An agent-native sandbox service. Run code, build projects, and deploy
-    environments via the command line.
+    \b
+    Canonical command paths:
+      treadstone system health
+      treadstone auth ...
+      treadstone api-keys ...
+      treadstone sandboxes ...
+      treadstone templates list
+      treadstone config ...
     """
     ctx.ensure_object(dict)
     ctx.obj["json_output"] = json_output
@@ -70,35 +127,21 @@ def cli(ctx: click.Context, json_output: bool, api_key: str | None, base_url: st
         ctx.obj["base_url"] = base_url
 
 
-@cli.command()
-@click.pass_context
-def health(ctx: click.Context) -> None:
-    """Check if the Treadstone server is reachable and healthy."""
-    client = build_client(ctx)
-    base_url = get_base_url(ctx)
-    if not is_json_mode(ctx):
-        click.echo(f"Connecting to {base_url} ...")
-    resp = client.get("/health")
-    handle_error(resp)
-    data = resp.json()
-    if is_json_mode(ctx):
-        print_json(data)
-    else:
-        status = data.get("status", "unknown")
-        click.echo(f"Server is {status}")
-
-
 from treadstone_cli.api_keys import api_keys  # noqa: E402
 from treadstone_cli.auth import auth  # noqa: E402
 from treadstone_cli.config_cmd import config  # noqa: E402
+from treadstone_cli.guide import guide  # noqa: E402
 from treadstone_cli.sandboxes import sandboxes  # noqa: E402
+from treadstone_cli.system import system  # noqa: E402
 from treadstone_cli.templates import templates  # noqa: E402
 
+cli.add_command(system)
 cli.add_command(auth)
 cli.add_command(api_keys, "api-keys")
 cli.add_command(sandboxes)
 cli.add_command(sandboxes, "sb")
 cli.add_command(templates)
 cli.add_command(config)
+cli.add_command(guide)
 
 friendly_exception_handler(cli)

--- a/cli/treadstone_cli/sandboxes.py
+++ b/cli/treadstone_cli/sandboxes.py
@@ -12,14 +12,14 @@ from treadstone_cli._output import handle_error, is_json_mode, print_detail, pri
 def sandboxes() -> None:
     """Manage sandboxes.
 
-    Create, list, start, stop, and delete sandboxes. Use 'sb' as a shorthand.
+    Create, inspect, and control sandboxes. Use 'sb' as a shorthand.
 
     \b
     Examples:
-      treadstone sandboxes create --template default --name my-box
-      treadstone sb list
-      treadstone sb get <sandbox-id>
-      treadstone sb delete <sandbox-id>
+      treadstone sandboxes create --template aio-sandbox-tiny --name my-box
+      treadstone sandboxes list --label env:dev
+      treadstone sandboxes get sb-abc123def456
+      treadstone sandboxes web enable sb-abc123def456
     """
 
 
@@ -35,6 +35,13 @@ def sandboxes() -> None:
     ),
 )
 @click.option("--label", multiple=True, help="Labels in key:val format (repeatable).")
+@click.option("--auto-stop-interval", default=15, type=int, help="Minutes of inactivity before the sandbox auto-stops.")
+@click.option(
+    "--auto-delete-interval",
+    default=-1,
+    type=int,
+    help="Minutes after stop before auto-delete. Use -1 to disable auto-delete.",
+)
 @click.option("--persist", is_flag=True, default=False, help="Enable persistent storage.")
 @click.option("--storage-size", default="10Gi", help="PVC size when --persist is set.")
 @click.pass_context
@@ -43,6 +50,8 @@ def create(
     template: str,
     name: str | None,
     label: tuple[str, ...],
+    auto_stop_interval: int,
+    auto_delete_interval: int,
     persist: bool,
     storage_size: str,
 ) -> None:
@@ -54,9 +63,10 @@ def create(
 
     \b
     Examples:
-      treadstone sb create --template default
-      treadstone sb create --template python --name dev-box --label env:dev
-      treadstone sb create --template node --persist --storage-size 20Gi
+      treadstone sandboxes create --template aio-sandbox-tiny
+      treadstone sandboxes create --template aio-sandbox-medium --name dev-box --label env:dev
+      treadstone sandboxes create --template aio-sandbox-large --persist --storage-size 20Gi
+      treadstone sandboxes create --template aio-sandbox-small --auto-stop-interval 30 --auto-delete-interval 120
     """
     client = require_auth(ctx)
     labels = {}
@@ -66,7 +76,13 @@ def create(
             raise SystemExit(1)
         k, v = lbl.split(":", 1)
         labels[k] = v
-    body: dict = {"template": template, "labels": labels, "persist": persist}
+    body: dict = {
+        "template": template,
+        "labels": labels,
+        "auto_stop_interval": auto_stop_interval,
+        "auto_delete_interval": auto_delete_interval,
+        "persist": persist,
+    }
     if persist:
         body["storage_size"] = storage_size
     if name:
@@ -81,22 +97,23 @@ def create(
 
 
 @sandboxes.command("list")
-@click.option("--label", default=None, help="Filter by label (key:val).")
+@click.option("--label", "labels", multiple=True, help="Filter by label (key:val). Repeat to require multiple labels.")
 @click.option("--limit", default=100, type=int, help="Max results.")
 @click.option("--offset", default=0, type=int, help="Skip N results.")
 @click.pass_context
-def list_sandboxes(ctx: click.Context, label: str | None, limit: int, offset: int) -> None:
+def list_sandboxes(ctx: click.Context, labels: tuple[str, ...], limit: int, offset: int) -> None:
     """List sandboxes with optional filtering.
 
     \b
     Examples:
-      treadstone sb list
-      treadstone sb list --label env:prod --limit 10
+      treadstone sandboxes list
+      treadstone sandboxes list --label env:prod --limit 10
+      treadstone sandboxes list --label env:dev --label team:agent
     """
     client = require_auth(ctx)
     params: dict = {"limit": limit, "offset": offset}
-    if label:
-        params["label"] = label
+    if labels:
+        params["label"] = list(labels)
     resp = client.get("/v1/sandboxes", params=params)
     handle_error(resp)
     data = resp.json()
@@ -109,10 +126,14 @@ def list_sandboxes(ctx: click.Context, label: str | None, limit: int, offset: in
 
 
 @sandboxes.command("get")
-@click.argument("sandbox_id")
+@click.argument("sandbox_id", metavar="SANDBOX_ID")
 @click.pass_context
 def get_sandbox(ctx: click.Context, sandbox_id: str) -> None:
-    """Show detailed information about a sandbox."""
+    """Show detailed information about a sandbox.
+
+    SANDBOX_ID must be the sandbox ID, not the sandbox name. Obtain it from
+    `treadstone sandboxes list` or the `id` field in create/get JSON output.
+    """
     client = require_auth(ctx)
     resp = client.get(f"/v1/sandboxes/{sandbox_id}")
     handle_error(resp)
@@ -124,10 +145,10 @@ def get_sandbox(ctx: click.Context, sandbox_id: str) -> None:
 
 
 @sandboxes.command("delete")
-@click.argument("sandbox_id")
+@click.argument("sandbox_id", metavar="SANDBOX_ID")
 @click.pass_context
 def delete_sandbox(ctx: click.Context, sandbox_id: str) -> None:
-    """Delete a sandbox."""
+    """Delete a sandbox by sandbox ID."""
     client = require_auth(ctx)
     resp = client.delete(f"/v1/sandboxes/{sandbox_id}")
     handle_error(resp)
@@ -135,10 +156,10 @@ def delete_sandbox(ctx: click.Context, sandbox_id: str) -> None:
 
 
 @sandboxes.command("start")
-@click.argument("sandbox_id")
+@click.argument("sandbox_id", metavar="SANDBOX_ID")
 @click.pass_context
 def start_sandbox(ctx: click.Context, sandbox_id: str) -> None:
-    """Start a stopped sandbox."""
+    """Start a stopped sandbox by sandbox ID."""
     client = require_auth(ctx)
     resp = client.post(f"/v1/sandboxes/{sandbox_id}/start")
     handle_error(resp)
@@ -150,10 +171,10 @@ def start_sandbox(ctx: click.Context, sandbox_id: str) -> None:
 
 
 @sandboxes.command("stop")
-@click.argument("sandbox_id")
+@click.argument("sandbox_id", metavar="SANDBOX_ID")
 @click.pass_context
 def stop_sandbox(ctx: click.Context, sandbox_id: str) -> None:
-    """Stop a running sandbox."""
+    """Stop a running sandbox by sandbox ID."""
     client = require_auth(ctx)
     resp = client.post(f"/v1/sandboxes/{sandbox_id}/stop")
     handle_error(resp)
@@ -162,3 +183,62 @@ def stop_sandbox(ctx: click.Context, sandbox_id: str) -> None:
         print_json(data)
     else:
         click.echo(f"Sandbox {sandbox_id} stopping.")
+
+
+@sandboxes.group("web")
+def web() -> None:
+    """Manage browser hand-off URLs for a sandbox.
+
+    Use SANDBOX_ID from `treadstone sandboxes list` or the `id` field in
+    create/get JSON output. Sandbox names are not accepted here.
+
+    \b
+    Examples:
+      treadstone sandboxes web enable sb-abc123def456
+      treadstone sandboxes web status sb-abc123def456
+      treadstone sandboxes web disable sb-abc123def456
+    """
+
+
+@web.command("enable")
+@click.argument("sandbox_id", metavar="SANDBOX_ID")
+@click.pass_context
+def enable_web(ctx: click.Context, sandbox_id: str) -> None:
+    """Enable a browser hand-off URL for a sandbox."""
+    client = require_auth(ctx)
+    resp = client.post(f"/v1/sandboxes/{sandbox_id}/web-link")
+    handle_error(resp)
+    data = resp.json()
+    if is_json_mode(ctx):
+        print_json(data)
+    else:
+        print_detail(data, title=f"Sandbox Web Access Enabled: {sandbox_id}")
+
+
+@web.command("status")
+@click.argument("sandbox_id", metavar="SANDBOX_ID")
+@click.pass_context
+def web_status(ctx: click.Context, sandbox_id: str) -> None:
+    """Show browser hand-off URL status for a sandbox."""
+    client = require_auth(ctx)
+    resp = client.get(f"/v1/sandboxes/{sandbox_id}/web-link")
+    handle_error(resp)
+    data = resp.json()
+    if is_json_mode(ctx):
+        print_json(data)
+    else:
+        print_detail(data, title=f"Sandbox Web Access: {sandbox_id}")
+
+
+@web.command("disable")
+@click.argument("sandbox_id", metavar="SANDBOX_ID")
+@click.pass_context
+def disable_web(ctx: click.Context, sandbox_id: str) -> None:
+    """Disable the browser hand-off URL for a sandbox."""
+    client = require_auth(ctx)
+    resp = client.delete(f"/v1/sandboxes/{sandbox_id}/web-link")
+    handle_error(resp)
+    if is_json_mode(ctx):
+        print_json({"detail": "Sandbox web access disabled.", "sandbox_id": sandbox_id})
+    else:
+        click.echo(f"Sandbox {sandbox_id} web access disabled.")

--- a/cli/treadstone_cli/system.py
+++ b/cli/treadstone_cli/system.py
@@ -1,0 +1,36 @@
+"""System-level commands."""
+
+from __future__ import annotations
+
+import click
+
+from treadstone_cli._client import build_client, get_base_url
+from treadstone_cli._output import handle_error, is_json_mode, print_json
+
+
+@click.group()
+def system() -> None:
+    """Inspect server reachability and other platform-wide state.
+
+    \b
+    Examples:
+      treadstone system health
+    """
+
+
+@system.command("health")
+@click.pass_context
+def health(ctx: click.Context) -> None:
+    """Check if the Treadstone server is reachable and healthy."""
+    client = build_client(ctx)
+    base_url = get_base_url(ctx)
+    if not is_json_mode(ctx):
+        click.echo(f"Connecting to {base_url} ...")
+    resp = client.get("/health")
+    handle_error(resp)
+    data = resp.json()
+    if is_json_mode(ctx):
+        print_json(data)
+    else:
+        status = data.get("status", "unknown")
+        click.echo(f"Server is {status}")

--- a/cli/treadstone_cli/templates.py
+++ b/cli/treadstone_cli/templates.py
@@ -13,6 +13,7 @@ def templates() -> None:
     """Manage sandbox templates.
 
     Templates define the runtime environment (image, CPU, memory) for sandboxes.
+    List templates before creating a sandbox when you need a valid template name.
 
     \b
     Examples:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.1.0"
+version = "0.3.7"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -26,6 +26,7 @@ dependencies = [
 dev = [
     "aiosqlite>=0.22.1",
     "auth0-python>=4.2.0,<5.0.0",
+    "click>=8.1",
     "fastapi-users[oauth,sqlalchemy]>=14.0.1",
     "httpx>=0.28.1",
     "httpx-oauth>=0.16.1",
@@ -35,6 +36,7 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
     "pytest-freezer>=0.4.9",
+    "rich>=14.0",
     "ruff>=0.15.6",
 ]
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.1.0"
+version = "0.3.7"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,0 +1,319 @@
+"""CLI behavior tests for the standalone treadstone-cli package."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+CLI_ROOT = Path(__file__).resolve().parents[2] / "cli"
+if str(CLI_ROOT) not in sys.path:
+    sys.path.insert(0, str(CLI_ROOT))
+
+_client = importlib.import_module("treadstone_cli._client")
+cli = importlib.import_module("treadstone_cli.main").cli
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        data: dict[str, Any] | None = None,
+        *,
+        status_code: int = 200,
+        cookies: dict[str, str] | None = None,
+    ):
+        self._data = data or {}
+        self.status_code = status_code
+        self.cookies = cookies or {}
+        self.text = json.dumps(self._data)
+
+    def json(self) -> dict[str, Any]:
+        return self._data
+
+
+def make_fake_client(routes: dict[tuple[str, str], Any], requests: list[dict[str, Any]]):
+    class FakeHTTPClient:
+        def __init__(
+            self,
+            *,
+            base_url: str,
+            headers: dict[str, str] | None = None,
+            cookies: dict[str, str] | None = None,
+            timeout: float = 30.0,
+        ) -> None:
+            self.base_url = base_url.rstrip("/")
+            self.headers = headers or {}
+            self.cookies = dict(cookies or {})
+            self.timeout = timeout
+
+        def get(self, path: str, params: dict[str, Any] | None = None) -> FakeResponse:
+            return self._request("GET", path, params=params)
+
+        def post(self, path: str, json: dict[str, Any] | None = None) -> FakeResponse:
+            return self._request("POST", path, json=json)
+
+        def patch(self, path: str, json: dict[str, Any] | None = None) -> FakeResponse:
+            return self._request("PATCH", path, json=json)
+
+        def delete(self, path: str) -> FakeResponse:
+            return self._request("DELETE", path)
+
+        def _request(
+            self,
+            method: str,
+            path: str,
+            *,
+            json: dict[str, Any] | None = None,
+            params: dict[str, Any] | None = None,
+        ) -> FakeResponse:
+            request = {
+                "method": method,
+                "path": path,
+                "json": json,
+                "params": params,
+                "headers": dict(self.headers),
+                "cookies": dict(self.cookies),
+                "base_url": self.base_url,
+            }
+            requests.append(request)
+            handler = routes[(method, path)]
+            if callable(handler):
+                return handler(request)
+            return handler
+
+    return FakeHTTPClient
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cli_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    config_dir = tmp_path / ".config" / "treadstone"
+    monkeypatch.setattr(_client, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(_client, "CONFIG_FILE", config_dir / "config.toml")
+    monkeypatch.setattr(_client, "SESSION_FILE", config_dir / "session.json")
+    return config_dir
+
+
+def test_root_help_uses_system_group_and_drops_top_level_health(runner: CliRunner) -> None:
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "  system" in result.output
+    assert "treadstone system health" in result.output
+    assert "\n  health" not in result.output
+
+    missing_alias = runner.invoke(cli, ["health"])
+    assert missing_alias.exit_code != 0
+    assert "No such command 'health'" in missing_alias.output
+
+
+def test_guide_agent_matches_skills_flag(runner: CliRunner) -> None:
+    guide_result = runner.invoke(cli, ["guide", "agent"])
+    skills_result = runner.invoke(cli, ["--skills"])
+
+    assert guide_result.exit_code == 0
+    assert skills_result.exit_code == 0
+    assert guide_result.output == skills_result.output
+    assert "SANDBOX_ID arguments always require the sandbox ID" in guide_result.output
+
+
+def test_login_saves_session_and_whoami_uses_it(
+    runner: CliRunner,
+    cli_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, Any]] = []
+
+    def whoami_handler(request: dict[str, Any]) -> FakeResponse:
+        assert request["headers"] == {}
+        assert request["cookies"] == {"session": "sess-123"}
+        return FakeResponse({"id": "usr-1", "email": "user@example.com", "role": "admin", "is_active": True})
+
+    routes = {
+        ("POST", "/v1/auth/login"): FakeResponse({"detail": "Login successful"}, cookies={"session": "sess-123"}),
+        ("GET", "/v1/auth/user"): whoami_handler,
+    }
+    monkeypatch.setattr(_client.httpx, "Client", make_fake_client(routes, requests))
+
+    login_result = runner.invoke(
+        cli,
+        ["--json", "auth", "login", "--email", "user@example.com", "--password", "Pass123!"],
+    )
+
+    assert login_result.exit_code == 0
+    login_data = json.loads(login_result.output)
+    assert login_data["session_saved"] is True
+    assert json.loads(_client.SESSION_FILE.read_text()) == {_client._DEFAULT_BASE_URL: "sess-123"}
+
+    whoami_result = runner.invoke(cli, ["--json", "auth", "whoami"])
+    assert whoami_result.exit_code == 0
+    whoami_data = json.loads(whoami_result.output)
+    assert whoami_data["email"] == "user@example.com"
+
+
+def test_protected_commands_prefer_api_key_over_saved_session(
+    runner: CliRunner,
+    cli_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _client.save_session(_client._DEFAULT_BASE_URL, "sess-123")
+    _client.set_config_value("api_key", "sk-test")
+    requests: list[dict[str, Any]] = []
+
+    def whoami_handler(request: dict[str, Any]) -> FakeResponse:
+        assert request["headers"]["Authorization"] == "Bearer sk-test"
+        assert request["cookies"] == {}
+        return FakeResponse({"id": "usr-1", "email": "api@example.com", "role": "admin", "is_active": True})
+
+    routes = {
+        ("GET", "/v1/auth/user"): whoami_handler,
+    }
+    monkeypatch.setattr(_client.httpx, "Client", make_fake_client(routes, requests))
+
+    result = runner.invoke(cli, ["--json", "auth", "whoami"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["email"] == "api@example.com"
+
+
+def test_api_key_create_save_writes_local_config(
+    runner: CliRunner,
+    cli_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _client.save_session(_client._DEFAULT_BASE_URL, "sess-123")
+    requests: list[dict[str, Any]] = []
+    routes = {
+        ("POST", "/v1/auth/api-keys"): FakeResponse(
+            {
+                "id": "key-1",
+                "name": "agent",
+                "key": "sk-created",
+                "scope": {"control_plane": True, "data_plane": {"mode": "all", "sandbox_ids": []}},
+            }
+        ),
+    }
+    monkeypatch.setattr(_client.httpx, "Client", make_fake_client(routes, requests))
+
+    result = runner.invoke(cli, ["--json", "api-keys", "create", "--name", "agent", "--save"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["saved_to_config"] is True
+    assert _client._read_config()["api_key"] == "sk-created"
+
+
+def test_sandboxes_create_supports_auto_intervals(
+    runner: CliRunner,
+    cli_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _client.save_session(_client._DEFAULT_BASE_URL, "sess-123")
+    requests: list[dict[str, Any]] = []
+
+    def create_handler(request: dict[str, Any]) -> FakeResponse:
+        assert request["json"]["auto_stop_interval"] == 30
+        assert request["json"]["auto_delete_interval"] == 90
+        assert request["json"]["labels"] == {"env": "dev"}
+        return FakeResponse({"id": "sb-1", "name": "demo", "urls": {"proxy": "http://proxy", "web": None}})
+
+    routes = {
+        ("POST", "/v1/sandboxes"): create_handler,
+    }
+    monkeypatch.setattr(_client.httpx, "Client", make_fake_client(routes, requests))
+
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sandboxes",
+            "create",
+            "--template",
+            "aio-sandbox-tiny",
+            "--name",
+            "demo",
+            "--label",
+            "env:dev",
+            "--auto-stop-interval",
+            "30",
+            "--auto-delete-interval",
+            "90",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["id"] == "sb-1"
+
+
+def test_sandboxes_list_accepts_multiple_labels(
+    runner: CliRunner,
+    cli_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _client.save_session(_client._DEFAULT_BASE_URL, "sess-123")
+    requests: list[dict[str, Any]] = []
+
+    def list_handler(request: dict[str, Any]) -> FakeResponse:
+        assert request["params"]["label"] == ["env:dev", "team:agent"]
+        return FakeResponse({"items": [], "total": 0})
+
+    routes = {
+        ("GET", "/v1/sandboxes"): list_handler,
+    }
+    monkeypatch.setattr(_client.httpx, "Client", make_fake_client(routes, requests))
+
+    result = runner.invoke(
+        cli,
+        ["--json", "sandboxes", "list", "--label", "env:dev", "--label", "team:agent"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["total"] == 0
+
+
+def test_sandboxes_web_commands_cover_enable_status_disable(
+    runner: CliRunner,
+    cli_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _client.save_session(_client._DEFAULT_BASE_URL, "sess-123")
+    requests: list[dict[str, Any]] = []
+    routes = {
+        ("POST", "/v1/sandboxes/sb-123/web-link"): FakeResponse(
+            {
+                "web_url": "https://sandbox-demo.treadstone-ai.dev",
+                "open_link": "https://sandbox-demo.treadstone-ai.dev/_treadstone/open?token=abc",
+                "expires_at": "2026-03-31T12:00:00+00:00",
+            }
+        ),
+        ("GET", "/v1/sandboxes/sb-123/web-link"): FakeResponse(
+            {
+                "web_url": "https://sandbox-demo.treadstone-ai.dev",
+                "enabled": True,
+                "expires_at": "2026-03-31T12:00:00+00:00",
+                "last_used_at": None,
+            }
+        ),
+        ("DELETE", "/v1/sandboxes/sb-123/web-link"): FakeResponse(status_code=204),
+    }
+    monkeypatch.setattr(_client.httpx, "Client", make_fake_client(routes, requests))
+
+    enable_result = runner.invoke(cli, ["--json", "sandboxes", "web", "enable", "sb-123"])
+    status_result = runner.invoke(cli, ["--json", "sandboxes", "web", "status", "sb-123"])
+    disable_result = runner.invoke(cli, ["--json", "sandboxes", "web", "disable", "sb-123"])
+
+    assert enable_result.exit_code == 0
+    assert status_result.exit_code == 0
+    assert disable_result.exit_code == 0
+    assert json.loads(enable_result.output)["open_link"].endswith("token=abc")
+    assert json.loads(status_result.output)["enabled"] is True
+    assert json.loads(disable_result.output)["sandbox_id"] == "sb-123"

--- a/uv.lock
+++ b/uv.lock
@@ -1063,6 +1063,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1123,6 +1135,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1717,6 +1738,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1816,7 +1850,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.1.0"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1836,6 +1870,7 @@ dependencies = [
 dev = [
     { name = "aiosqlite" },
     { name = "auth0-python" },
+    { name = "click" },
     { name = "fastapi-users", extra = ["oauth", "sqlalchemy"] },
     { name = "httpx" },
     { name = "httpx-oauth" },
@@ -1845,6 +1880,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-freezer" },
+    { name = "rich" },
     { name = "ruff" },
 ]
 
@@ -1867,6 +1903,7 @@ requires-dist = [
 dev = [
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "auth0-python", specifier = ">=4.2.0,<5.0.0" },
+    { name = "click", specifier = ">=8.1" },
     { name = "fastapi-users", extras = ["oauth", "sqlalchemy"], specifier = ">=14.0.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-oauth", specifier = ">=0.16.1" },
@@ -1876,6 +1913,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-freezer", specifier = ">=0.4.9" },
+    { name = "rich", specifier = ">=14.0" },
     { name = "ruff", specifier = ">=0.15.6" },
 ]
 


### PR DESCRIPTION
## Summary
- restructure the CLI around canonical system/auth/sandboxes paths and add an agent guide surface
- persist login sessions locally, add sandbox web commands, and support saving created API keys
- align README/CLI docs with current behavior, add CLI coverage, and sync package versions to 0.3.7

## Test Plan
- [x] make lint
- [x] TREADSTONE_DATABASE_URL='postgresql+asyncpg://fake:fake@localhost/fake?sslmode=require' make test
