### PR TITLE
feat: owner-scoped sandbox names and hard-delete lifecycle

### DIFF
--- a/alembic/versions/9f8b8c4d6e21_scope_sandbox_names_and_hard_delete.py
+++ b/alembic/versions/9f8b8c4d6e21_scope_sandbox_names_and_hard_delete.py
@@ -1,0 +1,58 @@
+"""scope sandbox names and hard delete
+
+Revision ID: 9f8b8c4d6e21
+Revises: ec1f57069933
+Create Date: 2026-03-25 14:30:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9f8b8c4d6e21"
+down_revision: Union[str, Sequence[str], None] = "ec1f57069933"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLES_TO_CLEAR = (
+    "sandbox_web_link",
+    "api_key_sandbox_grant",
+    "api_key",
+    "sandbox",
+    "oauth_account",
+    "invitation",
+    "user",
+)
+
+
+def _clear_existing_data() -> None:
+    connection = op.get_bind()
+    for table_name in _TABLES_TO_CLEAR:
+        connection.execute(sa.table(table_name).delete())
+
+
+
+def upgrade() -> None:
+    _clear_existing_data()
+
+    op.drop_index(op.f("ix_sandbox_name"), table_name="sandbox")
+    op.create_index(op.f("ix_sandbox_name"), "sandbox", ["name"], unique=False)
+    op.create_unique_constraint("uq_sandbox_owner_name", "sandbox", ["owner_id", "name"])
+    op.drop_column("sandbox", "gmt_deleted")
+
+
+
+def downgrade() -> None:
+    _clear_existing_data()
+
+    op.add_column("sandbox", sa.Column("gmt_deleted", sa.DateTime(timezone=True), nullable=True))
+    op.drop_constraint("uq_sandbox_owner_name", "sandbox", type_="unique")
+    op.drop_index(op.f("ix_sandbox_name"), table_name="sandbox")
+    op.create_index(op.f("ix_sandbox_name"), "sandbox", ["name"], unique=True)

--- a/cli/README.md
+++ b/cli/README.md
@@ -143,7 +143,7 @@ treadstone auth delete-user <user-id>    # Delete a user (admin)
 Create and manage sandboxes.
 
 Custom sandbox names must be 1-55 characters of lowercase letters, numbers, or hyphens. They must start and end
-with a letter or number. This keeps browser URLs like `sandbox-{name}.treadstone-ai.dev` within DNS label limits.
+with a letter or number. Sandbox names only need to be unique for the current user.
 
 ```bash
 treadstone sandboxes create --template aio-sandbox-tiny --name my-box

--- a/cli/treadstone_cli/sandboxes.py
+++ b/cli/treadstone_cli/sandboxes.py
@@ -31,7 +31,7 @@ def sandboxes() -> None:
     help=(
         "Sandbox name (auto-generated if omitted). Must be 1-55 characters of lowercase letters, "
         "numbers, or hyphens; must start and end with a letter or number. "
-        "This keeps sandbox-{name} within DNS label limits."
+        "Sandbox names only need to be unique for the current user."
     ),
 )
 @click.option("--label", multiple=True, help="Labels in key:val format (repeatable).")
@@ -58,8 +58,8 @@ def create(
     """Create a new sandbox from a template.
 
     Custom names must be 1-55 characters of lowercase letters, numbers, or
-    hyphens, and must start and end with a letter or number. This keeps
-    browser URLs like sandbox-{name}.treadstone-ai.dev within DNS label limits.
+    hyphens, and must start and end with a letter or number. Sandbox names
+    only need to be unique for the current user.
 
     \b
     Examples:

--- a/deploy/treadstone/values-local.yaml
+++ b/deploy/treadstone/values-local.yaml
@@ -25,7 +25,11 @@ ingress:
   enabled: true
   className: nginx
   hosts:
-    - host: ""
+    - host: localhost
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: "*.sandbox.localhost"
       paths:
         - path: /
           pathType: Prefix

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -34,15 +34,22 @@ EOF
 # ── Wait for service ─────────────────────────────────────────────────────────
 
 printf "Waiting for %s to be ready " "$BASE_URL"
+consecutive_successes=0
 for i in $(seq 1 30); do
     if curl -sf -o /dev/null "$BASE_URL/health" 2>/dev/null; then
-        printf " ready!\n\n"
-        break
+        consecutive_successes=$((consecutive_successes + 1))
+        printf "+"
+        if [ "$consecutive_successes" -ge 3 ]; then
+            printf " ready!\n\n"
+            break
+        fi
+    else
+        consecutive_successes=0
+        printf "."
     fi
-    printf "."
     sleep 2
     if [ "$i" -eq 30 ]; then
-        printf "\nERROR: timed out after 60s waiting for %s/health\n" "$BASE_URL"
+        printf "\nERROR: timed out after 60s waiting for 3 consecutive %s/health successes\n" "$BASE_URL"
         exit 1
     fi
 done

--- a/sdk/python/treadstone_sdk/models/create_sandbox_request.py
+++ b/sdk/python/treadstone_sdk/models/create_sandbox_request.py
@@ -21,8 +21,8 @@ class CreateSandboxRequest:
     Attributes:
         template (str):
         name (None | str | Unset): Optional custom sandbox name. Sandbox name must be 1-55 characters of lowercase
-            letters, numbers, or hyphens, and must start and end with a letter or number. This keeps browser URLs like
-            `sandbox-{name}.treadstone-ai.dev` within DNS label limits.
+            letters, numbers, or hyphens, and must start and end with a letter or number. Sandbox names only need to be
+            unique for the current user.
         labels (CreateSandboxRequestLabels | Unset):
         auto_stop_interval (int | Unset): Minutes of inactivity before the sandbox is automatically stopped. Default:
             15.

--- a/tests/api/test_sandbox_subdomain_api.py
+++ b/tests/api/test_sandbox_subdomain_api.py
@@ -111,7 +111,7 @@ async def _create_ready_sandbox(auth_client: AsyncClient, name: str = "mybox") -
     async with _test_session_factory() as session:
         sandbox = await session.get(Sandbox, sandbox_id)
         sandbox.status = SandboxStatus.READY.value
-        sandbox.k8s_sandbox_name = sandbox.name
+        sandbox.k8s_sandbox_name = sandbox.id
         session.add(sandbox)
         await session.commit()
     return sandbox_id
@@ -134,35 +134,43 @@ class TestSubdomainDisabled:
 class TestSubdomainRouting:
     async def test_subdomain_without_cookie_redirects_to_bootstrap(self, auth_client: AsyncClient, monkeypatch):
         _enable_subdomain(monkeypatch)
-        await _create_ready_sandbox(auth_client)
+        sandbox_id = await _create_ready_sandbox(auth_client)
 
-        resp = await auth_client.get("https://sandbox-mybox.sandbox.localhost/", follow_redirects=False)
+        resp = await auth_client.get(f"https://sandbox-{sandbox_id}.sandbox.localhost/", follow_redirects=False)
 
         assert resp.status_code == 303
         location = resp.headers["location"]
         parsed = urlparse(location)
         assert parsed.netloc == "api.localhost"
         assert parsed.path == "/v1/browser/bootstrap"
-        assert parse_qs(parsed.query)["return_to"] == ["https://sandbox-mybox.sandbox.localhost/"]
+        assert parse_qs(parsed.query)["return_to"] == [f"https://sandbox-{sandbox_id}.sandbox.localhost/"]
 
     async def test_logged_in_user_can_bootstrap_and_proxy(self, auth_client: AsyncClient, monkeypatch):
         _enable_subdomain(monkeypatch)
-        await _create_ready_sandbox(auth_client)
+        sandbox_id = await _create_ready_sandbox(auth_client)
         mock_client, captured = _capture_mock()
