### PR TITLE
fix: make sandbox web enable idempotent

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -205,6 +205,10 @@ treadstone --json sandboxes web enable <sandbox-id>
 treadstone --json api-keys list
 ```
 
+`treadstone sandboxes web enable <sandbox-id>` is idempotent: it returns the
+current active browser hand-off URL when one already exists. If you need a new
+hand-off URL, disable web access first and then enable it again.
+
 ## Error handling
 
 The CLI displays user-friendly error messages instead of stack traces:

--- a/cli/treadstone_cli/_guide_text.py
+++ b/cli/treadstone_cli/_guide_text.py
@@ -116,6 +116,7 @@ Useful fields to extract:
 - If a protected command says no authentication is configured, run `treadstone auth login` or provide an API key.
 - If a sandbox command fails with not found, verify the value comes from `sandboxes list`
   and is a sandbox ID rather than the sandbox name.
-- If you need a fresh browser hand-off URL, run `treadstone sandboxes web enable SANDBOX_ID` again.
+- If you need a fresh browser hand-off URL, run `treadstone sandboxes web disable SANDBOX_ID`
+  and then `treadstone sandboxes web enable SANDBOX_ID`.
 - If a machine-readable workflow is hard to follow from human output, rerun the command with `--json`.
 """

--- a/cli/treadstone_cli/sandboxes.py
+++ b/cli/treadstone_cli/sandboxes.py
@@ -204,7 +204,7 @@ def web() -> None:
 @click.argument("sandbox_id", metavar="SANDBOX_ID")
 @click.pass_context
 def enable_web(ctx: click.Context, sandbox_id: str) -> None:
-    """Enable a browser hand-off URL for a sandbox."""
+    """Ensure a browser hand-off URL exists for a sandbox."""
     client = require_auth(ctx)
     resp = client.post(f"/v1/sandboxes/{sandbox_id}/web-link")
     handle_error(resp)

--- a/tests/api/test_sandbox_subdomain_api.py
+++ b/tests/api/test_sandbox_subdomain_api.py
@@ -189,19 +189,19 @@ class TestSubdomainRouting:
         assert status_resp.json()["enabled"] is True
         assert "open_link" not in status_resp.json()
 
-    async def test_recreating_web_link_invalidates_previous_link(self, auth_client: AsyncClient, monkeypatch):
+    async def test_enabling_existing_web_link_returns_same_link(self, auth_client: AsyncClient, monkeypatch):
         _enable_subdomain(monkeypatch)
         sandbox_id = await _create_ready_sandbox(auth_client)
         first = (await auth_client.post(f"/v1/sandboxes/{sandbox_id}/web-link")).json()["open_link"]
         second = (await auth_client.post(f"/v1/sandboxes/{sandbox_id}/web-link")).json()["open_link"]
 
-        assert first != second
+        assert first == second
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="https://api.localhost") as client:
             first_resp = await client.get(first, follow_redirects=False)
             second_resp = await client.get(second, follow_redirects=False)
 
-        assert first_resp.status_code == 401
+        assert first_resp.status_code == 303
         assert second_resp.status_code == 303
 
     async def test_delete_web_link_revokes_open_link(self, auth_client: AsyncClient, monkeypatch):
@@ -238,7 +238,7 @@ class TestSubdomainRouting:
         assert first_open.status_code == 401
         assert second_open.status_code == 303
 
-    async def test_rotating_web_link_clears_last_used_at(self, auth_client: AsyncClient, monkeypatch):
+    async def test_enabling_existing_web_link_preserves_last_used_at(self, auth_client: AsyncClient, monkeypatch):
         _enable_subdomain(monkeypatch)
         sandbox_id = await _create_ready_sandbox(auth_client)
         first_link = (await auth_client.post(f"/v1/sandboxes/{sandbox_id}/web-link")).json()["open_link"]
@@ -252,9 +252,9 @@ class TestSubdomainRouting:
 
         assert first_status.status_code == 200
         assert first_status.json()["last_used_at"] is not None
-        assert second_link != first_link
+        assert second_link == first_link
         assert second_status.status_code == 200
-        assert second_status.json()["last_used_at"] is None
+        assert second_status.json()["last_used_at"] == first_status.json()["last_used_at"]
 
     async def test_browser_login_page_can_log_in_and_continue(self, auth_client: AsyncClient, monkeypatch):
         _enable_subdomain(monkeypatch)

--- a/tests/api/test_sandboxes_api.py
+++ b/tests/api/test_sandboxes_api.py
@@ -244,6 +244,16 @@ class TestGetSandbox:
             "http://sandbox-get-web.sandbox.localhost/_treadstone/open?token=swl"
         )
 
+    async def test_web_enable_returns_same_current_shareable_url_created_with_sandbox(self, auth_client, monkeypatch):
+        _enable_subdomain(monkeypatch)
+        create_resp = await auth_client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny", "name": "get-web"})
+        sandbox_id = create_resp.json()["id"]
+
+        enable_resp = await auth_client.post(f"/v1/sandboxes/{sandbox_id}/web-link")
+
+        assert enable_resp.status_code == 200
+        assert enable_resp.json()["open_link"] == create_resp.json()["urls"]["web"]
+
     async def test_get_nonexistent_returns_404(self, auth_client):
         resp = await auth_client.get("/v1/sandboxes/sb-nonexistent1234")
         assert resp.status_code == 404

--- a/treadstone/api/sandboxes.py
+++ b/treadstone/api/sandboxes.py
@@ -161,6 +161,19 @@ async def _upsert_web_link(
     return link
 
 
+async def _ensure_active_web_link(
+    session: AsyncSession,
+    sandbox,
+    user_id: str,
+    *,
+    ttl_seconds: int = OPEN_LINK_TTL_SECONDS,
+) -> SandboxWebLink:
+    link = await _load_active_web_link(session, sandbox.id)
+    if link is not None:
+        return link
+    return await _upsert_web_link(session, sandbox, user_id, ttl_seconds=ttl_seconds)
+
+
 def _parse_label_filters(labels: list[str]) -> dict[str, str]:
     parsed: dict[str, str] = {}
     for item in labels:
@@ -281,7 +294,7 @@ async def create_sandbox_web_link(
         raise SandboxNotFoundError(sandbox_id)
 
     web_url = _get_web_url(sandbox, str(request.base_url))
-    link = await _upsert_web_link(session, sandbox, user.id)
+    link = await _ensure_active_web_link(session, sandbox, user.id)
     return {
         "web_url": web_url,
         "open_link": build_open_link_url(web_url, link.id),


### PR DESCRIPTION
## Summary
- make `POST /v1/sandboxes/{id}/web-link` idempotent by returning the current active hand-off link when one already exists
- keep the existing create/get behavior so sandbox creation still auto-generates a web link and sandbox details keep exposing the current `urls.web`
- update API and CLI tests plus CLI docs/help text to reflect that a fresh hand-off URL now requires disable + enable

## Test Plan
- [x] uv run pytest tests/api/test_sandbox_subdomain_api.py tests/api/test_sandboxes_api.py tests/unit/test_cli_commands.py -v
- [x] make test
- [x] make lint