### PR TITLE
feat: add persistent sandbox storage classes and tiers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ TREADSTONE_SANDBOX_DOMAIN=
 TREADSTONE_SANDBOX_NAMESPACE=treadstone-local
 TREADSTONE_SANDBOX_PORT=8080
 TREADSTONE_SANDBOX_PROXY_TIMEOUT=180.0
+TREADSTONE_SANDBOX_STORAGE_CLASS=treadstone-workspace
+TREADSTONE_SANDBOX_DEFAULT_STORAGE_SIZE=5Gi
 
 # === Leader Election ===
 # Enable this in K8s environment files such as .env.local / .env.demo / .env.prod

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-hooks dev test test-unit test-api test-integration test-all test-e2e test-cov lint format migrate migration downgrade gen-openapi build clean ship up down deploy-infra deploy-runtime deploy-app deploy-all undeploy-app undeploy-runtime undeploy-all restart-app kind-create kind-delete port-forward
+.PHONY: help install install-hooks dev test test-unit test-api test-integration test-all test-e2e test-cov lint format migrate migration downgrade gen-openapi build clean ship up down deploy-storage deploy-infra deploy-runtime deploy-app deploy-all undeploy-storage undeploy-app undeploy-runtime undeploy-all restart-app kind-create kind-delete port-forward
 
 # ── Development ──────────────────────────────────────────────────────────────
 
@@ -91,12 +91,20 @@ clean: ## Remove build artifacts and caches
 # ── Deploy (Helm) ────────────────────────────────────────────────────────────
 
 ENV ?= local
+CLUSTER_PROFILE ?= $(if $(filter local,$(ENV)),local,ack)
 
 # Every environment gets its own namespace and Helm release name:
 # local → treadstone-local, demo → treadstone-demo, prod → treadstone-prod
-NS          := treadstone-$(ENV)
-APP_RELEASE := treadstone-$(ENV)
-RT_RELEASE  := sandbox-runtime-$(ENV)
+NS              := treadstone-$(ENV)
+APP_RELEASE     := treadstone-$(ENV)
+RT_RELEASE      := sandbox-runtime-$(ENV)
+STORAGE_NS      := cluster-storage-system
+STORAGE_RELEASE := cluster-storage-$(CLUSTER_PROFILE)
+
+deploy-storage: ## Deploy cluster-scoped StorageClass aliases for persistent sandboxes
+	helm upgrade --install $(STORAGE_RELEASE) deploy/cluster-storage \
+		-n $(STORAGE_NS) -f deploy/cluster-storage/values-$(CLUSTER_PROFILE).yaml \
+		--create-namespace
 
 deploy-infra: ## Deploy agent-sandbox controller (once per cluster)
 	helm upgrade --install agent-sandbox deploy/agent-sandbox \
@@ -123,7 +131,7 @@ deploy-app: ## Deploy Treadstone application (creates K8s secret from .env.<ENV>
 		-n $(NS) -f deploy/treadstone/values-$(ENV).yaml \
 		--create-namespace
 
-deploy-all: deploy-infra deploy-runtime deploy-app ## Deploy everything (infra → runtime → app)
+deploy-all: deploy-storage deploy-infra deploy-runtime deploy-app ## Deploy everything (storage → infra → runtime → app)
 
 restart-app: ## Rolling restart to pick up new env vars
 	kubectl rollout restart deployment/$(APP_RELEASE)-treadstone -n $(NS)
@@ -131,14 +139,18 @@ restart-app: ## Rolling restart to pick up new env vars
 port-forward: ## Port-forward treadstone service to localhost:8000
 	kubectl -n $(NS) port-forward svc/$(APP_RELEASE)-treadstone 8000:8000
 
+undeploy-storage: ## Undeploy cluster-scoped storage aliases (use with care on shared clusters)
+	helm uninstall $(STORAGE_RELEASE) -n $(STORAGE_NS) 2>/dev/null || true
+
 undeploy-app: ## Undeploy Treadstone application
 	helm uninstall $(APP_RELEASE) -n $(NS) 2>/dev/null || true
 
 undeploy-runtime: ## Undeploy sandbox runtime
 	helm uninstall $(RT_RELEASE) -n $(NS) 2>/dev/null || true
 
-undeploy-all: undeploy-app undeploy-runtime ## Undeploy app + runtime (keeps infra)
-	@echo "Note: agent-sandbox controller left in place. Run 'helm uninstall agent-sandbox' to remove."
+undeploy-all: undeploy-app undeploy-runtime ## Undeploy app + runtime (keeps shared infra + storage)
+	@echo "Note: agent-sandbox controller and cluster-storage are left in place."
+	@echo "Remove manually only if the cluster is dedicated to Treadstone."
 
 # ── Environment Lifecycle ─────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ Examples:
 treadstone sandboxes create --template aio-sandbox-tiny --name quick-demo
 
 # Persistent development environment