-        auth_client.cookies.set("session", "sandbox-app-session", domain="sandbox-mybox.sandbox.localhost", path="/")
-        auth_client.cookies.set("prefs", "a b", domain="sandbox-mybox.sandbox.localhost", path="/")
+        auth_client.cookies.set(
+            "session",
+            "sandbox-app-session",
+            domain=f"sandbox-{sandbox_id}.sandbox.localhost",
+            path="/",
+        )
+        auth_client.cookies.set("prefs", "a b", domain=f"sandbox-{sandbox_id}.sandbox.localhost", path="/")
 
         with patch("treadstone.services.sandbox_proxy._http_client", mock_client):
             with patch("treadstone.middleware.sandbox_subdomain.get_http_client", return_value=mock_client):
-                bootstrap = await auth_client.get("https://sandbox-mybox.sandbox.localhost/", follow_redirects=True)
+                bootstrap = await auth_client.get(
+                    f"https://sandbox-{sandbox_id}.sandbox.localhost/",
+                    follow_redirects=True,
+                )
                 resp = await auth_client.get(
-                    "https://sandbox-mybox.sandbox.localhost/",
+                    f"https://sandbox-{sandbox_id}.sandbox.localhost/",
                     headers={"Authorization": "Bearer app-token"},
                 )
 
         assert bootstrap.status_code == 200
         assert resp.status_code == 200
-        assert "mybox.default.svc.cluster.local:8080/" in captured["url"]
+        assert f"{sandbox_id}.default.svc.cluster.local:8080/" in captured["url"]
         outgoing_headers = {k.lower(): v for k, v in captured["headers"].items()}
         assert outgoing_headers["authorization"] == "Bearer app-token"
         cookie_header = {k.lower(): v for k, v in captured["headers"].items()}.get("cookie", "")
@@ -179,7 +187,10 @@ class TestSubdomainRouting:
             with patch("treadstone.middleware.sandbox_subdomain.get_http_client", return_value=mock_client):
                 async with AsyncClient(transport=ASGITransport(app=app), base_url="https://api.localhost") as client:
                     resp = await client.get(open_link, follow_redirects=True)
-                    followup = await client.get("https://sandbox-mybox.sandbox.localhost/", follow_redirects=True)
+                    followup = await client.get(
+                        f"https://sandbox-{sandbox_id}.sandbox.localhost/",
+                        follow_redirects=True,
+                    )
 
         assert resp.status_code == 200
         assert followup.status_code == 200
@@ -258,11 +269,11 @@ class TestSubdomainRouting:
 
     async def test_browser_login_page_can_log_in_and_continue(self, auth_client: AsyncClient, monkeypatch):
         _enable_subdomain(monkeypatch)
-        await _create_ready_sandbox(auth_client)
+        sandbox_id = await _create_ready_sandbox(auth_client)
         mock_client, _ = _capture_mock()
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="https://api.localhost") as browser:
-            first = await browser.get("https://sandbox-mybox.sandbox.localhost/", follow_redirects=False)
+            first = await browser.get(f"https://sandbox-{sandbox_id}.sandbox.localhost/", follow_redirects=False)
             bootstrap_url = first.headers["location"]
             bootstrap = await browser.get(bootstrap_url, follow_redirects=False)
             login_url = bootstrap.headers["location"]
@@ -276,7 +287,7 @@ class TestSubdomainRouting:
                         data={
                             "email": "sandbox@test.com",
                             "password": "Pass123!",
-                            "return_to": "https://sandbox-mybox.sandbox.localhost/",
+                            "return_to": f"https://sandbox-{sandbox_id}.sandbox.localhost/",
                         },
                         follow_redirects=True,
                     )

--- a/tests/api/test_sandboxes_api.py
+++ b/tests/api/test_sandboxes_api.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from treadstone.core.database import Base, get_session
 from treadstone.core.users import UserManager, get_user_db, get_user_manager
 from treadstone.main import app
+from treadstone.models.sandbox import Sandbox
 from treadstone.models.user import OAuthAccount, User
 
 _test_session_factory = None
@@ -51,6 +52,14 @@ async def auth_client(db_session):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         await client.post("/v1/auth/register", json={"email": "sandbox@test.com", "password": "Pass123!"})
         await client.post("/v1/auth/login", json={"email": "sandbox@test.com", "password": "Pass123!"})
+        yield client
+
+
+@pytest.fixture
+async def second_auth_client(db_session):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.post("/v1/auth/register", json={"email": "other@test.com", "password": "Pass123!"})
+        await client.post("/v1/auth/login", json={"email": "other@test.com", "password": "Pass123!"})
         yield client
 
 
@@ -126,9 +135,29 @@ class TestCreateSandbox:
         )
 
         assert resp.status_code == 202
