### PR TITLE
docs: refresh README and agent docs; clarify release install sections

### DIFF
--- a/.agents/skills/database-migration/SKILL.md
+++ b/.agents/skills/database-migration/SKILL.md
@@ -5,10 +5,10 @@ description: Database model design and Alembic migration workflow for Treadstone
 
 # Database Model & Migration Workflow
 
-All schema changes flow through this pipeline — never modify a production database by hand:
+All schema changes flow through this pipeline — never modify a shared database by hand:
 
 ```
-SQLAlchemy model → Alembic autogenerate → review migration → apply to test branch → verify → apply to production
+SQLAlchemy model → Alembic autogenerate → review migration → apply to test branch → verify → apply to target environment
 ```
 
 Quick reference:
@@ -105,6 +105,14 @@ If you skip this, `alembic revision --autogenerate` generates an empty migration
 
 ## Step 3: Write a Test for the Model
 
+Prefer the smallest test that proves the schema change matters:
+
+- `tests/unit/` for model shape / helper logic
+- `tests/integration/` for real DB constraints, indexes, and query behavior
+- `tests/api/` when the schema change is surfaced through an API contract
+
+A lightweight unit test is the minimum; use integration coverage when the migration changes persistence behavior.
+
 ```python
 # tests/unit/test_example_model.py
 from treadstone.models.example import Example
@@ -154,7 +162,7 @@ Open the generated file in `alembic/versions/` and verify:
 Never migrate production directly. Neon branches are instant, copy-on-write clones — use one as a staging environment.
 
 ```
-Production (main branch)
+Shared branch / environment
     └── Test branch (fork, apply migration here first)
 ```
 
@@ -163,15 +171,16 @@ Production (main branch)
    ```bash
    TREADSTONE_DATABASE_URL="<test-branch-url>" make migrate
    ```
-3. Run integration tests:
+3. Run the most relevant verification:
    ```bash
-   make test-all
+   make test-integration
    ```
-4. If tests pass, apply to production:
+   If the change also affects API or unit behavior, run `make test-all`.
+4. If tests pass, apply to the shared target branch / environment:
    ```bash
-   make migrate   # with .env pointing to production
+   make migrate
    ```
-5. If tests fail, fix and retry. Use `make downgrade` or reset the branch via Neon Console.
+5. If tests fail, fix and retry. Use `make downgrade` or reset the Neon branch from its parent.
 
 ---
 
@@ -203,9 +212,10 @@ To reset a Neon test branch entirely, use the Neon Console "Reset from parent" f
 - [ ] Model defined in `treadstone/models/<name>.py` with type hints
 - [ ] Model imported in `treadstone/models/__init__.py`
 - [ ] Unit test written and passing
+- [ ] Integration/API coverage added when the schema change affects real DB behavior
 - [ ] Migration generated with `make migration MSG="..."`
 - [ ] Migration file reviewed manually
 - [ ] Migration applied to Neon test branch
-- [ ] Integration tests passing (`make test-all`)
-- [ ] Migration applied to production
+- [ ] Relevant verification passing (`make test-integration` or `make test-all`)
+- [ ] Migration applied to the target shared environment
 - [ ] Committed together: model + migration + tests

--- a/.agents/skills/dev-lifecycle/SKILL.md
+++ b/.agents/skills/dev-lifecycle/SKILL.md
@@ -24,7 +24,7 @@ Branch naming: `feat/`, `fix/`, `chore/`, `refactor/`, `docs/`, `test/`.
 
 ## Step 2: TDD Cycle
 
-Repeat per unit of work — keep iterations small.
+Repeat per unit of work — keep iterations small. For docs-only changes, do not invent fake tests; instead verify examples against the source of truth (`Makefile`, CLI help, workflows, or code) and run lightweight checks such as `git diff --check`.
 
 1. **Write a failing test** in the appropriate directory (`tests/unit/`, `tests/api/`, or `tests/integration/`). See the Testing section in `AGENTS.md` for which directory to use.
 
@@ -41,6 +41,15 @@ Repeat per unit of work — keep iterations small.
    ```
 
 5. **Refactor** if needed, re-run `make test` to confirm nothing broke.
