### PR TITLE
feat: make session TTL configurable with 7-day default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ TREADSTONE_DEBUG=false
 # Local ingress default. If you run `make dev` directly without ingress, use http://localhost:8000 instead.
 TREADSTONE_API_BASE_URL=http://localhost
 TREADSTONE_AUTH_TYPE=cookie
+TREADSTONE_SESSION_TTL_SECONDS=604800
 
 # === Auth Secrets ===
 TREADSTONE_JWT_SECRET=CHANGE_ME_IN_PROD

--- a/tests/integration/.env.test.example
+++ b/tests/integration/.env.test.example
@@ -3,3 +3,4 @@
 # 2. Copy this file to .env.test and fill in your test branch connection string
 # 3. Run: make test-all
 TREADSTONE_DATABASE_URL=postgresql+asyncpg://user:password@ep-xxx-pooler.region.aws.neon.tech/neondb?sslmode=require
+TREADSTONE_SESSION_TTL_SECONDS=604800

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -26,6 +26,13 @@ def test_auth_defaults():
     s = Settings(_env_file=None, database_url=DB_URL)
     assert s.auth_type == "cookie"
     assert s.jwt_secret == "CHANGE_ME_IN_PROD"
+    assert s.session_ttl_seconds == 604800
+
+
+def test_session_ttl_can_be_overridden_from_env(monkeypatch):
+    monkeypatch.setenv("TREADSTONE_SESSION_TTL_SECONDS", "42")
+    s = Settings(_env_file=None, database_url=DB_URL)
+    assert s.session_ttl_seconds == 42
 
 
 def test_sandbox_storage_defaults():

--- a/tests/unit/test_user_manager.py
+++ b/tests/unit/test_user_manager.py
@@ -17,12 +17,12 @@ def test_auth_backend_name():
 
 def test_cookie_transport_config():
     assert cookie_transport.cookie_name == "session"
-    assert cookie_transport.cookie_max_age == 86400
+    assert cookie_transport.cookie_max_age == 604800
 
 
 def test_jwt_strategy_lifetime():
     strategy = get_jwt_strategy()
-    assert strategy.lifetime_seconds == 86400
+    assert strategy.lifetime_seconds == 604800
 
 
 def test_fastapi_users_instance():

--- a/treadstone/config.py
+++ b/treadstone/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     # Auth
     auth_type: str = "cookie"  # cookie | auth0 | authing | logto | none
     jwt_secret: str = _DEFAULT_JWT_SECRET
+    session_ttl_seconds: int = 604800
 
     # OAuth Social
     google_oauth_client_id: str = ""

--- a/treadstone/core/users.py
+++ b/treadstone/core/users.py
@@ -14,7 +14,7 @@ from treadstone.config import settings
 from treadstone.core.database import get_session
 from treadstone.models.user import OAuthAccount, Role, User
 
-COOKIE_MAX_AGE = 86400  # 24 hours
+COOKIE_MAX_AGE = settings.session_ttl_seconds
 
 
 def should_use_secure_cookies() -> bool:


### PR DESCRIPTION
## Summary

This change makes session TTL configurable while defaulting to 7 days, reducing re-authentication friction across deployments.

## Changes

- Add `session_ttl_seconds` setting with 7-day (604800s) default to `treadstone/config.py`
- Expose as `TREADSTONE_SESSION_TTL_SECONDS` environment variable
- Replace hard-coded `COOKIE_MAX_AGE` (24 hours) with settings-driven value in `treadstone/core/users.py`
- Apply to both browser login and CLI login sessions (shared JWT strategy)
- Update all env files (.env.example, .env.test.example, etc.)

## Test Plan

- ✅ Config tests verify default is 604800 and custom values are honored
- ✅ User manager tests confirm both `cookie_max_age` and `get_jwt_strategy().lifetime_seconds` use the new TTL
- All auth tests pass: `tests/unit/test_config.py`, `tests/unit/test_user_manager.py`, `tests/api/test_auth_api.py`

## What's Not Changed

- OAuth state TTL (600s)
- CLI flow TTL (600s)
- Logout behavior
- Refresh logic
- Any other auth behavior


Made with [Cursor](https://cursor.com)