-        assert resp.json()["urls"]["web"].startswith(
-            "http://sandbox-handoff-sb.sandbox.localhost/_treadstone/open?token=swl"
+        data = resp.json()
+        assert data["urls"]["web"].startswith(
+            f"http://sandbox-{data['id']}.sandbox.localhost/_treadstone/open?token=swl"
         )
+
+    async def test_create_same_name_for_different_users_succeeds(self, auth_client, second_auth_client):
+        first = await auth_client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny", "name": "shared-name"})
+        second = await second_auth_client.post(
+            "/v1/sandboxes",
+            json={"template": "aio-sandbox-tiny", "name": "shared-name"},
+        )
+
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert first.json()["id"] != second.json()["id"]
+
+    async def test_create_same_name_for_same_user_returns_409(self, auth_client):
+        first = await auth_client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny", "name": "taken-name"})
+        second = await auth_client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny", "name": "taken-name"})
+
+        assert first.status_code == 202
+        assert second.status_code == 409
+        assert second.json()["error"]["code"] == "sandbox_name_conflict"
 
     @pytest.mark.parametrize(
         "name",
@@ -241,7 +270,7 @@ class TestGetSandbox:
 
         assert resp.status_code == 200
         assert resp.json()["urls"]["web"].startswith(
-            "http://sandbox-get-web.sandbox.localhost/_treadstone/open?token=swl"
+            f"http://sandbox-{sandbox_id}.sandbox.localhost/_treadstone/open?token=swl"
         )
 
     async def test_web_enable_returns_same_current_shareable_url_created_with_sandbox(self, auth_client, monkeypatch):
@@ -271,6 +300,30 @@ class TestDeleteSandbox:
         resp = await auth_client.delete("/v1/sandboxes/sb-nonexistent1234")
         assert resp.status_code == 404
         assert resp.json()["error"]["code"] == "sandbox_not_found"
+
+    async def test_delete_revokes_active_web_link(self, auth_client, monkeypatch):
+        _enable_subdomain(monkeypatch)
+        create_resp = await auth_client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny", "name": "del-web"})
+        sandbox_id = create_resp.json()["id"]
+
+        delete_resp = await auth_client.delete(f"/v1/sandboxes/{sandbox_id}")
+        status_resp = await auth_client.get(f"/v1/sandboxes/{sandbox_id}/web-link")
+
+        assert delete_resp.status_code == 204
+        assert status_resp.status_code == 200
+        assert status_resp.json()["enabled"] is False
+
+    async def test_delete_keeps_row_until_sync_removes_it(self, auth_client):
+        create_resp = await auth_client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny", "name": "del-row"})
+        sandbox_id = create_resp.json()["id"]
+
+        delete_resp = await auth_client.delete(f"/v1/sandboxes/{sandbox_id}")
+
+        assert delete_resp.status_code == 204
+        async with _test_session_factory() as session:
+            sandbox = await session.get(Sandbox, sandbox_id)
+            assert sandbox is not None
+            assert sandbox.status == "deleting"
 
 
 class TestStartStopSandbox:

--- a/tests/e2e/06-sandbox-name-scope-and-web-link.hurl
+++ b/tests/e2e/06-sandbox-name-scope-and-web-link.hurl
@@ -1,0 +1,155 @@
+# Sandbox naming + web links:
+# - same user cannot reuse a sandbox name
+# - different users can use the same sandbox name
+# - browser URLs are based on sandbox.id, not sandbox.name
+# - deleting a sandbox revokes its web link immediately
+
+# ── User A setup ─────────────────────────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/register
+Content-Type: application/json
+{
+    "email": "e2e-06-a-{{unique}}@test.treadstone.dev",
+    "password": "{{test_password}}"
+}
+HTTP 201
+
+POST {{base_url}}/v1/auth/login
+Content-Type: application/json
+{
+    "email": "e2e-06-a-{{unique}}@test.treadstone.dev",
+    "password": "{{test_password}}"
+}
+HTTP 200
+
+POST {{base_url}}/v1/auth/api-keys
+Content-Type: application/json
+{"name": "e2e-name-scope-a"}
+HTTP 201
+[Captures]
+api_key_a: jsonpath "$.key"
+api_key_id_a: jsonpath "$.id"
+
+
+# ── Resolve a valid template ────────────────────────────────────────────────
+
+GET {{base_url}}/v1/sandbox-templates
+Authorization: Bearer {{api_key_a}}
+HTTP 200
+[Captures]
+template_name: jsonpath "$.items[0].name"
+[Asserts]
+jsonpath "$.items" count >= 1
+
+
+# ── User A creates a sandbox and gets an id-based web URL ───────────────────
+
+POST {{base_url}}/v1/sandboxes
+Authorization: Bearer {{api_key_a}}
+Content-Type: application/json
+{
+    "template": "{{template_name}}",
+    "name": "shared-{{unique}}"
+}
+HTTP 202
+[Captures]
+sandbox_id_a: jsonpath "$.id"
+[Asserts]
+jsonpath "$.name" == "shared-{{unique}}"
+jsonpath "$.urls.web" startsWith "http://sandbox-{{sandbox_id_a}}.sandbox.localhost/_treadstone/open?token="
+
+POST {{base_url}}/v1/sandboxes/{{sandbox_id_a}}/web-link
+Authorization: Bearer {{api_key_a}}
+HTTP 200
+[Asserts]
+jsonpath "$.web_url" startsWith "http://sandbox-{{sandbox_id_a}}.sandbox.localhost"
+jsonpath "$.open_link" startsWith "http://sandbox-{{sandbox_id_a}}.sandbox.localhost/_treadstone/open?token="
+
+GET {{base_url}}/v1/sandboxes/{{sandbox_id_a}}/web-link
+Authorization: Bearer {{api_key_a}}
+HTTP 200
+[Asserts]
+jsonpath "$.enabled" == true
+jsonpath "$.web_url" startsWith "http://sandbox-{{sandbox_id_a}}.sandbox.localhost"
+
+
+# ── Same user cannot reuse the same name ────────────────────────────────────
+
+POST {{base_url}}/v1/sandboxes
+Authorization: Bearer {{api_key_a}}
+Content-Type: application/json
+{
+    "template": "{{template_name}}",
+    "name": "shared-{{unique}}"
+}
+HTTP 409
+[Asserts]
+jsonpath "$.error.code" == "sandbox_name_conflict"
+
+
+# ── User B can reuse the same name ──────────────────────────────────────────
+
+POST {{base_url}}/v1/auth/register
+Content-Type: application/json
+{
+    "email": "e2e-06-b-{{unique}}@test.treadstone.dev",
+    "password": "{{test_password}}"
+}
+HTTP 201
+
+POST {{base_url}}/v1/auth/login
+Content-Type: application/json
+{
+    "email": "e2e-06-b-{{unique}}@test.treadstone.dev",
+    "password": "{{test_password}}"
+}
+HTTP 200
+
+POST {{base_url}}/v1/auth/api-keys
+Content-Type: application/json
+{"name": "e2e-name-scope-b"}
+HTTP 201
+[Captures]
+api_key_b: jsonpath "$.key"
+api_key_id_b: jsonpath "$.id"
+
+POST {{base_url}}/v1/sandboxes
+Authorization: Bearer {{api_key_b}}
+Content-Type: application/json
+{
+    "template": "{{template_name}}",
+    "name": "shared-{{unique}}"
+}
+HTTP 202
+[Captures]
+sandbox_id_b: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+
+
+# ── Deleting User A sandbox revokes the web link immediately ────────────────
+
+DELETE {{base_url}}/v1/sandboxes/{{sandbox_id_a}}
+Authorization: Bearer {{api_key_a}}
+HTTP 204
+
+GET {{base_url}}/v1/sandboxes/{{sandbox_id_a}}/web-link
+Authorization: Bearer {{api_key_a}}
+HTTP 200
+[Asserts]
+jsonpath "$.enabled" == false
+
+
+# ── Cleanup ─────────────────────────────────────────────────────────────────
+
+DELETE {{base_url}}/v1/sandboxes/{{sandbox_id_b}}
+Authorization: Bearer {{api_key_b}}
+HTTP 204
+
+DELETE {{base_url}}/v1/auth/api-keys/{{api_key_id_a}}
+Authorization: Bearer {{api_key_a}}
+HTTP 204
+
+DELETE {{base_url}}/v1/auth/api-keys/{{api_key_id_b}}
+Authorization: Bearer {{api_key_b}}
+HTTP 204

--- a/tests/unit/test_k8s_sync.py
+++ b/tests/unit/test_k8s_sync.py
@@ -125,7 +125,7 @@ class TestHandleWatchEvent:
 
         async with session_factory() as session:
             sb = await session.get(Sandbox, "sb00000000test1234")
-            assert sb.status == SandboxStatus.DELETED
+            assert sb is None
 
     async def test_deleted_from_ready_marks_error(self, session_factory):
         await _create_sandbox(session_factory, status=SandboxStatus.READY)
@@ -177,7 +177,7 @@ class TestReconcile:
 
         async with session_factory() as session:
             sb = await session.get(Sandbox, "sb00000000test1234")
-            assert sb.status == SandboxStatus.DELETED
+            assert sb is None
 
     async def test_reconcile_returns_resource_version(self, session_factory):
         k8s = FakeK8sClient()
@@ -239,7 +239,7 @@ class TestWatchLoop:
             assert sb.k8s_resource_version == "11"
 
     async def test_watch_deleted_event(self, session_factory):
-        """Watch DELETED event for a DELETING sandbox should mark it DELETED."""
+        """Watch DELETED event for a DELETING sandbox should delete the row."""
         await _create_sandbox(session_factory, status=SandboxStatus.DELETING)
         k8s = FakeK8sClient()
 
@@ -251,7 +251,7 @@ class TestWatchLoop:
 
         async with session_factory() as session:
             sb = await session.get(Sandbox, "sb00000000test1234")
-            assert sb.status == SandboxStatus.DELETED
+            assert sb is None
 
     async def test_watch_loop_completes_on_stream_end(self, session_factory):
         """Watch loop should return gracefully when the stream ends."""

--- a/tests/unit/test_sandbox_build_urls.py
+++ b/tests/unit/test_sandbox_build_urls.py
@@ -34,36 +34,36 @@ def _fake_settings(**overrides):
 
 def test_build_urls_web_omits_port_for_plain_localhost(monkeypatch) -> None:
     monkeypatch.setattr("treadstone.api.sandboxes.settings", _fake_settings())
-    sb = SimpleNamespace(id="1", name="sbx")
+    sb = SimpleNamespace(id="sb123", name="sbx")
     urls = _build_urls(sb, "http://localhost/")
-    assert urls["web"] == "http://sandbox-sbx.sandbox.localhost"
-    assert urls["proxy"] == "http://localhost/v1/sandboxes/1/proxy"
+    assert urls["web"] == "http://sandbox-sb123.sandbox.localhost"
+    assert urls["proxy"] == "http://localhost/v1/sandboxes/sb123/proxy"
 
 
 def test_build_urls_web_includes_port_for_dev_server(monkeypatch) -> None:
     monkeypatch.setattr("treadstone.api.sandboxes.settings", _fake_settings())
-    sb = SimpleNamespace(id="1", name="sbx")
+    sb = SimpleNamespace(id="sb123", name="sbx")
     urls = _build_urls(sb, "http://localhost:8000/")
-    assert urls["web"] == "http://sandbox-sbx.sandbox.localhost:8000"
+    assert urls["web"] == "http://sandbox-sb123.sandbox.localhost:8000"
 
 
 def test_build_urls_web_includes_port_for_port_forward(monkeypatch) -> None:
     monkeypatch.setattr("treadstone.api.sandboxes.settings", _fake_settings())
-    sb = SimpleNamespace(id="1", name="sbx")
+    sb = SimpleNamespace(id="sb123", name="sbx")
     urls = _build_urls(sb, "http://127.0.0.1:12345/")
-    assert urls["web"] == "http://sandbox-sbx.sandbox.localhost:12345"
+    assert urls["web"] == "http://sandbox-sb123.sandbox.localhost:12345"
 
 
 def test_build_urls_prod_domain(monkeypatch) -> None:
     monkeypatch.setattr("treadstone.api.sandboxes.settings", _fake_settings(sandbox_domain="treadstone-ai.dev"))
     sb = SimpleNamespace(id="sb123", name="my-project")
     urls = _build_urls(sb, "https://api.treadstone-ai.dev/")
-    assert urls["web"] == "https://sandbox-my-project.treadstone-ai.dev"
+    assert urls["web"] == "https://sandbox-sb123.treadstone-ai.dev"
     assert urls["proxy"] == "https://api.treadstone-ai.dev/v1/sandboxes/sb123/proxy"
 
 
 def test_build_urls_web_none_when_domain_empty(monkeypatch) -> None:
     monkeypatch.setattr("treadstone.api.sandboxes.settings", _fake_settings(sandbox_domain=""))
-    sb = SimpleNamespace(id="1", name="sbx")
+    sb = SimpleNamespace(id="sb123", name="sbx")
     urls = _build_urls(sb, "http://localhost/")
     assert urls["web"] is None

--- a/tests/unit/test_sandbox_model.py
+++ b/tests/unit/test_sandbox_model.py
@@ -7,7 +7,6 @@ def test_sandbox_status_enum():
     assert SandboxStatus.STOPPED == "stopped"
     assert SandboxStatus.ERROR == "error"
     assert SandboxStatus.DELETING == "deleting"
-    assert SandboxStatus.DELETED == "deleted"
 
 
 def test_sandbox_fields_exist():
@@ -34,7 +33,6 @@ def test_sandbox_fields_exist():
         "gmt_created",
         "gmt_started",
         "gmt_stopped",
-        "gmt_deleted",
     ]:
         assert hasattr(sb, field), f"Missing field: {field}"
 
@@ -57,10 +55,9 @@ def test_sandbox_tablename():
 VALID_TRANSITIONS: dict[str, list[str]] = {
     "creating": ["ready", "error", "deleting"],
     "ready": ["stopped", "error", "deleting"],
-    "stopped": ["ready", "deleting", "deleted"],
+    "stopped": ["ready", "deleting"],
     "error": ["stopped", "deleting"],
-    "deleting": ["deleted"],
-    "deleted": [],
+    "deleting": [],
 }
 
 
@@ -75,7 +72,6 @@ def test_is_valid_transition():
 
     assert is_valid_transition("creating", "ready") is True
     assert is_valid_transition("creating", "error") is True
-    assert is_valid_transition("creating", "deleted") is False
-    assert is_valid_transition("deleted", "ready") is False
+    assert is_valid_transition("creating", "stopped") is False
     assert is_valid_transition("deleting", "ready") is False
     assert is_valid_transition("ready", "deleting") is True

--- a/tests/unit/test_sandbox_name_rules.py
+++ b/tests/unit/test_sandbox_name_rules.py
@@ -12,7 +12,7 @@ def test_create_sandbox_schema_documents_name_rules() -> None:
 
     assert "1-55 characters" in name_schema["description"]
     assert "lowercase letters, numbers, or hyphens" in name_schema["description"]
-    assert "sandbox-{name}" in name_schema["description"]
+    assert "current user" in name_schema["description"].lower()
 
 
 def test_cli_source_documents_sandbox_name_rules() -> None:
@@ -21,4 +21,4 @@ def test_cli_source_documents_sandbox_name_rules() -> None:
     assert "1-55 characters" in source
     assert "lowercase letters" in source
     assert "numbers, or hyphens" in source
-    assert "sandbox-{name}" in source
+    assert "current user" in source.lower()

--- a/tests/unit/test_sandbox_service.py
+++ b/tests/unit/test_sandbox_service.py
@@ -20,8 +20,8 @@ def _make_sandbox(**overrides) -> Sandbox:
         "status": SandboxStatus.CREATING,
         "version": 1,
         "endpoints": {},
-        "k8s_sandbox_claim_name": "test-sandbox",
-        "k8s_sandbox_name": "test-sandbox",
+        "k8s_sandbox_claim_name": "sb1234567890abcdef",
+        "k8s_sandbox_name": "sb1234567890abcdef",
         "k8s_namespace": "treadstone-local",
     }
     defaults.update(overrides)