-treadstone sandboxes create --template aio-sandbox-large --name dev-box --persist --storage-size 20Gi
+treadstone sandboxes create --template aio-sandbox-large --name dev-box --persist --storage-size 5Gi
 ```
+
+Persistent sandbox storage uses preset workspace tiers today: `5Gi`, `10Gi`, and `20Gi`.
 
 ## Architecture
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -180,6 +180,7 @@ with a letter or number. Sandbox names only need to be unique for the current us
 ```bash
 treadstone sandboxes create --template aio-sandbox-tiny --name my-box
 treadstone sandboxes create --template aio-sandbox-medium --label env:dev --persist
+treadstone sandboxes create --template aio-sandbox-large --persist --storage-size 5Gi
 treadstone sandboxes list
 treadstone sandboxes list --label env:prod --label team:agent --limit 10
 treadstone sandboxes get <sandbox-id>
@@ -190,6 +191,8 @@ treadstone sandboxes web enable <sandbox-id>
 treadstone sandboxes web status <sandbox-id>
 treadstone sandboxes web disable <sandbox-id>
 ```
+
+Persistent sandbox storage currently supports the preset tiers `5Gi`, `10Gi`, and `20Gi`.
 
 ### `templates`
 

--- a/cli/treadstone_cli/sandboxes.py
+++ b/cli/treadstone_cli/sandboxes.py
@@ -7,6 +7,8 @@ import click
 from treadstone_cli._client import require_auth
 from treadstone_cli._output import handle_error, is_json_mode, print_detail, print_json, print_table
 
+_STORAGE_SIZE_CHOICES = ("5Gi", "10Gi", "20Gi")
+
 
 @click.group()
 def sandboxes() -> None:
@@ -44,7 +46,12 @@ def sandboxes() -> None:
     help="Minutes after stop before auto-delete. Use -1 to disable auto-delete.",
 )
 @click.option("--persist", is_flag=True, default=False, help="Enable persistent storage.")
-@click.option("--storage-size", default="10Gi", help="PVC size when --persist is set.")
+@click.option(
+    "--storage-size",
+    default="5Gi",
+    type=click.Choice(_STORAGE_SIZE_CHOICES, case_sensitive=True),
+    help="PVC size when --persist is set. Supported tiers: 5Gi, 10Gi, 20Gi.",
+)
 @click.pass_context
 def create(
     ctx: click.Context,
@@ -67,7 +74,7 @@ def create(
     Examples:
       treadstone sandboxes create --template aio-sandbox-tiny
       treadstone sandboxes create --template aio-sandbox-medium --name dev-box --label env:dev
-      treadstone sandboxes create --template aio-sandbox-large --persist --storage-size 20Gi
+      treadstone sandboxes create --template aio-sandbox-large --persist --storage-size 5Gi
       treadstone sandboxes create --template aio-sandbox-small --auto-stop-interval 30 --auto-delete-interval 120
     """
     client = require_auth(ctx)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,15 +4,17 @@ This document describes how to deploy Treadstone to Kubernetes and perform basic
 
 ## Architecture Overview
 
-The deployment consists of three layers of Helm charts, ordered by dependency from bottom to top:
+The deployment consists of four layers of Helm charts, ordered by dependency from bottom to top:
 
 | Layer | Chart | Description |
 |-------|-------|-------------|
+| Storage | `deploy/cluster-storage` | Cluster-scoped StorageClass aliases for persistent sandbox workspaces |
 | Infra | `deploy/agent-sandbox` | Sandbox CRD + controller (cluster-scoped, deploy once) |
 | Runtime | `deploy/sandbox-runtime` | SandboxTemplate + WarmPool (namespace-scoped) |
 | App | `deploy/treadstone` | FastAPI application + Ingress + RBAC + Migration Job |
 
-Each layer's Helm chart provides `values-{local,demo,prod}.yaml`, selected via the `ENV` variable.
+The app/runtime layers use the `ENV` variable (`local`, `demo`, `prod`). Cluster storage uses `CLUSTER_PROFILE`
+(`local`, `ack`, `aws`) because `StorageClass` resources are cluster-scoped rather than namespace-scoped.
 
 ## Prerequisites
 
@@ -48,8 +50,8 @@ make up              # Equivalent to make up ENV=local
 ### Demo / Prod Environments
 
 ```bash