+
+### Docs-Only Changes
+
+For `README.md`, `AGENTS.md`, `.agents/skills/*/SKILL.md`, or similar documentation-only work:
+
+- Still use a feature branch and PR
+- Prefer `docs:` commit messages
+- Validate commands and paths against the current repo before editing
+- Run `git diff --check` before shipping
 
 ## Step 3: Ship to Feature Branch
 

--- a/.agents/skills/dev-setup/SKILL.md
+++ b/.agents/skills/dev-setup/SKILL.md
@@ -41,20 +41,34 @@ This runs `uv sync` (creates `.venv`, installs all deps) and configures git hook
 
 The project uses [Neon](https://neon.tech) Serverless PostgreSQL — no local Postgres needed.
 
-Get the connection string from https://console.neon.tech, then:
+For local API development (`make dev`), start from:
 
 ```bash
 cp .env.example .env
 ```
 
-Edit `.env` and set the connection string in asyncpg format:
+Edit `.env` and set at least:
 
 ```
 TREADSTONE_DATABASE_URL=postgresql+asyncpg://neondb_owner:xxx@ep-xxx.ap-southeast-1.aws.neon.tech/neondb?sslmode=require
-TREADSTONE_DEBUG=true
+TREADSTONE_JWT_SECRET=CHANGE_ME
 ```
 
 The URL scheme must be `postgresql+asyncpg://` (not `postgresql://`). Keep `?sslmode=require`.
+
+For local Kubernetes deployment (`make up`), also prepare:
+
+```bash
+cp .env.example .env.local
+```
+
+Then set:
+
+```
+TREADSTONE_DATABASE_URL=postgresql+asyncpg://...
+TREADSTONE_JWT_SECRET=CHANGE_ME
+TREADSTONE_LEADER_ELECTION_ENABLED=true
+```
 
 ## 4. Apply Database Migrations
 
@@ -72,6 +86,14 @@ make test
 
 Expected: all tests pass (integration tests are excluded by default). If tests pass, the environment is ready.
 
+Optional API sanity check:
+
+```bash
+make dev
+# In another terminal:
+curl http://localhost:8000/health
+```
+
 ## 6. Local K8s Cluster (Sandbox Development)
 
 For sandbox-related features that require a real Kubernetes cluster, follow `deploy/README.md` — it covers Kind cluster creation, image building, Helm deployment, and smoke testing end-to-end.
@@ -80,6 +102,7 @@ Quick start:
 
 ```bash
 make up   # One-command: Kind cluster + build + deploy
+make test-e2e
 ```
 
 Pure API development (`make dev`) does not require a K8s cluster.
@@ -100,3 +123,8 @@ Pure API development (`make dev`) does not require a K8s cluster.
 **`alembic upgrade head` reports `authentication failed`:**
 - Confirm `.env` exists in the project root
 - URL-encode special characters in the password
+
+**`make up` fails before app startup:**
+- Confirm `.env.local` exists
+- Confirm `TREADSTONE_JWT_SECRET` is set
+- Confirm `TREADSTONE_LEADER_ELECTION_ENABLED=true` for the K8s environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,27 +217,30 @@ jobs:
             echo ""
             echo "## Install"
             echo ""
-            echo "**macOS / Linux — one-liner:**"
+            echo "Use the release installer script if you want the simplest path."
+            echo "It selects the right binary for your platform and verifies checksums when available."
+            echo ""
+            echo "**macOS / Linux**"
             echo '```bash'
             echo "curl -fsSL https://github.com/${{ github.repository }}/releases/download/v$VERSION/install.sh | sh"
             echo '```'
             echo ""
-            echo "**Windows — PowerShell:**"
+            echo "**Windows PowerShell**"
             echo '```powershell'
             echo "irm https://github.com/${{ github.repository }}/releases/download/v$VERSION/install.ps1 | iex"
             echo '```'
             echo ""
-            echo "**pip:**"
+            echo "**Alternative: PyPI**"
             echo '```bash'
             echo "pip install treadstone-cli==$VERSION"
             echo '```'
             echo ""
-            echo "**Docker:**"
+            echo "**Docker image**"
             echo '```bash'
             echo "docker pull ghcr.io/${{ github.repository_owner }}/treadstone:$VERSION"
             echo '```'
             echo ""
-            echo "**Manual download:**"
+            echo "**Manual binary download**"
             echo '```bash'
             echo "# macOS (Apple Silicon)"
             echo "curl -fsSL https://github.com/${{ github.repository }}/releases/download/v$VERSION/treadstone-darwin-arm64 -o treadstone && chmod +x treadstone"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,19 @@
 # Treadstone
 
-Agent-native sandbox service. Run code, build projects, deploy environments — via CLI, SDK, or REST API. Open source and self-hostable.
+Agent-native sandbox platform for AI agents. Run code, build projects, deploy environments, and hand off browser sessions via CLI, SDK, or REST API. Open source and self-hostable.
+
+## Start Here
+
+Use the matching local skill before you act:
+
+| If you need to... | Use |
+|-------|-------------|
+| Set up this repo for the first time | `dev-setup` |
+| Make any shippable change | `dev-lifecycle` |
+| Add or change SQLAlchemy models / Alembic migrations | `database-migration` |
+| Answer Neon-specific questions or plan Neon usage | `neon-postgres` |
+
+Skills live under `.agents/skills/*/SKILL.md`. AGENTS.md defines repo facts and guardrails; skills define procedures.
 
 ## Tech Stack
 
@@ -27,16 +40,18 @@ cli/               # CLI package (standalone, published as treadstone-cli)
   treadstone_cli/  # CLI source (click + httpx + rich)
 sdk/python/        # Python SDK (published as treadstone-sdk)
 tests/             # pytest test suites
+  api/             # FastAPI route tests via ASGITransport
+  unit/            # Pure logic / model / helper tests
+  integration/     # Real DB tests, excluded by default
   e2e/             # Hurl E2E tests (run against deployed cluster)
 alembic/           # Database migrations
 deploy/            # Helm charts, Kind config, K8s manifests
 docs/              # Design docs and plans (zh-CN)
+scripts/           # Helper scripts (release, install, deploy, E2E)
 .agents/skills/    # AI Agent reusable skills
 ```
 
 ## Skills
-
-Skills provide step-by-step operational guides. AGENTS.md defines rules and conventions; skills define procedures.
 
 | Skill | When to use |
 |-------|-------------|
@@ -51,6 +66,7 @@ For K8s deployment (Kind cluster, Helm, smoke tests), see [`deploy/README.md`](d
 
 - All code comments and commit messages in English. Docs default to Chinese in `docs/zh-CN/`.
 - **All GitHub-public content must be in English**: commit messages, PR titles/bodies, Issue titles/bodies, review comments, release notes.
+- Root-facing docs such as `README.md`, `AGENTS.md`, and `.agents/skills/*/SKILL.md` should stay concise and easy for both humans and agents to scan.
 - Async everywhere: all DB operations, HTTP calls, and API handlers must be async.
 - TDD: write a failing test first, implement, verify it passes.
 - DRY, YAGNI: no premature abstraction.
@@ -80,6 +96,7 @@ Rules:
 - SQLAlchemy async engine + asyncpg driver.
 - Alembic migrations (Alembic uses a sync URL — `env.py` strips `+asyncpg` automatically).
 - All connection strings must include `?sslmode=require`.
+- For local `make dev`, use `.env`. For Kubernetes deployment, use `.env.<ENV>` such as `.env.local`.
 - For model design conventions and the migration workflow, see the `database-migration` skill.
 
 ## Testing
@@ -93,6 +110,7 @@ Rules:
   - `tests/integration/` — requires real DB, marked `@pytest.mark.integration`, excluded by default
   - `tests/e2e/*.hurl` — E2E tests against a deployed cluster, written in [Hurl](https://hurl.dev) (run with `make test-e2e`)
 - Shared fixtures live in `tests/conftest.py`.
+- `make test` excludes integration tests via pytest config; use `make test-integration` or `make test-all` when real DB coverage is needed.
 - After `make up`, run `make test-e2e` to validate the deployment. Prefer this over manual curl exploration.
 
 ## OpenAPI / SDK Generation
@@ -111,14 +129,16 @@ Rules:
 
 ## Release
 
-- **Process:** On `main`, run `make release V=x.y.z` (e.g. `make release V=0.1.4`). This creates and pushes tag `vx.y.z`, which triggers [`.github/workflows/release.yml`](.github/workflows/release.yml): Docker → GHCR, `treadstone` + `treadstone-sdk` → PyPI, CLI binaries + GitHub Release assets. Watch with `gh run watch` or the Actions tab.
+- **Process:** On `main`, run `make release V=x.y.z` (e.g. `make release V=0.1.4`). This creates and pushes tag `vx.y.z`, which triggers [`.github/workflows/release.yml`](.github/workflows/release.yml): Docker image → GHCR, `treadstone-cli` + `treadstone-sdk` → PyPI, CLI binaries + install scripts → GitHub Release assets. Watch with `gh run watch` or the Actions tab.
 - **Agents:** Prefer **`make release V=…`** for tagging and publishing. Do not hand-craft `git tag` / `git push origin v…` or `gh release create` unless fixing a broken release—the Makefile enforces `main` and documents the intended flow.
 
 ## Automation
 
 - **pre-commit hook**: auto-runs `ruff format` + `ruff check` on every commit.
 - **pre-push hook**: blocks direct push to main.
-- **CI** (GitHub Actions): lint + test (parallel) + integration (PR only) + build. Any failure blocks merge.
+- **CI** (GitHub Actions): lint + test + openapi + build on pushes/PRs, plus integration on PRs. Any failure blocks merge.
+- **CD** (`.github/workflows/cd.yml`): pushes the `main` image to GHCR on changes to deployable server files.
+- **Release** (`.github/workflows/release.yml`): publishes tagged releases and GitHub Release assets on `v*` tags.
 
 ## Quick Command Reference
 
@@ -128,10 +148,12 @@ Run `make help` for the full list. Key commands:
 |---------|---------|
 | `make dev` | Start dev server (localhost:8000, hot reload) |
 | `make test` | Run tests (excludes integration) |
+| `make test-all` | Run all tests including integration |
 | `make test-e2e` | Run E2E tests against deployed cluster |
 | `make lint` / `make format` | Lint check / auto-format |
 | `make migrate` | Apply database migrations |
 | `make migration MSG=x` | Generate a new Alembic migration |
+| `make gen-openapi` | Export `openapi.json` from the FastAPI app |
 | `make up` / `make down` | Full K8s environment up/down (see `deploy/README.md`) |
 | `make ship MSG=x` | git add + commit + push (feature branches only) |
 | `make release V=x.y.z` | Tag `vx.y.z` on `main` and push (triggers full release pipeline) |

--- a/README.md
+++ b/README.md
@@ -1,153 +1,138 @@
 # Treadstone
 
-**Agent-Native sandbox.** Run code, build projects, deploy environments.
+**Agent-native sandbox platform for AI agents.** Run code, install dependencies, execute tests, build software, and hand off a browser session from isolated environments.
+
+Open source and self-hostable. Built for two readers at once:
+
+- **Developers** who want a sandbox control plane without building the whole platform themselves
+- **AI agents** that need a predictable CLI, SDK, and API they can operate autonomously
 
 > [!NOTE]
-> Treadstone is in early development. The CLI commands in this README reflect
-> what works today. Future ergonomic commands are called out explicitly when
-> they are still part of the product vision.
+> Treadstone is in early development. The commands below reflect what works today.
 
 ## Why Treadstone?
 
-AI agents need isolated environments to execute code, install packages, run
-tests, and build software. Existing sandbox solutions are either designed for
-human developers to self-host (requiring a Kubernetes cluster and significant
-ops work) or locked behind proprietary APIs with no self-deploy option.
+Autonomous software work needs more than a raw container.
 
-Treadstone takes a different approach: **an agent-native sandbox service** that
-agents interact with directly via CLI and SDK, while remaining fully open source
-and self-hostable.
+Agents also need authentication, API keys, multi-tenant sandbox lifecycle management, machine-readable output, browser hand-off for humans, and persistent storage when work needs to survive restarts.
 
-| | Self-host sandbox platforms | Proprietary sandbox APIs | **Treadstone** |
-|---|---|---|---|
-| **Audience** | Developers building platforms | Developers integrating SDKs | AI agents operating autonomously |
-| **Setup** | Deploy K8s + controllers + CRDs | Sign up for API key | `treadstone run "print('hello')"` |
-| **Self-host** | Yes | No | Yes |
-| **Managed option** | No | Yes | Yes |
-| **Multi-tenant** | Build it yourself | Built-in | Built-in |
+Treadstone packages that into an **agent-native sandbox service** instead of making every team assemble it from scratch on top of Kubernetes.
 
 ## Quick Start
 
-### Install
+### Install the CLI
+
+Use the release installer script. It downloads the right binary for your platform and verifies checksums when available.
 
 ```bash
-pip install git+https://github.com/earayu/treadstone.git
+curl -fsSL https://github.com/earayu/treadstone/releases/latest/download/install.sh | sh
 ```
 
-### CLI
+Windows PowerShell:
+
+```powershell
+irm https://github.com/earayu/treadstone/releases/latest/download/install.ps1 | iex
+```
+
+Alternative:
 
 ```bash
-# Check that the server is reachable
-treadstone system health
+pip install treadstone-cli
+```
 
-# Register and log in
-treadstone auth register --email you@example.com --password YourPass123!
-treadstone auth login --email you@example.com --password YourPass123!
+### Human Workflow
 
-# Create and save an API key for non-interactive use
-treadstone api-keys create --name my-key --save
-
-# Optional: override the server URL explicitly
+```bash
+# Optional: point the CLI at your own deployment
 export TREADSTONE_BASE_URL="http://localhost:8000"
 
-# List available templates
+treadstone system health
+treadstone auth register
+treadstone auth login
+treadstone api-keys create --name local --save
 treadstone templates list
-
-# Create a sandbox
-treadstone sandboxes create --template aio-sandbox-tiny --name my-sandbox
-
-# List and inspect sandboxes
+treadstone sandboxes create --template aio-sandbox-tiny --name demo
 treadstone sandboxes list
-treadstone sandboxes get <sandbox_id>
-
-# Generate a browser hand-off URL for a human
 treadstone sandboxes web enable <sandbox_id>
-
-# Create a persistent sandbox with storage
-treadstone sandboxes create --template aio-sandbox-large --persist --storage-size 20Gi
-
-# Lifecycle management
-treadstone sandboxes stop <sandbox_id>
-treadstone sandboxes start <sandbox_id>
-treadstone sandboxes delete <sandbox_id>
-
-# Print the built-in AI usage guide
-treadstone guide agent
-treadstone --skills
-
-# All commands support JSON output for automation
-treadstone --json sandboxes list
-treadstone --json sandboxes create --template aio-sandbox-tiny --name my-sandbox
-treadstone --json sandboxes web enable <sandbox_id>
 ```
 
-Sandbox names are human-readable labels scoped to the current user. Follow-up
-CLI commands use `sandbox_id`, and browser entry URLs should be read from
-command output rather than derived from the sandbox name.
+### Agent Workflow
 
-### Python SDK
+For automation, prefer JSON output and capture returned IDs from command output.
+
+```bash
+treadstone --json system health
+treadstone auth register --email agent@example.com --password YourPass123!
+treadstone auth login --email agent@example.com --password YourPass123!
+treadstone --json api-keys create --name automation --save
+
+treadstone --json templates list
+treadstone --json sandboxes create --template aio-sandbox-tiny --name demo
+treadstone --json sandboxes get <sandbox_id>
+treadstone --json sandboxes web enable <sandbox_id>
+
+treadstone guide agent
+treadstone --skills
+```
+
+Treat `name` as a human-readable label only. Follow-up operations use `sandbox_id`, and browser URLs should be read from command output instead of constructed from the sandbox name.
+
+## What Treadstone Gives You
+
+- **Agent-ready interfaces**: CLI, Python SDK, and REST API
+- **Machine-readable workflows**: `--json` output and a built-in agent guide
+- **Sandbox lifecycle management**: create, inspect, start, stop, delete
+- **Human hand-off**: generate browser entry links for live sandboxes
+- **Flexible execution modes**: ephemeral or persistent sandboxes
+- **Production control plane**: auth, API keys, RBAC, rate limiting, and multi-tenancy
+- **Open deployment model**: self-host today, managed path planned
+
+## Python SDK
+
+Install:
+
+```bash
+pip install treadstone-sdk
+```
+
+Example:
 
 ```python
 from treadstone_sdk import AuthenticatedClient
 from treadstone_sdk.api.sandbox_templates import sandbox_templates_list_sandbox_templates
-from treadstone_sdk.api.sandboxes import sandboxes_create_sandbox, sandboxes_get_sandbox
+from treadstone_sdk.api.sandboxes import sandboxes_create_sandbox
 from treadstone_sdk.models.create_sandbox_request import CreateSandboxRequest
 
-client = AuthenticatedClient(base_url="http://localhost:8000", token="sk_your_api_key")
+client = AuthenticatedClient(
+    base_url="http://localhost:8000",
+    token="sk_your_api_key",
+)
 
 templates = sandbox_templates_list_sandbox_templates.sync(client=client)
-template_name = templates.items[0].name
 
 sandbox = sandboxes_create_sandbox.sync(
     client=client,
-    body=CreateSandboxRequest(template=template_name, name="demo"),
+    body=CreateSandboxRequest(template=templates.items[0].name, name="demo"),
 )
 
-sandbox_id = sandbox.id
-detail = sandboxes_get_sandbox.sync(sandbox_id=sandbox_id, client=client)
+print(sandbox.id)
 ```
 
-Use the SDK when you want typed API access from Python. Sandbox names are only
-current-user labels; use `sandbox.id` for follow-up API calls and browser hand-off flows.
+Use the SDK when you want typed API access from Python. As with the CLI, use `sandbox.id` for follow-up operations.
 
-## Authentication Model
+## Built-in Templates
 
-Treadstone currently uses two credential types:
-
-- **Session Cookie** authenticates browser-oriented control plane flows. In the
-  CLI, `treadstone auth login` saves the session locally for the active base
-  URL.
-- **API Key** authenticates programmatic access across both the **control plane**
-  and **data plane**.
-
-For protected CLI commands, API keys take precedence. If no API key is set, the
-CLI falls back to the saved login session for the active base URL.
-
-API keys default to full user access, but can now be narrowed with coarse
-scopes:
-
-- `control_plane`: enable or disable account and sandbox management APIs
-- `data_plane.mode = all | none | selected`
-- `data_plane.sandbox_ids`: restrict data plane access to specific sandboxes
-
-This keeps the default API/CLI/SDK path simple while leaving room for finer
-grained scopes in a future release.
-
-## Sandbox Templates
-
-Treadstone ships with five built-in size tiers — all powered by the same
-AIO (All-in-One) image with different resource allocations. No ecosystem to
-maintain, no marketplace to curate.
+Treadstone ships with five built-in size tiers powered by the same AIO sandbox image.
 
 | Template | CPU | Memory | Use Case |
-|----------|-----|--------|----------|
-| `aio-sandbox-tiny` | 0.25 core | 512 Mi | Code execution, script running |
+|---|---|---|---|
+| `aio-sandbox-tiny` | 0.25 core | 512 Mi | Code execution, scripts, lightweight tasks |
 | `aio-sandbox-small` | 0.5 core | 1 Gi | Simple development tasks |
 | `aio-sandbox-medium` | 1 core | 2 Gi | General-purpose development |
-| `aio-sandbox-large` | 2 cores | 4 Gi | Full-featured + browser automation |
+| `aio-sandbox-large` | 2 cores | 4 Gi | Full-featured development and browser automation |
 | `aio-sandbox-xlarge` | 4 cores | 8 Gi | Heavy workloads |
 
-Current CLI examples:
+Examples:
 
 ```bash
 # Lightweight sandbox
@@ -157,41 +142,13 @@ treadstone sandboxes create --template aio-sandbox-tiny --name quick-demo
 treadstone sandboxes create --template aio-sandbox-large --name dev-box --persist --storage-size 20Gi
 ```
 
-Future ergonomic goal (not implemented yet):
-
-```bash
-treadstone run --template aio-sandbox-tiny "import math; print(math.pi)"
-treadstone create --template aio-sandbox-large --persist --storage 20Gi
-```
-
 ## Architecture
 
-```
-┌──────────────────────────────────────────────────────┐
-│  CLI / Python SDK / REST API                         │
-├──────────────────────────────────────────────────────┤
-│  Platform Service Layer          (Treadstone)        │
-│  Auth · API Keys · RBAC · Rate Limiting · Billing    │
-├──────────────────────────────────────────────────────┤
-│  Orchestration Layer                                 │
-│  Kubernetes · agent-sandbox CRD · WarmPool           │
-├──────────────────────────────────────────────────────┤
-│  Sandbox Runtime Layer                               │
-│  Container · gVisor Isolation · Persistent Volumes   │
-└──────────────────────────────────────────────────────┘
-```
+Treadstone is organized as three layers:
 
-**Platform Service Layer** — Authentication, multi-tenancy, API key management,
-rate limiting, and usage metering. This is what turns an open-source sandbox
-runtime into a production-ready service.
-
-**Orchestration Layer** — Kubernetes-native scheduling via
-[agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRDs with
-warm pool pre-provisioning for fast startup.
-
-**Sandbox Runtime Layer** — Isolated container execution with gVisor secure
-runtime. Supports both ephemeral (no storage) and persistent (PVC-backed)
-sandbox modes.
+- **Platform service layer**: authentication, API keys, RBAC, rate limiting, billing hooks, and multi-tenancy
+- **Orchestration layer**: Kubernetes plus [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRDs and warm pool support
+- **Sandbox runtime layer**: isolated containers with [gVisor](https://gvisor.dev/) and optional persistent volumes
 
 ## Tech Stack
 
@@ -200,26 +157,27 @@ sandbox modes.
 | Backend | Python 3.12+, FastAPI, SQLAlchemy (async), asyncpg |
 | Database | [Neon](https://neon.tech) Serverless PostgreSQL |
 | Orchestration | Kubernetes, [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD |
-| Isolation | [gVisor](https://gvisor.dev/) (K8s RuntimeClass) |
+| Isolation | [gVisor](https://gvisor.dev/) |
 | Runtime | [agent-infra/sandbox](https://github.com/agent-infra/sandbox) |
 | Package manager | [uv](https://github.com/astral-sh/uv) |
-| CI/CD | GitHub Actions → GHCR |
+| CI/CD | GitHub Actions -> GHCR |
 
 ## Status
 
-Treadstone is under active development. Here is what works today and what is
-coming next.
+What works today:
 
-| Phase | Scope | Status |
-|---|---|---|
-| **Phase 1** | User auth (JWT, OAuth, API keys), RBAC, invitation system | Done |
-| **Phase 2** | Sandbox CRUD, lifecycle management, K8s sync, HTTP proxy, subdomain routing | Done |
-| **Phase 3** | CLI, Python SDK, agent-facing developer experience | Done |
-| **Phase 4** | Usage metering, billing (Stripe), quotas | Planned |
-| **Phase 5** | Managed hosting, production hardening, monitoring | Planned |
+- User auth, API keys, RBAC, and invitations
+- Sandbox CRUD and lifecycle management
+- Kubernetes sync, HTTP proxy, and browser hand-off flow
+- CLI and Python SDK for agent-facing usage
 
-Design documents and implementation plans are available in the
-[docs/](docs/zh-CN/plans/) directory.
+What is planned next:
+
+- Usage metering and billing
+- Managed hosting
+- More production hardening and monitoring
+
+Design documents and implementation plans are available in [docs/zh-CN/plans/](docs/zh-CN/plans/).
 
 ## Development
 
@@ -235,6 +193,8 @@ make build            # Build Docker image
 make up               # Spin up local Kind cluster + deploy
 make down             # Tear down local environment
 ```
+
+For local Kubernetes deployment and smoke testing, see [deploy/README.md](deploy/README.md).
 
 ## License
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,25 +4,34 @@ Command-line interface for the Treadstone sandbox service.
 
 ## Installation
 
-### From PyPI
+### Recommended: release installer
+
+```bash
+curl -fsSL https://github.com/earayu/treadstone/releases/latest/download/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://github.com/earayu/treadstone/releases/latest/download/install.ps1 | iex
+```
+
+The installer downloads the correct binary for your platform and verifies checksums when available.
+
+### Alternative: PyPI
 
 ```bash
 pip install treadstone-cli
 ```
 
-### Pre-built binary
-
-Download the latest release from [GitHub Releases](https://github.com/earayu/treadstone/releases). The binary is self-contained and does not require Python.
-
-```bash
-# macOS / Linux
-chmod +x treadstone
-sudo mv treadstone /usr/local/bin/
-```
-
 ## Quick start
 
+### Human workflow
+
 ```bash
+# Optional: point the CLI at your own deployment
+export TREADSTONE_BASE_URL="http://localhost:8000"
+
 # Check that the server is reachable
 treadstone system health
 
@@ -51,13 +60,23 @@ treadstone guide agent
 treadstone --skills
 ```
 
-For automation and AI agents, prefer JSON output and capture the returned sandbox ID:
+### Agent workflow
+
+For automation and AI agents, prefer JSON output and capture the returned sandbox ID from command output.
 
 ```bash
+treadstone --json system health
+treadstone auth register --email agent@example.com --password YourPass123!
+treadstone auth login --email agent@example.com --password YourPass123!
+treadstone --json api-keys create --name automation --save
+
 treadstone --json templates list
 treadstone --json sandboxes create --template aio-sandbox-tiny --name my-sandbox
-treadstone --json sandboxes list
+treadstone --json sandboxes get <sandbox-id>
 treadstone --json sandboxes web enable <sandbox-id>
+
+treadstone guide agent
+treadstone --skills
 ```
 
 Treat `name` as a human-readable label only. Follow-up sandbox commands require


### PR DESCRIPTION
## Summary
- Refresh the root README for clearer homepage-style positioning and structure.
- Update AGENTS.md and agent skills (dev-setup, dev-lifecycle, database-migration) for consistency with current workflows.
- Tweak CLI README and GitHub Release body text for install paths (installer script, PyPI, Docker, manual binaries).

## Test Plan
- [x] `make lint`
- [x] `make test`

Made with [Cursor](https://cursor.com)