@@ -31,11 +31,16 @@ def _make_sandbox(**overrides) -> Sandbox:
     return sb
 
 
-def _mock_session(sandbox: Sandbox | None = None):
+def _mock_session(sandbox: Sandbox | None = None, *extra_scalars):
     session = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = sandbox
-    session.execute.return_value = mock_result
+    execute_results = [sandbox, *extra_scalars, None]
+
+    def _make_result(value):
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = value
+        return mock_result
+
+    session.execute.side_effect = [_make_result(value) for value in execute_results] or [_make_result(None)]
     session.get.return_value = sandbox
     session.add = MagicMock()
     session.commit = AsyncMock()
@@ -82,7 +87,8 @@ class TestSandboxServiceCreate:
         assert result.status == SandboxStatus.CREATING
         assert result.owner_id == "user1234567890abcd"
         assert result.template == "aio-sandbox-tiny"
-        assert result.k8s_sandbox_claim_name == "my-sandbox"
+        assert result.name == "my-sandbox"
+        assert result.k8s_sandbox_claim_name == result.id
         session.add.assert_called_once()
         session.commit.assert_called()
 
@@ -100,6 +106,7 @@ class TestSandboxServiceCreate:
 
         k8s.create_sandbox_claim.assert_called_once()
         call_kwargs = k8s.create_sandbox_claim.call_args
+        assert call_kwargs.kwargs["name"].startswith("sb")
         assert call_kwargs.kwargs["template_ref"] == "aio-sandbox-tiny"
 
 
@@ -150,10 +157,10 @@ class TestSandboxServiceDelete:
         assert sb.status == SandboxStatus.DELETING
         k8s.delete_sandbox_claim.assert_called_once()
 
-    async def test_delete_from_deleted_raises(self):
+    async def test_delete_from_deleting_raises(self):
         from treadstone.services.sandbox_service import SandboxService
 
-        sb = _make_sandbox(status=SandboxStatus.DELETED)
+        sb = _make_sandbox(status=SandboxStatus.DELETING)
         session = _mock_session(sb)
         service = SandboxService(session=session, k8s_client=_mock_k8s_client())
 