-make up ENV=demo     # Requires an existing, accessible K8s cluster
-make up ENV=prod
+make up ENV=demo CLUSTER_PROFILE=ack     # Requires an existing, accessible K8s cluster
+make up ENV=prod CLUSTER_PROFILE=ack
 ```
 
 ### One-Command Teardown
@@ -81,18 +83,20 @@ kind load docker-image treadstone:latest --name treadstone
 ### 3. Deploy All Helm Charts
 
 ```bash
-make deploy-all ENV=local
+make deploy-all ENV=local CLUSTER_PROFILE=local
 ```
 
 This is equivalent to running in sequence:
 
 ```bash
+make deploy-storage CLUSTER_PROFILE=local  # StorageClass aliases (cluster-scoped)
 make deploy-infra ENV=local     # Sandbox CRD + controller
 make deploy-runtime ENV=local   # SandboxTemplate + WarmPool
 make deploy-app ENV=local       # App + Secret + Migration
 ```
 
 `deploy-app` automatically creates a K8s Secret (`treadstone-secrets`) from `.env.local`, and runs the database migration in a Helm pre-install/pre-upgrade hook.
+Persistent sandboxes use `TREADSTONE_SANDBOX_STORAGE_CLASS` from the environment file and default to a 5 GiB workspace.
 
 ### 4. Verify Deployment
 
@@ -203,7 +207,7 @@ make restart-app
 
 ```bash
 make undeploy-app                  # Uninstall app only
