### PR TITLE
fix: publish standard skill output for cli

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -46,7 +46,7 @@ treadstone sandboxes list
 # Create a browser hand-off URL for a human
 treadstone sandboxes web enable <sandbox-id>
 
-# Print the AI-oriented usage guide
+# Print the built-in agent skill
 treadstone guide agent
 treadstone --skills
 ```
@@ -108,7 +108,7 @@ treadstone config path
 | `--base-url URL` | Override the server URL |
 | `--api-key KEY` | Override the API key |
 | `--json` | Output responses as JSON (useful for scripting) |
-| `--skills` | Print the built-in AI usage guide |
+| `--skills` | Print the built-in agent skill in `SKILL.md` format |
 | `--version` | Show CLI version |
 | `--help` | Show help message |
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.3.7"
+version = "0.3.8"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/cli/treadstone_cli/_guide_text.py
+++ b/cli/treadstone_cli/_guide_text.py
@@ -2,64 +2,120 @@
 
 from __future__ import annotations
 
-AGENT_GUIDE = """Treadstone Agent Guide
+AGENT_GUIDE = """---
+name: treadstone-cli
+description: Use this skill when you need to operate the Treadstone CLI to check
+  system health, authenticate, manage API keys, inspect templates, create or inspect
+  sandboxes, or generate browser hand-off URLs. Use only commands that exist today,
+  prefer `treadstone --json ...` when you need machine-readable output, and remember
+  that sandbox operations require `SANDBOX_ID` values rather than sandbox names.
+---
 
-Purpose
-  Treadstone CLI manages control-plane access, sandboxes, templates, and API keys.
-  This guide only describes commands that exist today.
+# Treadstone CLI
 
-Canonical command tree
-  treadstone system health
-  treadstone auth register
-  treadstone auth login
-  treadstone auth whoami
-  treadstone api-keys create|list|update|delete
-  treadstone sandboxes create|list|get|start|stop|delete
-  treadstone sandboxes web enable|status|disable
-  treadstone templates list
-  treadstone config set|get|unset|path
-  treadstone guide agent
+Use this skill to drive the Treadstone control plane through the CLI without inventing commands or guessing identifiers.
 
-Authentication rules
-  1. Protected commands use an API key first if one is provided by flag, env var, or local config.
-  2. If no API key is available, protected commands fall back to the saved login session for the active base URL.
-  3. `treadstone auth login` saves a local session. `treadstone auth logout` clears that saved session.
-  4. `treadstone api-keys create --save` stores the new key in local config for later non-interactive use.
+## When To Use
 
-Identifier rules
-  - SANDBOX_ID arguments always require the sandbox ID, not the sandbox name.
-  - Use `treadstone --json sandboxes list` or `treadstone --json sandboxes create ...` to read sandbox IDs.
-  - KEY_ID arguments always require the API key ID.
+- The user asks you to run or explain `treadstone` CLI commands.
+- The task involves Treadstone authentication, API keys, templates, sandboxes, or browser hand-off URLs.
+- You need machine-readable sandbox or API key data from terminal commands.
 
-Common workflows
-  1. First-time interactive onboarding
-     treadstone system health
-     treadstone auth register --email you@example.com --password YourPass123!
-     treadstone auth login --email you@example.com --password YourPass123!
-     treadstone auth whoami
+## Working Rules
 
-  2. Create and save a reusable API key
-     treadstone api-keys create --name automation --save
+1. Use only the canonical commands listed below.
+2. Prefer `treadstone --json ...` when you need IDs, URLs, or fields to pass into later steps.
+3. Protected commands use an API key first if one is provided by flag, environment variable, or local config.
+4. If no API key is available, protected commands fall back to the saved login session for the active base URL.
+5. `treadstone auth login` saves a local session. `treadstone auth logout` clears that saved session.
+6. `treadstone api-keys create --save` stores the new key in local config for later non-interactive use.
 
-  3. Create a sandbox and inspect it
-     treadstone templates list
-     treadstone sandboxes create --template aio-sandbox-tiny --name demo
-     treadstone sandboxes list
-     treadstone sandboxes get SANDBOX_ID
+## Canonical Command Tree
 
-  4. Generate a browser hand-off URL for a human
-     treadstone sandboxes web enable SANDBOX_ID
-     Read the `open_link` field from JSON output or the "open_link" row in human output.
+```text
+treadstone system health
+treadstone auth register
+treadstone auth login
+treadstone auth logout
+treadstone auth whoami
+treadstone auth change-password
+treadstone auth invite
+treadstone auth users
+treadstone auth delete-user
+treadstone api-keys create|list|update|delete
+treadstone sandboxes create|list|get|start|stop|delete
+treadstone sandboxes web enable|status|disable
+treadstone templates list
+treadstone config set|get|unset|path
+treadstone guide agent
+treadstone --skills
+```
 
-JSON usage
-  - Pass `--json` before the command, for example: `treadstone --json sandboxes list`
-  - Useful fields:
-    - sandboxes create/get: `id`, `urls.proxy`, `urls.web`
-    - sandboxes web enable: `open_link`, `web_url`, `expires_at`
-    - api-keys create: `key`, `id`, `saved_to_config`
+## Default Workflows
 
-Failure recovery
-  - If a protected command says no authentication is configured, run `treadstone auth login` or provide an API key.
-  - If a sandbox command fails with not found, verify the value is a sandbox ID from `sandboxes list`, not the name.
-  - If you need a fresh browser hand-off URL, run `treadstone sandboxes web enable SANDBOX_ID` again.
+### Check Access And Identity
+
+```bash
+treadstone system health
+treadstone auth whoami
+```
+
+If authentication is missing, continue with login:
+
+```bash
+treadstone auth login --email you@example.com --password YourPass123!
+```
+
+### First-Time Interactive Onboarding
+
+```bash
+treadstone system health
+treadstone auth register --email you@example.com --password YourPass123!
+treadstone auth login --email you@example.com --password YourPass123!
+treadstone auth whoami
+```
+
+### Create And Save A Reusable API Key
+
+```bash
+treadstone api-keys create --name automation --save
+```
+
+### Create A Sandbox And Inspect It
+
+```bash
+treadstone templates list
+treadstone sandboxes create --template aio-sandbox-tiny --name demo
+treadstone --json sandboxes list
+treadstone sandboxes get SANDBOX_ID
+```
+
+### Generate A Browser Hand-Off URL For A Human
+
+```bash
+treadstone --json sandboxes web enable SANDBOX_ID
+```
+
+Read `open_link` from JSON output and report `web_url` and `expires_at` when they are present.
+
+## Identifier And Output Rules
+
+- SANDBOX_ID arguments always require the sandbox ID, not the sandbox name.
+- Use `treadstone --json sandboxes list` or `treadstone --json sandboxes create ...` to read sandbox IDs.
+- KEY_ID arguments always require the API key ID.
+- `--json` is a global flag and must appear before the subcommand.
+
+Useful fields to extract:
+
+- `sandboxes create` and `sandboxes get`: `id`, `urls.proxy`, `urls.web`
+- `sandboxes web enable`: `open_link`, `web_url`, `expires_at`
+- `api-keys create`: `key`, `id`, `saved_to_config`
+
+## Failure Recovery
+
+- If a protected command says no authentication is configured, run `treadstone auth login` or provide an API key.
+- If a sandbox command fails with not found, verify the value comes from `sandboxes list`
+  and is a sandbox ID rather than the sandbox name.
+- If you need a fresh browser hand-off URL, run `treadstone sandboxes web enable SANDBOX_ID` again.
+- If a machine-readable workflow is hard to follow from human output, rerun the command with `--json`.
 """

--- a/cli/treadstone_cli/guide.py
+++ b/cli/treadstone_cli/guide.py
@@ -20,5 +20,5 @@ def guide() -> None:
 
 @guide.command("agent")
 def agent_guide() -> None:
-    """Print the agent-oriented usage guide."""
+    """Print the built-in agent skill in SKILL.md format."""
     click.echo(AGENT_GUIDE.rstrip())

--- a/cli/treadstone_cli/main.py
+++ b/cli/treadstone_cli/main.py
@@ -68,7 +68,7 @@ class _TreadstoneGroup(click.Group):
                     ("List templates", "treadstone templates list"),
                     ("Create a sandbox", "treadstone sandboxes create --template aio-sandbox-tiny"),
                     ("Get a browser hand-off URL", "treadstone sandboxes web enable SANDBOX_ID"),
-                    ("Read the AI guide", "treadstone guide agent  or  treadstone --skills"),
+                    ("Print the agent skill", "treadstone guide agent  or  treadstone --skills"),
                 ]
             )
 
@@ -91,7 +91,7 @@ class _TreadstoneGroup(click.Group):
     is_eager=True,
     expose_value=False,
     callback=_print_skills,
-    help="Print the agent-oriented usage guide.",
+    help="Print the built-in agent skill in SKILL.md format.",
 )
 @click.option(
     "--api-key",

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -136,7 +136,7 @@ wheels = [
 
 [[package]]
 name = "treadstone-cli"
-version = "0.1.0"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.3.7"
+version = "0.3.8"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.3.7"
+version = "0.3.8"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -123,6 +123,9 @@ def test_guide_agent_matches_skills_flag(runner: CliRunner) -> None:
     assert guide_result.exit_code == 0
     assert skills_result.exit_code == 0
     assert guide_result.output == skills_result.output
+    assert guide_result.output.startswith("---\nname: treadstone-cli\n")
+    assert "description:" in guide_result.output
+    assert "# Treadstone CLI" in guide_result.output
     assert "SANDBOX_ID arguments always require the sandbox ID" in guide_result.output
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1850,7 +1850,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- replace the `treadstone --skills` guide with a standard `SKILL.md` style document
- update CLI/help README wording to describe the built-in agent skill output
- bump release versions to 0.3.8 and sync lockfiles

## Test Plan
- [x] make lint
- [x] make test
- [x] uv run --directory cli treadstone --skills
- [x] uv run --directory cli treadstone --version