@@ -172,7 +179,7 @@ class TestSandboxServiceStartStop:
 
         result = await service.start(sandbox_id="sb1234567890abcdef", owner_id="user1234567890abcd")
         assert result.status == SandboxStatus.CREATING
-        k8s.scale_sandbox.assert_called_once_with(name="test-sandbox", namespace="treadstone-local", replicas=1)
+        k8s.scale_sandbox.assert_called_once_with(name="sb1234567890abcdef", namespace="treadstone-local", replicas=1)
 
     async def test_stop_calls_scale_sandbox_0(self):
         from treadstone.services.sandbox_service import SandboxService
@@ -184,7 +191,7 @@ class TestSandboxServiceStartStop:
 
         result = await service.stop(sandbox_id="sb1234567890abcdef", owner_id="user1234567890abcd")
         assert result.status == SandboxStatus.STOPPED
-        k8s.scale_sandbox.assert_called_once_with(name="test-sandbox", namespace="treadstone-local", replicas=0)
+        k8s.scale_sandbox.assert_called_once_with(name="sb1234567890abcdef", namespace="treadstone-local", replicas=0)
 
     async def test_start_from_ready_raises(self):
         from treadstone.services.sandbox_service import SandboxService

--- a/tests/unit/test_sandbox_subdomain.py
+++ b/tests/unit/test_sandbox_subdomain.py
@@ -1,52 +1,52 @@
 """Unit tests for sandbox subdomain extraction and auth-header stripping."""
 
-from treadstone.middleware.sandbox_subdomain import _strip_internal_auth, extract_sandbox_name
+from treadstone.middleware.sandbox_subdomain import _strip_internal_auth, extract_sandbox_id
 
 
-class TestExtractSandboxName:
-    """extract_sandbox_name recognises the ``sandbox-`` prefix and strips it."""
+class TestExtractSandboxId:
+    """extract_sandbox_id recognises the ``sandbox-`` prefix and strips it."""
 
     def test_valid_sandbox_subdomain(self):
-        assert extract_sandbox_name("sandbox-foobar.treadstone-ai.dev", "treadstone-ai.dev") == "foobar"
+        assert extract_sandbox_id("sandbox-foobar.treadstone-ai.dev", "treadstone-ai.dev") == "foobar"
 
     def test_valid_with_port(self):
-        assert extract_sandbox_name("sandbox-foobar.sandbox.localhost:8000", "sandbox.localhost") == "foobar"
+        assert extract_sandbox_id("sandbox-foobar.sandbox.localhost:8000", "sandbox.localhost") == "foobar"
 
     def test_case_insensitive(self):
-        assert extract_sandbox_name("Sandbox-Foobar.Sandbox.Localhost:8000", "sandbox.localhost") == "foobar"
+        assert extract_sandbox_id("Sandbox-Foobar.Sandbox.Localhost:8000", "sandbox.localhost") == "foobar"
 
     def test_hyphenated_name(self):
-        assert extract_sandbox_name("sandbox-my-cool-box.treadstone-ai.dev", "treadstone-ai.dev") == "my-cool-box"
+        assert extract_sandbox_id("sandbox-my-cool-box.treadstone-ai.dev", "treadstone-ai.dev") == "my-cool-box"
 
     def test_api_subdomain_ignored(self):
-        assert extract_sandbox_name("api.treadstone-ai.dev", "treadstone-ai.dev") is None
+        assert extract_sandbox_id("api.treadstone-ai.dev", "treadstone-ai.dev") is None
 
     def test_www_subdomain_ignored(self):
-        assert extract_sandbox_name("www.treadstone-ai.dev", "treadstone-ai.dev") is None
+        assert extract_sandbox_id("www.treadstone-ai.dev", "treadstone-ai.dev") is None
 
     def test_docs_subdomain_ignored(self):
-        assert extract_sandbox_name("docs.treadstone-ai.dev", "treadstone-ai.dev") is None
+        assert extract_sandbox_id("docs.treadstone-ai.dev", "treadstone-ai.dev") is None
 
     def test_demo_subdomain_ignored(self):
-        assert extract_sandbox_name("demo.treadstone-ai.dev", "treadstone-ai.dev") is None
+        assert extract_sandbox_id("demo.treadstone-ai.dev", "treadstone-ai.dev") is None
 
     def test_bare_prefix_no_name(self):
-        assert extract_sandbox_name("sandbox-.treadstone-ai.dev", "treadstone-ai.dev") is None
+        assert extract_sandbox_id("sandbox-.treadstone-ai.dev", "treadstone-ai.dev") is None
 
     def test_no_match_exact_domain(self):
-        assert extract_sandbox_name("treadstone-ai.dev", "treadstone-ai.dev") is None
+        assert extract_sandbox_id("treadstone-ai.dev", "treadstone-ai.dev") is None
 
     def test_no_match_different_domain(self):
-        assert extract_sandbox_name("sandbox-foo.other.dev", "treadstone-ai.dev") is None
+        assert extract_sandbox_id("sandbox-foo.other.dev", "treadstone-ai.dev") is None
 
     def test_no_match_nested_subdomain(self):
-        assert extract_sandbox_name("a.sandbox-foo.treadstone-ai.dev", "treadstone-ai.dev") is None
+        assert extract_sandbox_id("a.sandbox-foo.treadstone-ai.dev", "treadstone-ai.dev") is None
 
     def test_custom_prefix(self):
-        assert extract_sandbox_name("sb-test.sandbox.localhost:8000", "sandbox.localhost", prefix="sb-") == "test"
+        assert extract_sandbox_id("sb-test.sandbox.localhost:8000", "sandbox.localhost", prefix="sb-") == "test"
 
     def test_custom_prefix_no_match(self):
-        assert extract_sandbox_name("sandbox-foo.treadstone-ai.dev", "treadstone-ai.dev", prefix="sb-") is None
+        assert extract_sandbox_id("sandbox-foo.treadstone-ai.dev", "treadstone-ai.dev", prefix="sb-") is None
 
 
 class TestStripInternalAuth:

--- a/treadstone/api/auth.py
+++ b/treadstone/api/auth.py
@@ -84,7 +84,6 @@ async def _validate_owned_sandbox_ids(session: AsyncSession, owner_id: str, sand
         select(Sandbox.id).where(
             Sandbox.owner_id == owner_id,
             Sandbox.id.in_(deduped),
-            Sandbox.gmt_deleted.is_(None),
         )
     )
     owned_ids = result.scalars().all()

--- a/treadstone/api/browser.py
+++ b/treadstone/api/browser.py
@@ -20,7 +20,7 @@ from treadstone.services.browser_auth import issue_bootstrap_ticket
 router = APIRouter(prefix="/v1/browser", tags=["browser"])
 
 
-def _extract_sandbox_name(host: str) -> str | None:
+def _extract_sandbox_id(host: str) -> str | None:
     host_no_port = host.split(":")[0].lower()
     domain = settings.sandbox_domain.lower()
 
@@ -41,15 +41,15 @@ def _validate_return_to(return_to: str) -> tuple[str, str, str, str]:
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ValidationError("return_to must be an absolute sandbox Web UI URL.")
 
-    sandbox_name = _extract_sandbox_name(parsed.netloc)
-    if sandbox_name is None:
+    sandbox_id = _extract_sandbox_id(parsed.netloc)
+    if sandbox_id is None:
         raise ValidationError("return_to must target a sandbox subdomain.")
 
     next_path = parsed.path or "/"
     if parsed.query:
         next_path = f"{next_path}?{parsed.query}"
 
-    return parsed.scheme, parsed.netloc, sandbox_name, next_path
+    return parsed.scheme, parsed.netloc, sandbox_id, next_path
 
 
 def _render_login_page(return_to: str, error: str | None = None, status_code: int = 200) -> HTMLResponse:
@@ -114,7 +114,7 @@ async def browser_bootstrap(
     current_user: User | None = Depends(optional_cookie_user),
     session: AsyncSession = Depends(get_session),
 ):
-    scheme, host, sandbox_name, next_path = _validate_return_to(return_to)
+    scheme, host, sandbox_id, next_path = _validate_return_to(return_to)
 
     if current_user is None:
         return RedirectResponse(
@@ -124,14 +124,13 @@ async def browser_bootstrap(
 
     result = await session.execute(
         select(Sandbox).where(
-            Sandbox.name == sandbox_name,
+            Sandbox.id == sandbox_id,
             Sandbox.owner_id == current_user.id,
-            Sandbox.gmt_deleted.is_(None),
         )
     )
     sandbox = result.scalar_one_or_none()
     if sandbox is None:
-        raise NotFoundError("Sandbox", sandbox_name)
+        raise NotFoundError("Sandbox", sandbox_id)
 
     ticket = issue_bootstrap_ticket(sandbox_id=sandbox.id, next_path=next_path)
     redirect_to = f"{scheme}://{host}/_treadstone/open?{urlencode({'ticket': ticket, 'next': next_path})}"

--- a/treadstone/api/sandbox_proxy.py
+++ b/treadstone/api/sandbox_proxy.py
@@ -51,7 +51,10 @@ async def http_proxy(
 
     headers = dict(request.headers)
     try:
-        routing = resolve_routing(headers, path_sandbox_id=sandbox.k8s_sandbox_name or sandbox.name)
+        routing = resolve_routing(
+            headers,
+            path_sandbox_id=sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.id,
+        )
     except ValueError as exc:
         raise ValidationError(str(exc)) from exc
 

--- a/treadstone/api/sandboxes.py
+++ b/treadstone/api/sandboxes.py
@@ -56,7 +56,7 @@ def _build_canonical_web_url(sb, base_url: str) -> str | None:
         scheme = parsed.scheme
     else:
         scheme = "https" if base.startswith("https") else "http"
-    return f"{scheme}://{settings.sandbox_subdomain_prefix}{sb.name}.{settings.sandbox_domain}{_web_port_suffix(base)}"
+    return f"{scheme}://{settings.sandbox_subdomain_prefix}{sb.id}.{settings.sandbox_domain}{_web_port_suffix(base)}"
 
 
 def _build_urls(sb, base_url: str, web_link: SandboxWebLink | None = None) -> dict:

--- a/treadstone/api/schemas.py
+++ b/treadstone/api/schemas.py
@@ -21,9 +21,7 @@ SANDBOX_NAME_RULE = (
     "and must start and end with a letter or number."
 )
 SANDBOX_NAME_DESCRIPTION = (
-    "Optional custom sandbox name. "
-    f"{SANDBOX_NAME_RULE} "
-    "This keeps browser URLs like `sandbox-{name}.treadstone-ai.dev` within DNS label limits."
+    f"Optional custom sandbox name. {SANDBOX_NAME_RULE} Sandbox names only need to be unique for the current user."
 )
 STORAGE_SIZE_PATTERN = re.compile(r"^[1-9]\d*(?:Ei|Pi|Ti|Gi|Mi|Ki)$")
 STORAGE_SIZE_RULE = "storage_size must be a valid Kubernetes quantity like 5Gi, 500Mi, or 1Ti."
@@ -94,7 +92,7 @@ class SandboxUrls(BaseModel):
     proxy: str = Field(..., examples=["http://localhost:8000/v1/sandboxes/sb-abc123def456/proxy"])
     web: str | None = Field(
         default=None,
-        examples=["http://sandbox-my-sandbox.sandbox.localhost:8000/_treadstone/open?token=swlabc123"],
+        examples=["http://sandbox-sbabc123def456.sandbox.localhost:8000/_treadstone/open?token=swlabc123"],
         description=(
             "Recommended browser entry URL. When a sandbox web link is enabled, this is the shareable hand-off URL."
         ),
@@ -136,13 +134,16 @@ class SandboxListResponse(BaseModel):
 
 
 class SandboxWebLinkResponse(BaseModel):
-    web_url: str = Field(..., examples=["https://sandbox-demo.treadstone-ai.dev/"])
-    open_link: str = Field(..., examples=["https://sandbox-demo.treadstone-ai.dev/_treadstone/open?token=swlabc123"])
+    web_url: str = Field(..., examples=["https://sandbox-sbabc123def456.treadstone-ai.dev/"])
+    open_link: str = Field(
+        ...,
+        examples=["https://sandbox-sbabc123def456.treadstone-ai.dev/_treadstone/open?token=swlabc123"],
+    )
     expires_at: datetime = Field(..., examples=["2026-03-31T12:00:00+00:00"])
 
 
 class SandboxWebLinkStatusResponse(BaseModel):
-    web_url: str = Field(..., examples=["https://sandbox-demo.treadstone-ai.dev/"])
+    web_url: str = Field(..., examples=["https://sandbox-sbabc123def456.treadstone-ai.dev/"])
     enabled: bool = Field(..., examples=[True])
     expires_at: datetime | None = Field(default=None, examples=["2026-03-31T12:00:00+00:00"])
     last_used_at: datetime | None = Field(default=None, examples=[None])

--- a/treadstone/config.py
+++ b/treadstone/config.py
@@ -49,8 +49,8 @@ class Settings(BaseSettings):
     pod_namespace: str = ""
 
     # Subdomain-based sandbox routing (for browser Web UI access)
-    # Dev: "sandbox.localhost"  →  sandbox-{name}.sandbox.localhost[:port]
-    # Prod: "treadstone-ai.dev" →  sandbox-{name}.treadstone-ai.dev
+    # Dev: "sandbox.localhost"  →  sandbox-{sandbox_id}.sandbox.localhost[:port]
+    # Prod: "treadstone-ai.dev" →  sandbox-{sandbox_id}.treadstone-ai.dev
     # Empty string disables subdomain routing.
     sandbox_domain: str = ""
 

--- a/treadstone/core/errors.py
+++ b/treadstone/core/errors.py
@@ -82,7 +82,7 @@ class SandboxNameConflictError(TreadstoneError):
     def __init__(self, name: str):
         super().__init__(
             code="sandbox_name_conflict",
-            message=f"A sandbox named '{name}' already exists.",
+            message=f"A sandbox named '{name}' already exists for the current user.",
             status=409,
         )
 

--- a/treadstone/middleware/sandbox_subdomain.py
+++ b/treadstone/middleware/sandbox_subdomain.py
@@ -2,7 +2,7 @@
 ASGI middleware for authenticated subdomain-based sandbox routing.
 
 When sandbox_domain is configured (e.g. "treadstone-ai.dev"), requests to
-  sandbox-{name}.treadstone-ai.dev
+  sandbox-{sandbox_id}.treadstone-ai.dev
 are authenticated at the edge and then transparently proxied to the
 corresponding sandbox pod, supporting both HTTP and WebSocket.
 """
@@ -42,7 +42,7 @@ from treadstone.services.sandbox_proxy import (
 logger = logging.getLogger(__name__)
 
 
-def extract_sandbox_name(host: str, sandbox_domain: str, prefix: str = "sandbox-") -> str | None:
+def extract_sandbox_id(host: str, sandbox_domain: str, prefix: str = "sandbox-") -> str | None:
     host_no_port = host.split(":")[0].lower()
     domain = sandbox_domain.lower()
 
@@ -54,8 +54,8 @@ def extract_sandbox_name(host: str, sandbox_domain: str, prefix: str = "sandbox-
         return None
     if not subdomain.startswith(prefix):
         return None
-    name = subdomain[len(prefix) :]
-    return name if name else None
+    sandbox_id = subdomain[len(prefix) :]
+    return sandbox_id if sandbox_id else None
 
 
 def _request_scheme(scope: Scope) -> str:
@@ -110,17 +110,17 @@ class SandboxSubdomainMiddleware:
             return
 
         host = self._get_host(scope)
-        sandbox_name = (
-            extract_sandbox_name(host, settings.sandbox_domain, settings.sandbox_subdomain_prefix) if host else None
+        sandbox_id = (
+            extract_sandbox_id(host, settings.sandbox_domain, settings.sandbox_subdomain_prefix) if host else None
         )
-        if sandbox_name is None:
+        if sandbox_id is None:
             await self.app(scope, receive, send)
             return
 
         if scope["type"] == "http":
-            await self._handle_http(scope, receive, send, sandbox_name, host)
+            await self._handle_http(scope, receive, send, sandbox_id, host)
         else:
-            await self._handle_websocket(scope, receive, send, sandbox_name)
+            await self._handle_websocket(scope, receive, send, sandbox_id)
 
     @staticmethod
     def _get_host(scope: Scope) -> str | None:
@@ -129,11 +129,9 @@ class SandboxSubdomainMiddleware:
                 return value.decode("latin-1")
         return None
 
-    async def _load_sandbox(self, sandbox_name: str) -> Sandbox | None:
+    async def _load_sandbox(self, sandbox_id: str) -> Sandbox | None:
         async with async_session() as session:
-            result = await session.execute(
-                select(Sandbox).where(Sandbox.name == sandbox_name, Sandbox.gmt_deleted.is_(None))
-            )
+            result = await session.execute(select(Sandbox).where(Sandbox.id == sandbox_id))
             return result.scalar_one_or_none()
 
     def _build_return_to(self, scope: Scope, host: str) -> str:
@@ -212,7 +210,10 @@ class SandboxSubdomainMiddleware:
         body = b"".join(body_parts)
 
         full_path = f"{path}?{query_string}" if query_string else path
-        target_url = build_sandbox_url(sandbox.k8s_sandbox_name or sandbox.name, full_path)
+        target_url = build_sandbox_url(
+            sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.id,
+            full_path,
+        )
         logger.info("Subdomain proxy %s %s → %s", request.method, sandbox.name, target_url)
 
         client = await get_http_client()
@@ -234,9 +235,9 @@ class SandboxSubdomainMiddleware:
         )
         await streaming(scope, receive, send)
 
-    async def _handle_http(self, scope: Scope, receive: Receive, send: Send, sandbox_name: str, host: str) -> None:
+    async def _handle_http(self, scope: Scope, receive: Receive, send: Send, sandbox_id: str, host: str) -> None:
         request = Request(scope, receive)
-        sandbox = await self._load_sandbox(sandbox_name)
+        sandbox = await self._load_sandbox(sandbox_id)
         if sandbox is None:
             error_resp = Response("Sandbox not found.", status_code=404)
             await error_resp(scope, receive, send)
@@ -261,8 +262,8 @@ class SandboxSubdomainMiddleware:
 
         await self._proxy_http(request, scope, receive, send, sandbox)
 
-    async def _handle_websocket(self, scope: Scope, receive: Receive, send: Send, sandbox_name: str) -> None:
-        sandbox = await self._load_sandbox(sandbox_name)
+    async def _handle_websocket(self, scope: Scope, receive: Receive, send: Send, sandbox_id: str) -> None:
+        sandbox = await self._load_sandbox(sandbox_id)
         if sandbox is None or sandbox.status != SandboxStatus.READY.value:
             websocket = WebSocket(scope, receive, send)
             await websocket.close(code=1008)
@@ -285,7 +286,7 @@ class SandboxSubdomainMiddleware:
         try:
             await proxy_websocket(
                 client_ws=websocket,
-                sandbox_id=sandbox.k8s_sandbox_name or sandbox.name,
+                sandbox_id=sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.id,
                 path=path,
             )
         except Exception:

--- a/treadstone/models/sandbox.py
+++ b/treadstone/models/sandbox.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import StrEnum
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -15,16 +15,14 @@ class SandboxStatus(StrEnum):
     STOPPED = "stopped"
     ERROR = "error"
     DELETING = "deleting"
-    DELETED = "deleted"
 
 
 VALID_TRANSITIONS: dict[str, list[str]] = {
     SandboxStatus.CREATING: [SandboxStatus.READY, SandboxStatus.ERROR, SandboxStatus.DELETING],
     SandboxStatus.READY: [SandboxStatus.STOPPED, SandboxStatus.ERROR, SandboxStatus.DELETING],
-    SandboxStatus.STOPPED: [SandboxStatus.READY, SandboxStatus.DELETING, SandboxStatus.DELETED],
+    SandboxStatus.STOPPED: [SandboxStatus.READY, SandboxStatus.DELETING],
     SandboxStatus.ERROR: [SandboxStatus.STOPPED, SandboxStatus.DELETING],
-    SandboxStatus.DELETING: [SandboxStatus.DELETED],
-    SandboxStatus.DELETED: [],
+    SandboxStatus.DELETING: [],
 }
 
 
@@ -34,9 +32,10 @@ def is_valid_transition(from_status: str, to_status: str) -> bool:
 
 class Sandbox(Base):
     __tablename__ = "sandbox"
+    __table_args__ = (UniqueConstraint("owner_id", "name", name="uq_sandbox_owner_name"),)
 
     id: Mapped[str] = mapped_column(String(24), primary_key=True, default=lambda: "sb" + random_id())
-    name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     owner_id: Mapped[str] = mapped_column(
         String(24), ForeignKey("user.id", ondelete="cascade"), nullable=False, index=True
     )
@@ -70,4 +69,3 @@ class Sandbox(Base):
     gmt_created: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
     gmt_started: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     gmt_stopped: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    gmt_deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/treadstone/services/k8s_sync.py
+++ b/treadstone/services/k8s_sync.py
@@ -97,14 +97,14 @@ async def handle_watch_event(
 
         if event_type == "DELETED":
             if sandbox.status == SandboxStatus.DELETING:
-                target_status = SandboxStatus.DELETED
+                await _delete_sandbox_row(session, sandbox.id)
             else:
                 logger.warning("Unexpected DELETED event for %s (status=%s), marking error", sandbox.id, sandbox.status)
-                target_status = SandboxStatus.ERROR
-
-            rows = await _optimistic_update(session, sandbox.id, sandbox.version, target_status, resource_version=cr_rv)
-            if rows == 0:
-                logger.debug("Optimistic lock conflict for %s, skipping", sandbox.id)
+                rows = await _optimistic_update(
+                    session, sandbox.id, sandbox.version, SandboxStatus.ERROR, resource_version=cr_rv
+                )
+                if rows == 0:
+                    logger.debug("Optimistic lock conflict for %s, skipping", sandbox.id)
             return
 
         if event_type in ("ADDED", "MODIFIED"):
@@ -167,18 +167,16 @@ async def reconcile(
             cr_map[name] = cr
 
     async with session_factory() as session:
-        result = await session.execute(
-            select(Sandbox).where(Sandbox.status != SandboxStatus.DELETED, Sandbox.k8s_namespace == namespace)
-        )
+        result = await session.execute(select(Sandbox).where(Sandbox.k8s_namespace == namespace))
         sandboxes = result.scalars().all()
 
         for sandbox in sandboxes:
-            cr_key = sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.name
+            cr_key = sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.id
             cr = cr_map.pop(cr_key, None)
 
             if cr is None:
                 if sandbox.status == SandboxStatus.DELETING:
-                    await _optimistic_update(session, sandbox.id, sandbox.version, SandboxStatus.DELETED)
+                    await _delete_sandbox_row(session, sandbox.id)
                 elif sandbox.status != SandboxStatus.CREATING:
                     logger.warning("CR missing for %s (status=%s), marking error", sandbox.id, sandbox.status)
                     await _optimistic_update(session, sandbox.id, sandbox.version, SandboxStatus.ERROR)
@@ -296,9 +294,6 @@ async def _optimistic_update(
         values["gmt_started"] = now
     elif new_status == SandboxStatus.STOPPED:
         values["gmt_stopped"] = now
-    elif new_status == SandboxStatus.DELETED:
-        values["gmt_deleted"] = now
-
     result = await session.execute(
         update(Sandbox).where(Sandbox.id == sandbox_id, Sandbox.version == expected_version).values(**values)
     )
@@ -314,4 +309,12 @@ async def _update_sync_metadata(
     if message is not None:
         values["status_message"] = message
     await session.execute(update(Sandbox).where(Sandbox.id == sandbox_id).values(**values))
+    await session.commit()
+
+
+async def _delete_sandbox_row(session: AsyncSession, sandbox_id: str) -> None:
+    sandbox = await session.get(Sandbox, sandbox_id)
+    if sandbox is None:
+        return
+    await session.delete(sandbox)
     await session.commit()

--- a/treadstone/services/sandbox_service.py
+++ b/treadstone/services/sandbox_service.py
@@ -21,6 +21,7 @@ from treadstone.core.errors import (
     TemplateNotFoundError,
 )
 from treadstone.models.sandbox import Sandbox, SandboxStatus, is_valid_transition
+from treadstone.models.sandbox_web_link import SandboxWebLink
 from treadstone.models.user import random_id, utc_now
 from treadstone.services.k8s_client import K8sClientProtocol, get_k8s_client
 
@@ -83,10 +84,10 @@ class SandboxService:
 
         if persist:
             sandbox.provision_mode = "direct"
-            sandbox.k8s_sandbox_name = sandbox_name
+            sandbox.k8s_sandbox_name = sandbox_id
         else:
             sandbox.provision_mode = "claim"
-            sandbox.k8s_sandbox_claim_name = sandbox_name
+            sandbox.k8s_sandbox_claim_name = sandbox_id
 
         self.session.add(sandbox)
         try:
@@ -125,9 +126,10 @@ class SandboxService:
     async def _create_via_claim(self, sandbox: Sandbox, template: str) -> None:
         await self._resolve_template(sandbox.k8s_namespace, template)
 
-        logger.info("Creating SandboxClaim %s (template=%s, ns=%s)", sandbox.name, template, sandbox.k8s_namespace)
+        claim_name = sandbox.k8s_sandbox_claim_name or sandbox.id
+        logger.info("Creating SandboxClaim %s (template=%s, ns=%s)", claim_name, template, sandbox.k8s_namespace)
         await self.k8s.create_sandbox_claim(
-            name=sandbox.name,
+            name=claim_name,
             template_ref=template,
             namespace=sandbox.k8s_namespace,
         )
@@ -154,11 +156,12 @@ class SandboxService:
             }
         ]
 
+        k8s_name = sandbox.k8s_sandbox_name or sandbox.id
         logger.info(
-            "Creating Sandbox CR %s (template=%s, persist=true, ns=%s)", sandbox.name, template, sandbox.k8s_namespace
+            "Creating Sandbox CR %s (template=%s, persist=true, ns=%s)", k8s_name, template, sandbox.k8s_namespace
         )
         await self.k8s.create_sandbox(
-            name=sandbox.name,
+            name=k8s_name,
             namespace=sandbox.k8s_namespace,
             image=image,
             container_port=settings.sandbox_port,
@@ -173,10 +176,7 @@ class SandboxService:
         return result.scalar_one_or_none()
 
     async def list_by_owner(self, owner_id: str, labels: dict | None = None) -> list[Sandbox]:
-        stmt = select(Sandbox).where(
-            Sandbox.owner_id == owner_id,
-            Sandbox.status != SandboxStatus.DELETED,
-        )
+        stmt = select(Sandbox).where(Sandbox.owner_id == owner_id)
         result = await self.session.execute(stmt)
         sandboxes = list(result.scalars().all())
 
@@ -196,15 +196,27 @@ class SandboxService:
         sandbox.status = SandboxStatus.DELETING
         sandbox.version += 1
         self.session.add(sandbox)
+
+        link_result = await self.session.execute(
+            select(SandboxWebLink).where(
+                SandboxWebLink.sandbox_id == sandbox.id,
+                SandboxWebLink.gmt_deleted.is_(None),
+            )
+        )
+        link = link_result.scalar_one_or_none()
+        if link is not None:
+            link.gmt_deleted = utc_now()
+            link.gmt_updated = utc_now()
+            self.session.add(link)
         await self.session.commit()
 
         try:
             if sandbox.provision_mode == "direct":
-                sb_name = sandbox.k8s_sandbox_name or sandbox.name
+                sb_name = sandbox.k8s_sandbox_name or sandbox.id
                 logger.info("Deleting Sandbox CR %s (ns=%s)", sb_name, sandbox.k8s_namespace)
                 await self.k8s.delete_sandbox(name=sb_name, namespace=sandbox.k8s_namespace)
             else:
-                claim_name = sandbox.k8s_sandbox_claim_name or sandbox.name
+                claim_name = sandbox.k8s_sandbox_claim_name or sandbox.id
                 logger.info("Deleting SandboxClaim %s (ns=%s)", claim_name, sandbox.k8s_namespace)
                 await self.k8s.delete_sandbox_claim(name=claim_name, namespace=sandbox.k8s_namespace)
         except Exception:
@@ -229,7 +241,7 @@ class SandboxService:
         self.session.add(sandbox)
         await self.session.commit()
 
-        k8s_name = sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.name
+        k8s_name = sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.id
         try:
             logger.info("Scaling sandbox %s to replicas=1 (ns=%s)", k8s_name, sandbox.k8s_namespace)
             await self.k8s.scale_sandbox(name=k8s_name, namespace=sandbox.k8s_namespace, replicas=1)
@@ -257,7 +269,7 @@ class SandboxService:
         self.session.add(sandbox)
         await self.session.commit()
 
-        k8s_name = sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.name
+        k8s_name = sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.id
         try:
             logger.info("Scaling sandbox %s to replicas=0 (ns=%s)", k8s_name, sandbox.k8s_namespace)
             await self.k8s.scale_sandbox(name=k8s_name, namespace=sandbox.k8s_namespace, replicas=0)


### PR DESCRIPTION
## Summary
- Sandbox names are unique **per owner** (model + Alembic migration `9f8b8c4d6e21_scope_sandbox_names_and_hard_delete`).
- **Soft delete removed**: dropped `gmt_deleted`, dropped `SandboxStatus.DELETED`; keep `DELETING`, then **physically delete** the row when K8s confirms removal.
- Runtime / web / K8s naming uses **sandbox id** instead of name (`sandbox_service`, `k8s_sync`, API routes, `browser`, `sandbox_subdomain`, `sandbox_proxy`).
- Delete **revokes active web links** immediately before K8s deletion starts.
- Owner-scoped conflict message: *A sandbox named 'foo' already exists for the current user.*
- CLI, OpenAPI schemas, and SDK copy updated for per-user name uniqueness.

## Migration
- Migration clears existing auth/sandbox data before schema changes (prelaunch assumption). No archive table.

## Test plan
- [x] `uv run pytest -q` (239 passed, 6 deselected)
- [x] `make lint`
- [x] `make gen-openapi`
- [x] `make gen-sdk` (SDK `pyproject.toml` version restored to `0.3.8` after generation)

## Follow-ups (optional)
- Patch SDK generation so it does not reset SDK version.
- After `make up`, run `make test-e2e` against the cluster.

Closes #68 (if applicable).

Made with [Cursor](https://cursor.com)