-make undeploy-all                  # Uninstall app + runtime (keep infra controller)
+make undeploy-all                  # Uninstall app + runtime (keep shared infra + storage)
 make down                          # Tear down everything (including Kind cluster in local)
 ```
 

--- a/deploy/cluster-storage/Chart.yaml
+++ b/deploy/cluster-storage/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cluster-storage
+description: Cluster-scoped StorageClass aliases for Treadstone persistent sandboxes
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/cluster-storage/templates/_helpers.tpl
+++ b/deploy/cluster-storage/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{- define "cluster-storage.labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/deploy/cluster-storage/templates/storageclass.yaml
+++ b/deploy/cluster-storage/templates/storageclass.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.storageClass.name }}
+  labels:
+    {{- include "cluster-storage.labels" . | nindent 4 }}
+    {{- with .Values.storageClass.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.storageClass.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+provisioner: {{ .Values.storageClass.provisioner }}
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
+volumeBindingMode: {{ .Values.storageClass.volumeBindingMode }}
+allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
+{{- with .Values.storageClass.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/deploy/cluster-storage/values-ack.yaml
+++ b/deploy/cluster-storage/values-ack.yaml
@@ -1,0 +1,9 @@
+storageClass:
+  provisioner: diskplugin.csi.alibabacloud.com
+  reclaimPolicy: Delete
+  volumeBindingMode: WaitForFirstConsumer
+  allowVolumeExpansion: true
+  parameters:
+    type: cloud_essd
+    performanceLevel: PL0
+    fstype: ext4

--- a/deploy/cluster-storage/values-aws.yaml
+++ b/deploy/cluster-storage/values-aws.yaml
@@ -1,0 +1,8 @@
+storageClass:
+  provisioner: ebs.csi.aws.com
+  reclaimPolicy: Delete
+  volumeBindingMode: WaitForFirstConsumer
+  allowVolumeExpansion: true
+  parameters:
+    type: gp3
+    fsType: ext4

--- a/deploy/cluster-storage/values-local.yaml
+++ b/deploy/cluster-storage/values-local.yaml
@@ -1,0 +1,6 @@
+storageClass:
+  provisioner: rancher.io/local-path
+  reclaimPolicy: Delete
+  volumeBindingMode: WaitForFirstConsumer
+  allowVolumeExpansion: true
+  parameters: {}

--- a/deploy/cluster-storage/values.yaml
+++ b/deploy/cluster-storage/values.yaml
@@ -1,0 +1,11 @@
+enabled: true
+
+storageClass:
+  name: treadstone-workspace
+  annotations: {}
+  labels: {}
+  provisioner: diskplugin.csi.alibabacloud.com
+  reclaimPolicy: Delete
+  volumeBindingMode: WaitForFirstConsumer
+  allowVolumeExpansion: true
+  parameters: {}

--- a/deploy/treadstone/templates/clusterrole.yaml
+++ b/deploy/treadstone/templates/clusterrole.yaml
@@ -54,6 +54,14 @@ rules:
     verbs:
       - get
       - patch
+  # StorageClasses: read-only for persistent sandbox storage backend checks
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
   # Lease objects: leader election for singleton background sync
   - apiGroups:
       - coordination.k8s.io

--- a/scripts/kind-setup.sh
+++ b/scripts/kind-setup.sh
@@ -5,6 +5,7 @@ CLUSTER_NAME="treadstone"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 KIND_CONFIG="${SCRIPT_DIR}/../deploy/kind/kind-config.yaml"
 INGRESS_NGINX_VERSION="v1.12.1"
+LOCAL_PATH_PROVISIONER_VERSION="v0.0.31"
 
 check_prerequisites() {
     local missing=()
@@ -60,6 +61,24 @@ install_ingress_nginx() {
     echo "ingress-nginx is ready."
 }
 
+install_local_path_provisioner() {
+    if kubectl get namespace local-path-storage &>/dev/null && \
+       kubectl get deployment -n local-path-storage local-path-provisioner &>/dev/null; then
+        echo ""
+        echo "local-path-provisioner already running, skipping install."
+        return 0
+    fi
+
+    echo ""
+    echo "Installing local-path-provisioner (${LOCAL_PATH_PROVISIONER_VERSION}) ..."
+    kubectl apply -f "https://raw.githubusercontent.com/rancher/local-path-provisioner/${LOCAL_PATH_PROVISIONER_VERSION}/deploy/local-path-storage.yaml"
+    echo "Waiting for local-path-provisioner to be ready (timeout 300s) ..."
+    kubectl wait --namespace local-path-storage \
+        --for=condition=available deployment/local-path-provisioner \
+        --timeout=300s
+    echo "local-path-provisioner is ready."
+}
+
 verify_cluster() {
     echo ""
     echo "Verifying cluster nodes ..."
@@ -74,6 +93,7 @@ main() {
     check_prerequisites
     create_cluster
     install_ingress_nginx
+    install_local_path_provisioner
     verify_cluster
     echo ""
     echo "Next steps:"

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ENV="${1:-local}"
+CLUSTER_PROFILE="${2:-${CLUSTER_PROFILE:-}}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLUSTER_NAME="treadstone"
 
@@ -20,7 +21,11 @@ fi
 
 echo ""
 echo "Deploying Helm charts (ENV=$ENV) ..."
-make deploy-all ENV="$ENV"
+if [ -n "$CLUSTER_PROFILE" ]; then
+    make deploy-all ENV="$ENV" CLUSTER_PROFILE="$CLUSTER_PROFILE"
+else
+    make deploy-all ENV="$ENV"
+fi
 
 NS="treadstone-${ENV}"
 

--- a/tests/api/test_sandboxes_api.py
+++ b/tests/api/test_sandboxes_api.py
@@ -10,6 +10,7 @@ from treadstone.core.users import UserManager, get_user_db, get_user_manager
 from treadstone.main import app
 from treadstone.models.sandbox import Sandbox
 from treadstone.models.user import OAuthAccount, User
+from treadstone.services.k8s_client import FakeK8sClient, set_k8s_client
 
 _test_session_factory = None
 
@@ -126,6 +127,32 @@ class TestCreateSandbox:
         assert data["name"] == "persist-sb"
         assert data["status"] == "creating"
 
+    async def test_create_with_persist_uses_default_storage_size(self, auth_client):
+        create_resp = await auth_client.post(
+            "/v1/sandboxes",
+            json={"template": "aio-sandbox-tiny", "name": "persist-default", "persist": True},
+        )
+        assert create_resp.status_code == 202
+
+        sandbox_id = create_resp.json()["id"]
+        get_resp = await auth_client.get(f"/v1/sandboxes/{sandbox_id}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["storage_size"] == "5Gi"
+
+    async def test_create_with_missing_storage_class_returns_503(self, auth_client):
+        k8s = FakeK8sClient()
+        k8s.remove_storage_class("treadstone-workspace")
+        set_k8s_client(k8s)
+
+        resp = await auth_client.post(
+            "/v1/sandboxes",
+            json={"template": "aio-sandbox-tiny", "name": "persist-no-sc", "persist": True},
+        )
+
+        assert resp.status_code == 503
+        data = resp.json()
+        assert data["error"]["code"] == "storage_backend_not_ready"
+
     async def test_create_with_subdomain_returns_shareable_web_entry_url(self, auth_client, monkeypatch):
         _enable_subdomain(monkeypatch)
 
@@ -204,6 +231,16 @@ class TestCreateSandbox:
         )
         assert resp.status_code == 422
         assert resp.json()["error"]["code"] == "validation_error"
+
+    async def test_create_with_unsupported_storage_tier_returns_422(self, auth_client):
+        resp = await auth_client.post(
+            "/v1/sandboxes",
+            json={"template": "aio-sandbox-tiny", "name": "bad-storage-tier", "persist": True, "storage_size": "7Gi"},
+        )
+        assert resp.status_code == 422
+        data = resp.json()
+        assert data["error"]["code"] == "validation_error"
+        assert "5Gi" in data["error"]["message"]
 
     async def test_create_with_invalid_auto_stop_interval_returns_422(self, auth_client):
         resp = await auth_client.post(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -29,6 +29,12 @@ def test_auth_defaults():
     assert s.jwt_secret == "CHANGE_ME_IN_PROD"
 
 
+def test_sandbox_storage_defaults():
+    s = Settings(_env_file=None, database_url=DB_URL)
+    assert s.sandbox_storage_class == "treadstone-workspace"
+    assert s.sandbox_default_storage_size == "5Gi"
+
+
 def test_auth_type_override():
     s = Settings(_env_file=None, database_url=DB_URL, auth_type="logto")
     assert s.auth_type == "logto"

--- a/tests/unit/test_k8s_client.py
+++ b/tests/unit/test_k8s_client.py
@@ -11,19 +11,26 @@ from treadstone.services.k8s_client import (
 
 
 class _EmptyStreamResponse:
+    def __init__(self, payload: dict | None = None):
+        self._payload = payload or {}
+
     async def aiter_lines(self):
         for line in ():
             yield line
 
+    def json(self):
+        return self._payload
+
 
 class _RecordedCall:
-    def __init__(self, recorder: list[dict], payload: dict):
+    def __init__(self, recorder: list[dict], payload: dict, response_payload: dict | None = None):
         self._recorder = recorder
         self._payload = payload
+        self._response_payload = response_payload
 
     async def __aenter__(self):
         self._recorder.append(self._payload)
-        return _EmptyStreamResponse()
+        return _EmptyStreamResponse(self._response_payload)
 
     async def __aexit__(self, exc_type, exc, tb):
         return False
@@ -34,7 +41,11 @@ class _RecordingAPI:
         self.calls: list[dict] = []
 
     def call_api(self, method: str, **kwargs):
-        return _RecordedCall(self.calls, {"method": method, **kwargs})
+        response_payload = None
+        if method == "GET" and kwargs.get("base", "").startswith("/apis/storage.k8s.io/v1/storageclasses/"):
+            name = kwargs["base"].rsplit("/", 1)[-1]
+            response_payload = {"metadata": {"name": name}}
+        return _RecordedCall(self.calls, {"method": method, **kwargs}, response_payload=response_payload)
 
 
 async def test_list_sandbox_templates():
@@ -140,6 +151,7 @@ async def test_create_sandbox_direct():
                 "metadata": {"name": "workspace"},
                 "spec": {
                     "accessModes": ["ReadWriteOnce"],
+                    "storageClassName": "treadstone-workspace",
                     "resources": {"requests": {"storage": "10Gi"}},
                 },
             }
@@ -165,6 +177,13 @@ async def test_create_sandbox_direct_without_storage():
     )
     assert sb["kind"] == "Sandbox"
     assert "volumeClaimTemplates" not in sb["spec"]
+
+
+async def test_get_storage_class():
+    client = FakeK8sClient()
+    storage_class = await client.get_storage_class("treadstone-workspace")
+    assert storage_class is not None
+    assert storage_class["metadata"]["name"] == "treadstone-workspace"
 
 
 async def test_delete_sandbox_direct():
@@ -218,3 +237,21 @@ async def test_watch_sandboxes_passes_query_params_separately():
         "timeoutSeconds": str(WATCH_TIMEOUT_SECONDS),
         "resourceVersion": "123",
     }
+
+
+async def test_get_storage_class_requests_expected_endpoint():
+    client = Kr8sClient()
+    api = _RecordingAPI()
+
+    async def fake_get_api():
+        return api
+
+    client._get_api = fake_get_api  # type: ignore[method-assign]
+
+    storage_class = await client.get_storage_class("treadstone-workspace")
+
+    assert storage_class == {"metadata": {"name": "treadstone-workspace"}}
+    call = api.calls[0]
+    assert call["method"] == "GET"
+    assert call["base"] == "/apis/storage.k8s.io/v1/storageclasses/treadstone-workspace"
+    assert call["version"] == ""

--- a/tests/unit/test_sandbox_service.py
+++ b/tests/unit/test_sandbox_service.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from treadstone.core.errors import InvalidTransitionError, TemplateNotFoundError
+from treadstone.core.errors import InvalidTransitionError, StorageBackendNotReadyError, TemplateNotFoundError
 from treadstone.models.sandbox import Sandbox, SandboxStatus
 
 
@@ -57,6 +57,7 @@ def _mock_k8s_client():
     k8s.create_sandbox = AsyncMock(return_value={"metadata": {"name": "test-sb"}, "kind": "Sandbox"})
     k8s.delete_sandbox = AsyncMock(return_value=True)
     k8s.scale_sandbox = AsyncMock(return_value=True)
+    k8s.get_storage_class = AsyncMock(return_value={"metadata": {"name": "treadstone-workspace"}})
     k8s.get_sandbox_claim = AsyncMock(return_value=None)
     k8s.list_sandbox_templates = AsyncMock(
         return_value=[
@@ -254,7 +255,28 @@ class TestDualPathProvisioning:
         k8s.create_sandbox_claim.assert_not_called()
         call_kwargs = k8s.create_sandbox.call_args.kwargs
         assert call_kwargs["volume_claim_templates"] is not None
+        assert call_kwargs["volume_claim_templates"][0]["spec"]["storageClassName"] == "treadstone-workspace"
         assert call_kwargs["volume_claim_templates"][0]["spec"]["resources"]["requests"]["storage"] == "20Gi"
+
+    async def test_create_with_persist_checks_storage_class_before_creating(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        k8s.get_storage_class.return_value = None
+        service = SandboxService(session=session, k8s_client=k8s)
+
+        with pytest.raises(StorageBackendNotReadyError):
+            await service.create(
+                owner_id="user1234567890abcd",
+                template="aio-sandbox-tiny",
+                persist=True,
+            )
+
+        session.add.assert_not_called()
+        session.commit.assert_not_called()
+        k8s.create_sandbox.assert_not_called()
+        k8s.create_sandbox_claim.assert_not_called()
 
     async def test_delete_claim_path_calls_delete_sandbox_claim(self):
         from treadstone.services.sandbox_service import SandboxService

--- a/treadstone/api/sandboxes.py
+++ b/treadstone/api/sandboxes.py
@@ -202,7 +202,7 @@ async def create_sandbox(
         auto_stop_interval=body.auto_stop_interval,
         auto_delete_interval=body.auto_delete_interval,
         persist=body.persist,
-        storage_size=body.storage_size or "10Gi",
+        storage_size=body.storage_size or settings.sandbox_default_storage_size,
     )
     web_link = None
     if settings.sandbox_domain:

--- a/treadstone/api/schemas.py
+++ b/treadstone/api/schemas.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
 
+from treadstone.config import SANDBOX_STORAGE_SIZE_VALUES, settings
 from treadstone.models.api_key import ApiKeyDataPlaneMode
 from treadstone.models.user import Role
 
@@ -23,8 +25,8 @@ SANDBOX_NAME_RULE = (
 SANDBOX_NAME_DESCRIPTION = (
     f"Optional custom sandbox name. {SANDBOX_NAME_RULE} Sandbox names only need to be unique for the current user."
 )
-STORAGE_SIZE_PATTERN = re.compile(r"^[1-9]\d*(?:Ei|Pi|Ti|Gi|Mi|Ki)$")
-STORAGE_SIZE_RULE = "storage_size must be a valid Kubernetes quantity like 5Gi, 500Mi, or 1Ti."
+STORAGE_SIZE_RULE = "storage_size must be one of the supported storage tiers: 5Gi, 10Gi, or 20Gi."
+StorageSize = Literal["5Gi", "10Gi", "20Gi"]
 
 # ── Sandbox ──────────────────────────────────────────────────────────────────
 
@@ -42,7 +44,11 @@ class CreateSandboxRequest(BaseModel):
         description="Minutes after stop before the sandbox is automatically deleted. -1 disables auto-delete.",
     )
     persist: bool = Field(default=False, examples=[False])
-    storage_size: str | None = Field(default=None, examples=["10Gi"], description="Persistent volume size.")
+    storage_size: StorageSize | None = Field(
+        default=None,
+        examples=["5Gi"],
+        description="Persistent volume size. Supported tiers: 5Gi, 10Gi, 20Gi.",
+    )
 
     @field_validator("name")
     @classmethod
@@ -69,10 +75,10 @@ class CreateSandboxRequest(BaseModel):
 
     @field_validator("storage_size")
     @classmethod
-    def validate_storage_size(cls, value: str | None) -> str | None:
+    def validate_storage_size(cls, value: StorageSize | None) -> StorageSize | None:
         if value is None:
             return None
-        if not STORAGE_SIZE_PATTERN.fullmatch(value):
+        if value not in SANDBOX_STORAGE_SIZE_VALUES:
             raise ValueError(STORAGE_SIZE_RULE)
         return value
 
@@ -80,7 +86,7 @@ class CreateSandboxRequest(BaseModel):
     def validate_storage_config(self) -> CreateSandboxRequest:
         if self.persist:
             if self.storage_size is None:
-                self.storage_size = "10Gi"
+                self.storage_size = settings.sandbox_default_storage_size
             return self
 
         if self.storage_size is not None:
@@ -121,8 +127,10 @@ class SandboxDetailResponse(SandboxResponse):
     image: str | None = Field(default=None, examples=["ghcr.io/agent-infra/sandbox:latest"])
     status_message: str | None = Field(default=None, examples=[None])
     persist: bool = Field(default=False, examples=[False])
-    storage_size: str | None = Field(
-        default=None, examples=["10Gi"], description="Persistent volume size (only present when persist=true)."
+    storage_size: StorageSize | None = Field(
+        default=None,
+        examples=["5Gi"],
+        description="Persistent volume size (only present when persist=true). Supported tiers: 5Gi, 10Gi, 20Gi.",
     )
     started_at: datetime | None = Field(default=None, examples=["2026-03-21T12:01:00+00:00"])
     stopped_at: datetime | None = Field(default=None, examples=[None])

--- a/treadstone/config.py
+++ b/treadstone/config.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from urllib.parse import urlparse
 
 from pydantic_settings import BaseSettings
@@ -5,6 +6,7 @@ from pydantic_settings import BaseSettings
 _DEFAULT_JWT_SECRET = "CHANGE_ME_IN_PROD"
 _MIN_JWT_SECRET_LENGTH = 32
 _UNSUPPORTED_OIDC_AUTH_TYPES = {"auth0", "authing", "logto"}
+SANDBOX_STORAGE_SIZE_VALUES = ("5Gi", "10Gi", "20Gi")
 
 
 class Settings(BaseSettings):
@@ -38,6 +40,8 @@ class Settings(BaseSettings):
     sandbox_namespace: str = "treadstone-local"
     sandbox_port: int = 8080
     sandbox_proxy_timeout: float = 180.0
+    sandbox_storage_class: str = "treadstone-workspace"
+    sandbox_default_storage_size: Literal["5Gi", "10Gi", "20Gi"] = "5Gi"
 
     # Leader election for singleton background sync tasks in multi-replica deploys
     leader_election_enabled: bool = False

--- a/treadstone/core/errors.py
+++ b/treadstone/core/errors.py
@@ -78,6 +78,18 @@ class SandboxTimeoutError(TreadstoneError):
         )
 
 
+class StorageBackendNotReadyError(TreadstoneError):
+    def __init__(self, storage_class_name: str):
+        super().__init__(
+            code="storage_backend_not_ready",
+            message=(
+                "Persistent sandbox storage is not ready. "
+                f"StorageClass '{storage_class_name}' was not found in the cluster."
+            ),
+            status=503,
+        )
+
+
 class SandboxNameConflictError(TreadstoneError):
     def __init__(self, name: str):
         super().__init__(

--- a/treadstone/services/k8s_client.py
+++ b/treadstone/services/k8s_client.py
@@ -75,6 +75,8 @@ class K8sClientProtocol(Protocol):
 
     async def scale_sandbox(self, name: str, namespace: str, replicas: int) -> bool: ...
 
+    async def get_storage_class(self, name: str) -> dict[str, Any] | None: ...
+
     # ── SandboxTemplate (extensions.agents.x-k8s.io) — read only ──
     async def list_sandbox_templates(self, namespace: str) -> list[dict[str, Any]]: ...
 
@@ -259,6 +261,15 @@ class Kr8sClient:
         ) as resp:
             return resp.status_code < 400
 
+    async def get_storage_class(self, name: str) -> dict[str, Any] | None:
+        api = await self._get_api()
+        url = f"/apis/storage.k8s.io/v1/storageclasses/{name}"
+        try:
+            async with api.call_api("GET", base=url, version="") as resp:
+                return resp.json()
+        except Exception:
+            return None
+
     # ── SandboxTemplate ──
 
     async def list_sandbox_templates(self, namespace: str) -> list[dict[str, Any]]:
@@ -344,6 +355,14 @@ class FakeK8sClient:
         self._templates: list[dict[str, Any]] = list(self._DEFAULT_TEMPLATES)
         self._claims: dict[str, dict[str, Any]] = {}
         self._sandboxes: dict[str, dict[str, Any]] = {}
+        self._storage_classes: dict[str, dict[str, Any]] = {
+            "treadstone-workspace": {
+                "apiVersion": "storage.k8s.io/v1",
+                "kind": "StorageClass",
+                "metadata": {"name": "treadstone-workspace"},
+                "provisioner": "test.fake.provisioner",
+            }
+        }
         self._watch_queue: asyncio.Queue[tuple[str, dict[str, Any]] | None] = asyncio.Queue()
 
     async def create_sandbox_claim(
@@ -481,6 +500,9 @@ class FakeK8sClient:
         sb["metadata"]["resourceVersion"] = rv
         return True
 
+    async def get_storage_class(self, name: str) -> dict[str, Any] | None:
+        return self._storage_classes.get(name)
+
     async def list_sandbox_templates(self, namespace: str) -> list[dict[str, Any]]:
         return list(self._templates)
 
@@ -495,6 +517,9 @@ class FakeK8sClient:
             sb["status"]["replicas"] = 1
             rv = str(int(sb["metadata"].get("resourceVersion", "1")) + 1)
             sb["metadata"]["resourceVersion"] = rv
+
+    def remove_storage_class(self, name: str) -> None:
+        self._storage_classes.pop(name, None)
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/treadstone/services/sandbox_service.py
+++ b/treadstone/services/sandbox_service.py
@@ -18,6 +18,7 @@ from treadstone.core.errors import (
     InvalidTransitionError,
     SandboxNameConflictError,
     SandboxNotFoundError,
+    StorageBackendNotReadyError,
     TemplateNotFoundError,
 )
 from treadstone.models.sandbox import Sandbox, SandboxStatus, is_valid_transition
@@ -61,10 +62,14 @@ class SandboxService:
         auto_stop_interval: int = 15,
         auto_delete_interval: int = -1,
         persist: bool = False,
-        storage_size: str = "10Gi",
+        storage_size: str | None = None,
     ) -> Sandbox:
         sandbox_id = "sb" + random_id()
         sandbox_name = name or f"sb-{random_id(8)}"
+        effective_storage_size = storage_size or settings.sandbox_default_storage_size
+
+        if persist:
+            await self._ensure_persistent_storage_backend_ready()
 
         sandbox = Sandbox()
         sandbox.id = sandbox_id
@@ -80,7 +85,7 @@ class SandboxService:
         sandbox.gmt_created = utc_now()
         sandbox.k8s_namespace = settings.sandbox_namespace
         sandbox.persist = persist
-        sandbox.storage_size = storage_size if persist else None
+        sandbox.storage_size = effective_storage_size if persist else None
 
         if persist:
             sandbox.provision_mode = "direct"
@@ -99,7 +104,7 @@ class SandboxService:
 
         try:
             if persist:
-                await self._create_direct(sandbox, template, storage_size)
+                await self._create_direct(sandbox, template, effective_storage_size)
             else:
                 await self._create_via_claim(sandbox, template)
         except TemplateNotFoundError:
@@ -134,6 +139,12 @@ class SandboxService:
             namespace=sandbox.k8s_namespace,
         )
 
+    async def _ensure_persistent_storage_backend_ready(self) -> None:
+        storage_class_name = settings.sandbox_storage_class.strip()
+        storage_class = await self.k8s.get_storage_class(storage_class_name)
+        if storage_class is None:
+            raise StorageBackendNotReadyError(storage_class_name)
+
     async def _create_direct(self, sandbox: Sandbox, template: str, storage_size: str) -> None:
         tmpl = await self._resolve_template(sandbox.k8s_namespace, template)
 
@@ -151,6 +162,7 @@ class SandboxService:
                 "metadata": {"name": "workspace"},
                 "spec": {
                     "accessModes": ["ReadWriteOnce"],
+                    "storageClassName": settings.sandbox_storage_class,
                     "resources": {"requests": {"storage": storage_size}},
                 },
             }


### PR DESCRIPTION
## Summary
- add explicit persistent sandbox storage class support with fail-fast validation
- add a cluster-scoped Helm chart for storage aliases and wire it into deploy flow
- restrict persistent storage sizes to supported tiers with a 5Gi default

## Testing
- make lint
- uv run pytest tests/api/test_sandboxes_api.py tests/unit/test_config.py tests/unit/test_k8s_client.py tests/unit/test_sandbox_service.py -q
