### PR TITLE
docs: add metering design documents (zh-CN)

### DIFF
--- a/docs/zh-CN/design/2026-03-26-metering-compute.md
+++ b/docs/zh-CN/design/2026-03-26-metering-compute.md
@@ -1,0 +1,1223 @@
+# Compute 计量设计
+
+**日期：** 2026-03-26
+**状态：** 设计中
+**关联文档：** [计量系统总览](2026-03-26-metering-overview.md)
+
+---
+
+## 1. Compute Credit 定义
+
+### 1.1 基本单位
+
+**1 Compute Credit = 1 vCPU-hour 等价的计算资源。**
+
+Compute Credit 是 Treadstone 平台衡量 sandbox 计算资源消耗的标准化单位。当一个 sandbox 以 1 vCPU / 2 GiB 内存运行 1 小时，消耗恰好 1 Compute Credit。
+
+### 1.2 费率公式
+
+```
+credit_rate_per_hour = max(vCPU_request, memory_GiB_request / 2)
+```
+
+该公式确保以较大维度为准计费：
+
+- 若用户选择的 sandbox 模板 CPU 和内存保持 1:2 的比例（当前所有模板均如此），则 `vCPU_request == memory_GiB_request / 2`，公式简化为 `vCPU_request`。
+- 若未来引入非标比例的模板（如 CPU 密集型 2 vCPU / 2 GiB），则 `max(2, 2/2) = 2`，按 CPU 计费。
+- 若引入内存密集型模板（如 1 vCPU / 8 GiB），则 `max(1, 8/2) = 4`，按内存计费。
+
+### 1.3 当前模板费率表
+
+| Template | vCPU Request | Memory Request | Credit Rate (credits/h) |
+|----------|-------------|---------------|------------------------|
+| tiny     | 0.25        | 0.5 GiB       | 0.25                   |
+| small    | 0.5         | 1 GiB         | 0.50                   |
+| medium   | 1           | 2 GiB         | 1.00                   |
+| large    | 2           | 4 GiB         | 2.00                   |
+| xlarge   | 4           | 8 GiB         | 4.00                   |
+
+> **为什么基于 request 而非 limit？**
+>
+> Kubernetes 调度器以 Pod 的 resource request 决定节点分配——request 是节点上为 Pod **保底预留**的资源量。limit 仅限制运行时突发使用的上限（当前 Treadstone 的 limit = 2× request，见 `_build_resource_limits()`）。Treadstone 向用户售卖的是**保底可用资源**，因此按 request 计费更合理。用户无论是否实际用满 request，都已占用了集群上对应的调度容量。
+>
+> 这与行业标准一致：AWS Fargate 按 vCPU-hour / GB-hour 的 request 计费；GCP Cloud Run 按分配的 vCPU 和内存计费。
+
+### 1.4 计量精度
+
+| 维度 | 精度 |
+|------|------|
+| 内部记录 | 按秒（与 Daytona / E2B 对齐） |
+| credits_consumed 字段 | `Decimal(10,4)`，精确到万分之一 credit |
+| 对外展示 | 精确到分钟（向上取整），在 dashboard / 账单中展示 |
+| tick 间隔 | 60 秒，实际精度 ≈ 秒级（基于 `last_metered_at` 到 `now()` 的实际差值） |
+
+内部按秒级差值计算，确保即使 tick 间隔有波动（如 leader 切换导致间隔 > 60s），计量结果仍然准确。
+
+---
+
+## 2. ComputeSession 生命周期
+
+### 2.1 概念
+
+`ComputeSession` 追踪一个 sandbox 的**单次运行期间**的计算资源消耗。每次 sandbox 从非运行状态进入 `ready` 状态时创建一个新 session，当 sandbox 离开 `ready` 状态（进入 `stopped` / `error` / `deleting`）时关闭该 session。
+
+一个 sandbox 的生命周期中可能产生多个 `ComputeSession`（每次 start/stop 循环产生一个）。
+
+### 2.2 表结构
+
+```sql
+CREATE TABLE compute_session (
+    id                      VARCHAR(24)    PRIMARY KEY,
+    sandbox_id              VARCHAR(24)    NOT NULL REFERENCES sandbox(id),
+    user_id                 VARCHAR(24)    NOT NULL REFERENCES "user"(id),
+    template                VARCHAR(32)    NOT NULL,
+    credit_rate_per_hour    DECIMAL(10,4)  NOT NULL,
+    started_at              TIMESTAMPTZ    NOT NULL,
+    ended_at                TIMESTAMPTZ,               -- NULL = 运行中
+    last_metered_at         TIMESTAMPTZ    NOT NULL,
+    credits_consumed        DECIMAL(10,4)  NOT NULL DEFAULT 0,
+    credits_consumed_monthly DECIMAL(10,4) NOT NULL DEFAULT 0,
+    credits_consumed_extra  DECIMAL(10,4)  NOT NULL DEFAULT 0,
+    gmt_created             TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    gmt_updated             TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ix_compute_session_sandbox ON compute_session(sandbox_id);
+CREATE INDEX ix_compute_session_user    ON compute_session(user_id);
+CREATE INDEX ix_compute_session_open    ON compute_session(ended_at) WHERE ended_at IS NULL;
+```
+
+字段说明：
+
+| 字段 | 用途 |
+|------|------|
+| `id` | 主键，格式 `"cs" + random_id()`，与现有 ID 风格一致 |
+| `sandbox_id` | 关联的 sandbox |
+| `user_id` | 冗余存储 sandbox owner，避免每次 tick 都需要 JOIN sandbox 表 |
+| `template` | 冗余存储模板名称，方便后续按模板维度统计 |
+| `credit_rate_per_hour` | session 创建时锁定的费率。即使模板后续调价，已有 session 不受影响 |
+| `started_at` | session 开始时间（sandbox 进入 `ready` 的时刻） |
+| `ended_at` | session 结束时间。`NULL` 表示 sandbox 仍在运行 |
+| `last_metered_at` | 上次 tick 计量的时间点，用于增量计算 |
+| `credits_consumed` | 累计消耗的 credit 总量 |
+| `credits_consumed_monthly` | 从月度额度扣除的部分 |
+| `credits_consumed_extra` | 从额外额度（CreditGrant）扣除的部分 |
+| `gmt_created` / `gmt_updated` | 审计时间戳，`gmt_updated` 兼作乐观锁版本标记 |
+
+> **设计选择：`user_id` 冗余**
+>
+> `user_id` 可以通过 `sandbox.owner_id` JOIN 获取，但 `tick_metering()` 每 60 秒执行一次，涉及所有 open session。冗余 `user_id` 避免了 N 次 JOIN，将 tick 的核心查询简化为单表扫描 + 批量更新。
+
+### 2.3 SQLAlchemy 模型
+
+```python
+class ComputeSession(Base):
+    __tablename__ = "compute_session"
+
+    id: Mapped[str] = mapped_column(
+        String(24), primary_key=True, default=lambda: "cs" + random_id()
+    )
+    sandbox_id: Mapped[str] = mapped_column(
+        String(24), ForeignKey("sandbox.id"), nullable=False, index=True
+    )
+    user_id: Mapped[str] = mapped_column(
+        String(24), ForeignKey("user.id"), nullable=False, index=True
+    )
+    template: Mapped[str] = mapped_column(String(32), nullable=False)
+    credit_rate_per_hour: Mapped[Decimal] = mapped_column(
+        Numeric(10, 4), nullable=False
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_metered_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    credits_consumed: Mapped[Decimal] = mapped_column(
+        Numeric(10, 4), nullable=False, default=Decimal("0")
+    )
+    credits_consumed_monthly: Mapped[Decimal] = mapped_column(
+        Numeric(10, 4), nullable=False, default=Decimal("0")
+    )
+    credits_consumed_extra: Mapped[Decimal] = mapped_column(
+        Numeric(10, 4), nullable=False, default=Decimal("0")
+    )
+    gmt_created: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+    gmt_updated: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+```
+
+### 2.4 Session 状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> Open: sandbox状态变为ready<br/>open_compute_session()
+    Open --> Open: tick_metering()每60秒<br/>增量计算credits
+    Open --> Closed_Normal: sandbox变为stopped<br/>close_compute_session()
+    Open --> Closed_Error: sandbox变为error<br/>close_compute_session()
+    Open --> Closed_Delete: sandbox变为deleting<br/>close_compute_session()
+    Open --> Closed_Period: 月度周期结束<br/>split_session_at_period_end()
+    Closed_Normal --> [*]
+    Closed_Error --> [*]
+    Closed_Delete --> [*]
+    Closed_Period --> [*]
+
+    note right of Open
+        ended_at IS NULL
+        last_metered_at 随 tick 推进
+        credits_consumed 持续累加
+    end note
+
+    note right of Closed_Normal
+        ended_at = 关闭时刻
+        credits_consumed = 最终值
+    end note
+```
+
+### 2.5 Session 生命周期详细流程
+
+#### 2.5.1 创建（Open）
+
+触发时机：K8s Sync 检测到 sandbox 状态从 `creating` 变为 `ready`。
+
+```python
+async def open_compute_session(
+    session: AsyncSession,
+    sandbox: Sandbox,
+) -> ComputeSession:
+    credit_rate = calculate_credit_rate(sandbox.template)
+    now = utc_now()
+
+    cs = ComputeSession(
+        sandbox_id=sandbox.id,
+        user_id=sandbox.owner_id,
+        template=sandbox.template,
+        credit_rate_per_hour=credit_rate,
+        started_at=now,
+        last_metered_at=now,
+        credits_consumed=Decimal("0"),
+        credits_consumed_monthly=Decimal("0"),
+        credits_consumed_extra=Decimal("0"),
+    )
+    session.add(cs)
+    await session.commit()
+    return cs
+```
+
+此时 `credits_consumed = 0`，`ended_at = NULL`。session 将在后续 tick 中累积消耗。
+
+#### 2.5.2 更新（Tick）
+
+后台 `tick_metering()` 每 60 秒运行一次（详见第 4 节）。对于每个 open session：
+
+1. 计算 `elapsed = now() - last_metered_at`（秒级精度）
+2. 计算 `new_credits = elapsed_seconds / 3600 * credit_rate_per_hour`
+3. 调用 `consume_compute_credits()` 扣除额度（详见第 3 节）
+4. 更新 `credits_consumed += new_credits`，`last_metered_at = now()`
+
+#### 2.5.3 关闭（Close）
+
+触发时机：K8s Sync 检测到 sandbox 状态变为 `stopped` / `error` / `deleting`。
+
+```python
+async def close_compute_session(
+    session: AsyncSession,
+    sandbox_id: str,
+) -> None:
+    now = utc_now()
+    result = await session.execute(
+        select(ComputeSession).where(
+            ComputeSession.sandbox_id == sandbox_id,
+            ComputeSession.ended_at.is_(None),
+        )
+    )
+    cs = result.scalar_one_or_none()
+    if cs is None:
+        return
+
+    elapsed = (now - cs.last_metered_at).total_seconds()
+    final_credits = Decimal(str(elapsed)) / Decimal("3600") * cs.credit_rate_per_hour
+
+    consume_result = await consume_compute_credits(
+        session, cs.user_id, final_credits
+    )
+
+    cs.credits_consumed += final_credits
+    cs.credits_consumed_monthly += consume_result.monthly
+    cs.credits_consumed_extra += consume_result.extra
+    cs.ended_at = now
+    cs.last_metered_at = now
+    cs.gmt_updated = now
+
+    session.add(cs)
+    await session.commit()
+```
+
+关闭时先计算从 `last_metered_at` 到 `now` 的最后一段消耗，确保不丢失最后一个 tick 间隔内的使用量。
+
+---
+
+## 3. Credit 消费逻辑（双池消费）
+
+### 3.1 双池模型
+
+用户的 Compute Credit 额度由两个来源组成：
+
+| 池 | 来源 | 生命周期 | 优先级 |
+|----|------|---------|--------|
+| **Monthly Credits** | 订阅套餐自带，每月初自动刷新 | 当月有效，不结转 | **优先消费** |
+| **Extra Credits** | 一次性发放（欢迎奖励、活动、管理员发放、推荐、购买） | 有各自的过期时间或永不过期 | Monthly 耗尽后消费 |
+
+消费顺序：**先 Monthly，再 Extra。** 这保证了用户购买的额外额度不会被月度刷新"浪费"。
+
+### 3.2 CreditGrant 表
+
+`CreditGrant` 表存储 Extra Credits 的每笔发放记录，支持细粒度的过期管理和消费追踪。
+
+```sql
+CREATE TABLE credit_grant (
+    id                VARCHAR(24)    PRIMARY KEY,
+    user_id           VARCHAR(24)    NOT NULL REFERENCES "user"(id),
+    credit_type       VARCHAR(16)    NOT NULL,   -- "compute" | "storage"
+    grant_type        VARCHAR(32)    NOT NULL,   -- "welcome_bonus"|"campaign"|"admin_grant"|"referral"|"purchase"
+    campaign_id       VARCHAR(64),               -- 关联的活动 ID（可选）
+    original_amount   DECIMAL(10,4)  NOT NULL,
+    remaining_amount  DECIMAL(10,4)  NOT NULL,
+    reason            TEXT,                       -- 人类可读的发放原因
+    granted_by        VARCHAR(24),               -- 管理员 user_id（可选）
+    granted_at        TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    expires_at        TIMESTAMPTZ,               -- NULL = 永不过期
+    gmt_created       TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    gmt_updated       TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ix_credit_grant_user_type ON credit_grant(user_id, credit_type);
+CREATE INDEX ix_credit_grant_expires   ON credit_grant(expires_at) WHERE remaining_amount > 0;
+```
+
+字段说明：
+
+| 字段 | 用途 |
+|------|------|
+| `credit_type` | 区分 compute / storage 额度，避免混用 |
+| `grant_type` | 标记来源，方便统计各渠道的发放量 |
+| `original_amount` | 初始发放量，不可变，用于审计 |
+| `remaining_amount` | 剩余量，消费时递减 |
+| `expires_at` | 过期时间。`NULL` 表示永不过期。消费时优先使用即将过期的 grant |
+| `granted_by` | 如果是管理员手动发放，记录操作者 |
+
+### 3.3 消费算法
+
+消费算法的核心原则：
+
+1. **先 Monthly 后 Extra**：最大化 Extra Credits 的保留
+2. **Extra 内按过期时间升序消费**：优先使用即将过期的 grant，减少浪费
+3. **跳过已过期的 grant**：`expires_at < now()` 的 grant 不参与消费
+4. **永不过期的 grant 排在最后**：`expires_at IS NULL` 排序为 `NULLS LAST`
+
+#### 3.3.1 伪代码
+
+```python
+@dataclass
+class ConsumeResult:
+    monthly: Decimal   # 从月度额度扣除的量
+    extra: Decimal     # 从 Extra Credits 扣除的量
+    shortfall: Decimal # 不足量（额度全部耗尽时 > 0）
+
+
+async def consume_compute_credits(
+    session: AsyncSession,
+    user_id: str,
+    amount: Decimal,
+) -> ConsumeResult:
+    """从用户的 compute 额度中扣除 amount 个 credits。
+
+    扣除顺序：Monthly → Extra (按 expires_at ASC, NULLS LAST)。
+    """
+    plan = await get_user_plan(session, user_id)
+    monthly_remaining = (
+        plan.compute_credits_monthly_limit - plan.compute_credits_monthly_used
+    )
+
+    # --- 阶段 1：从月度额度扣除 ---
+    if monthly_remaining >= amount:
+        plan.compute_credits_monthly_used += amount
+        plan.gmt_updated = utc_now()
+        session.add(plan)
+        return ConsumeResult(monthly=amount, extra=Decimal("0"), shortfall=Decimal("0"))
+
+    monthly_consumed = monthly_remaining
+    extra_needed = amount - monthly_remaining
+    plan.compute_credits_monthly_used = plan.compute_credits_monthly_limit
+    plan.gmt_updated = utc_now()
+    session.add(plan)
+
+    # --- 阶段 2：从 CreditGrant 中按过期时间升序扣除 ---
+    now = utc_now()
+    result = await session.execute(
+        select(CreditGrant)
+        .where(
+            CreditGrant.user_id == user_id,
+            CreditGrant.credit_type == "compute",
+            CreditGrant.remaining_amount > 0,
+            or_(
+                CreditGrant.expires_at.is_(None),
+                CreditGrant.expires_at > now,
+            ),
+        )
+        .order_by(
+            CreditGrant.expires_at.asc().nulls_last()
+        )
+        .with_for_update()  # 行级锁，防止并发消费
+    )
+    grants = result.scalars().all()
+
+    extra_consumed = Decimal("0")
+    for grant in grants:
+        if extra_needed <= Decimal("0"):
+            break
+
+        deduct = min(grant.remaining_amount, extra_needed)
+        grant.remaining_amount -= deduct
+        grant.gmt_updated = now
+        session.add(grant)
+
+        extra_consumed += deduct
+        extra_needed -= deduct
+
+    shortfall = max(Decimal("0"), extra_needed)
+
+    return ConsumeResult(
+        monthly=monthly_consumed,
+        extra=extra_consumed,
+        shortfall=shortfall,
+    )
+```
+
+#### 3.3.2 关键设计决策
+
+**为什么使用 `SELECT ... FOR UPDATE`？**
+
+`tick_metering()` 运行在单一 leader 节点上，理论上不会有并发 tick。但以下场景可能引发并发消费：
+
+- Leader 切换期间的短暂重叠
+- API 层面的手动额度调整（管理员操作）
+- 未来的 Storage 计量也会消费同一用户的额度
+
+`FOR UPDATE` 对 CreditGrant 行加锁，确保同一用户的多个并发消费操作串行化，避免超额扣除。
+
+**Shortfall 的处理**
+
+当 `shortfall > 0` 时，意味着用户的所有额度已耗尽。此时：
+
+1. `credits_consumed` 仍然累加——记录实际消耗，用于账单和审计
+2. 触发 Grace Period 检查（详见 enforcement 文档）
+3. 不立即终止 sandbox——给用户缓冲时间
+
+#### 3.3.3 消费流程图
+
+```mermaid
+flowchart TD
+    Start["consume_compute_credits(user_id,amount)"] --> GetPlan["获取UserPlan"]
+    GetPlan --> CalcMonthly["计算monthly_remaining=limit-used"]
+    CalcMonthly --> CheckMonthly{"monthly_remaining>=amount?"}
+
+    CheckMonthly -->|是| DeductMonthly["plan.monthly_used+=amount<br/>return{monthly:amount,extra:0}"]
+    DeductMonthly --> Done["返回ConsumeResult"]
+
+    CheckMonthly -->|否| PartialMonthly["monthly_consumed=monthly_remaining<br/>extra_needed=amount-monthly_remaining<br/>plan.monthly_used=limit"]
+    PartialMonthly --> QueryGrants["查询CreditGrant<br/>WHERE user_id AND compute<br/>AND remaining>0 AND未过期<br/>ORDER BY expires_at ASC NULLS LAST<br/>FOR UPDATE"]
+    QueryGrants --> LoopGrants["遍历grants"]
+    LoopGrants --> CheckNeed{"extra_needed>0且有剩余grant?"}
+
+    CheckNeed -->|是| Deduct["deduct=min(grant.remaining,extra_needed)<br/>grant.remaining-=deduct<br/>extra_consumed+=deduct"]
+    Deduct --> LoopGrants
+
+    CheckNeed -->|否| CalcShortfall["shortfall=max(0,extra_needed)"]
+    CalcShortfall --> ReturnResult["return{monthly,extra,shortfall}"]
+    ReturnResult --> Done
+```
+
+---
+
+## 4. 后台 Tick Metering
+
+### 4.1 概述
+
+`tick_metering()` 是计量系统的心跳。它运行在 `sync_supervisor` 管理的 leader 节点上，每 60 秒对所有 open `ComputeSession` 进行一次增量计量。
+
+### 4.2 执行逻辑
+
+```python
+TICK_INTERVAL = 60  # seconds
+
+async def tick_metering(session_factory: async_sessionmaker[AsyncSession]) -> None:
+    """对所有运行中的 ComputeSession 执行增量计量。"""
+    async with session_factory() as session:
+        now = utc_now()
+
+        # 查询所有 open sessions
+        result = await session.execute(
+            select(ComputeSession).where(
+                ComputeSession.ended_at.is_(None)
+            )
+        )
+        open_sessions = result.scalars().all()
+
+        for cs in open_sessions:
+            elapsed_seconds = (now - cs.last_metered_at).total_seconds()
+            if elapsed_seconds <= 0:
+                continue
+
+            new_credits = (
+                Decimal(str(elapsed_seconds))
+                / Decimal("3600")
+                * cs.credit_rate_per_hour
+            )
+
+            consume_result = await consume_compute_credits(
+                session, cs.user_id, new_credits
+            )
+
+            # 乐观锁：仅当 gmt_updated 未被其他操作修改时更新
+            rows = await session.execute(
+                update(ComputeSession)
+                .where(
+                    ComputeSession.id == cs.id,
+                    ComputeSession.gmt_updated == cs.gmt_updated,
+                )
+                .values(
+                    credits_consumed=cs.credits_consumed + new_credits,
+                    credits_consumed_monthly=cs.credits_consumed_monthly + consume_result.monthly,
+                    credits_consumed_extra=cs.credits_consumed_extra + consume_result.extra,
+                    last_metered_at=now,
+                    gmt_updated=now,
+                )
+            )
+
+            if rows.rowcount == 0:
+                logger.warning(
+                    "Optimistic lock conflict for ComputeSession %s, skipping this tick",
+                    cs.id,
+                )
+                await session.rollback()
+                continue
+
+        await session.commit()
+
+        # 检查是否有用户触发了 Grace Period
+        await check_grace_periods(session)
+```
+
+### 4.3 为什么选择 60 秒间隔
+
+| 考量 | 分析 |
+|------|------|
+| **精度需求** | 用户对计量精度的预期为分钟级。60 秒 tick 恰好满足"精确到分钟"的对外展示需求 |
+| **数据库负载** | 每次 tick 执行 `O(N)` 次 session 更新（N = 活跃 sandbox 数）。60 秒间隔在 1000 个并发 sandbox 下，约 17 QPS 的写入负载，对 Neon 完全可接受 |
+| **崩溃恢复误差** | 最大漏计时间 = 1 个 tick 间隔 = 60 秒。对于任何 sandbox 模板，60 秒的最大误差 ≤ 0.067 credits（xlarge），在可接受范围内 |
+| **Leader 切换** | Leader election 的 renew interval 通常为 10-15 秒，远小于 tick 间隔。新 leader 接手后最多 60 秒内会执行第一次 tick |
+| **行业参考** | Daytona 和 E2B 的公开文档表明其内部计量间隔在 30-120 秒范围内 |
+
+若未来 sandbox 规模超过 10,000，可考虑将 tick 改为批量 SQL 更新（单条 UPDATE ... FROM 子查询），而非逐行遍历。
+
+### 4.4 并发控制
+
+尽管 `tick_metering()` 通过 leader election 保证单点执行，仍需防御以下边界场景：
+
+#### 4.4.1 乐观锁机制
+
+每个 `ComputeSession` 的 `gmt_updated` 字段兼作乐观锁版本号。tick 更新时通过 `WHERE gmt_updated = :expected` 确保无并发修改：
+
+```python
+# 更新时携带 gmt_updated 条件
+rows = await session.execute(
+    update(ComputeSession)
+    .where(
+        ComputeSession.id == cs.id,
+        ComputeSession.gmt_updated == cs.gmt_updated,  # 乐观锁
+    )
+    .values(...)
+)
+if rows.rowcount == 0:
+    # 被 close_compute_session() 或其他操作抢先修改，跳过本次 tick
+    await session.rollback()
+```
+
+#### 4.4.2 需要防御的场景
+
+| 场景 | 风险 | 防御手段 |
+|------|------|---------|
+| Leader 切换重叠 | 旧 leader 的最后一次 tick 和新 leader 的第一次 tick 并发 | 乐观锁。两次 tick 不会重复计量——`last_metered_at` 确保增量不重叠 |
+| tick 和 close 并发 | `tick_metering()` 读取 session 后、更新前，`close_compute_session()` 抢先关闭了该 session | 乐观锁。tick 的 UPDATE rowcount=0，跳过。close 已完成最终计量 |
+| tick 执行时间 > 60 秒 | 下一个 tick 在上一个还没完成时启动 | 使用 `asyncio.Lock` 或在调度层确保上一次 tick 完成后才启动下一次 |
+
+### 4.5 与 sync_supervisor 的集成
+
+`tick_metering()` 集成到现有的 `LeaderControlledSyncSupervisor` 中，作为 sync loop 的一部分：
+
+```python
+async def _sync_loop_with_metering(
+    namespace: str,
+    k8s_client: K8sClientProtocol,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """原有 start_sync_loop 的增强版本，增加 tick_metering 定时任务。"""
+    metering_task = asyncio.create_task(
+        _periodic_tick_metering(session_factory)
+    )
+    try:
+        await start_sync_loop(namespace, k8s_client, session_factory)
+    finally:
+        metering_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await metering_task
+
+
+async def _periodic_tick_metering(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    while True:
+        await asyncio.sleep(TICK_INTERVAL)
+        try:
+            await tick_metering(session_factory)
+        except Exception:
+            logger.exception("tick_metering failed")
+```
+
+这样，`tick_metering()` 的生命周期与 K8s sync loop 完全绑定：只有 leader 节点运行 sync loop，也只有 leader 节点执行 tick。Leader 丧失后，sync loop 被 cancel，metering task 随之停止。
+
+---
+
+## 5. K8s Sync 集成
+
+### 5.1 集成点
+
+计量系统通过 hook 的方式嵌入现有的 `k8s_sync.py`，在 sandbox 状态转换时触发 session 的开启和关闭。
+
+| K8s Sync 事件 | 状态转换 | 计量操作 |
+|---------------|---------|---------|
+| Watch ADDED/MODIFIED | `creating → ready` | `open_compute_session()` |
+| Watch ADDED/MODIFIED | `ready → stopped` | `close_compute_session()` |
+| Watch ADDED/MODIFIED | `ready → error` | `close_compute_session()` |
+| Watch ADDED/MODIFIED | `ready → deleting` | `close_compute_session()` |
+| Watch DELETED | `deleting → deleted` | `close_compute_session()`（如有 open session） |
+| Reconcile | 发现 `ready` 的 sandbox 无 open session | `open_compute_session()`（修复遗漏） |
+| Reconcile | 发现非 `ready` 的 sandbox 有 open session | `close_compute_session()`（修复遗漏） |
+
+### 5.2 代码集成方式
+
+在 `handle_watch_event()` 和 `reconcile()` 的状态更新后，调用 `MeteringService`：
+
+```python
+# 在 k8s_sync.py 的 _optimistic_update 成功后增加：
+
+if new_status == SandboxStatus.READY and sandbox.status != SandboxStatus.READY:
+    await metering_service.open_compute_session(sandbox)
+
+if sandbox.status == SandboxStatus.READY and new_status in (
+    SandboxStatus.STOPPED,
+    SandboxStatus.ERROR,
+    SandboxStatus.DELETING,
+):
+    await metering_service.close_compute_session(sandbox.id)
+```
+
+### 5.3 完整交互序列图
+
+```mermaid
+sequenceDiagram
+    participant User as 用户/Agent
+    participant API as FastAPI
+    participant SBS as SandboxService
+    participant K8S as Kubernetes
+    participant Sync as K8sSync(Leader)
+    participant Meter as MeteringService
+    participant DB as Neon_DB
+
+    Note over User,DB: === 创建并启动 Sandbox ===
+
+    User->>API: POST /sandboxes {template:"small"}
+    API->>SBS: create(owner_id,template)
+    SBS->>DB: INSERT sandbox (status=creating)
+    SBS->>K8S: create SandboxClaim CR
+    API-->>User: 201 {id:"sb...",status:"creating"}
+
+    Note over K8S,Sync: K8s 控制器创建 Pod，sandbox 就绪
+
+    K8S-->>Sync: Watch EVENT: sandbox CR Ready
+    Sync->>DB: UPDATE sandbox SET status=ready
+    Sync->>Meter: open_compute_session(sandbox)
+    Meter->>DB: INSERT compute_session (started_at=now)
+
+    Note over Sync,DB: === 后台 Tick Metering (每60秒) ===
+
+    loop 每60秒
+        Sync->>Meter: tick_metering()
+        Meter->>DB: SELECT open compute_sessions
+        Meter->>DB: consume_compute_credits(user_id,new_credits)
+        Meter->>DB: UPDATE compute_session SET credits+=delta
+    end
+
+    Note over User,DB: === 停止 Sandbox ===
+
+    User->>API: POST /sandboxes/{id}/stop
+    API->>SBS: stop(sandbox_id,owner_id)
+    SBS->>DB: UPDATE sandbox SET status=stopped
+    SBS->>K8S: scale replicas=0
+
+    K8S-->>Sync: Watch EVENT: sandbox CR Stopped
+    Sync->>DB: UPDATE sandbox (确认stopped)
+    Sync->>Meter: close_compute_session(sandbox_id)
+    Meter->>DB: UPDATE compute_session SET ended_at=now, final credits
+
+    Note over User,DB: === 重新启动 Sandbox ===
+
+    User->>API: POST /sandboxes/{id}/start
+    API->>SBS: start(sandbox_id,owner_id)
+    SBS->>DB: UPDATE sandbox SET status=creating
+    SBS->>K8S: scale replicas=1
+
+    K8S-->>Sync: Watch EVENT: sandbox CR Ready
+    Sync->>DB: UPDATE sandbox SET status=ready
+    Sync->>Meter: open_compute_session(sandbox)
+    Meter->>DB: INSERT 新的 compute_session
+```
+
+### 5.4 Reconcile 中的计量修复
+
+`reconcile()` 作为 Watch 的兜底机制，除了修复 sandbox 状态漂移外，还要修复计量状态：
+
+```python
+async def reconcile_metering(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """检查并修复计量状态与 sandbox 状态的不一致。"""
+    async with session_factory() as session:
+        # 1. 找到 status=ready 但没有 open session 的 sandbox
+        ready_sandboxes = await session.execute(
+            select(Sandbox).where(Sandbox.status == SandboxStatus.READY)
+        )
+        for sandbox in ready_sandboxes.scalars():
+            open_session = await session.execute(
+                select(ComputeSession).where(
+                    ComputeSession.sandbox_id == sandbox.id,
+                    ComputeSession.ended_at.is_(None),
+                )
+            )
+            if open_session.scalar_one_or_none() is None:
+                logger.warning("Ready sandbox %s has no open session, opening one", sandbox.id)
+                await open_compute_session(session, sandbox)
+
+        # 2. 找到非 ready 状态但有 open session 的 sandbox
+        open_sessions = await session.execute(
+            select(ComputeSession).where(ComputeSession.ended_at.is_(None))
+        )
+        for cs in open_sessions.scalars():
+            sandbox = await session.get(Sandbox, cs.sandbox_id)
+            if sandbox is None or sandbox.status != SandboxStatus.READY:
+                logger.warning(
+                    "ComputeSession %s for sandbox %s is open but sandbox is %s, closing",
+                    cs.id, cs.sandbox_id,
+                    sandbox.status if sandbox else "deleted",
+                )
+                await close_compute_session(session, cs.sandbox_id)
+
+        await session.commit()
+```
+
+---
+
+## 6. 崩溃容错与对账
+
+### 6.1 服务端崩溃恢复
+
+**场景：** leader 节点崩溃并重启（或新节点当选 leader）。
+
+**恢复机制：**
+
+1. 新 leader 启动后，`tick_metering()` 被首次调度执行
+2. 查询所有 `ended_at IS NULL` 的 open sessions
+3. 对每个 session，计算 `now() - last_metered_at` 的差值
+4. 如果 leader 宕机了 5 分钟，`last_metered_at` 距 `now()` 就是 5 分钟
+5. tick 会一次性补算这 5 分钟的消耗
+
+**最大误差：** 等于最后一次成功 tick 到崩溃时刻的间隔，最大为 1 个 tick 周期（60 秒）。因为崩溃时正在处理的 tick 可能未提交。
+
+**数值示例：** 一个 xlarge sandbox（4 credits/h），leader 宕机 5 分钟后恢复：
+
+```
+补算量 = 5 * 60 / 3600 * 4 = 0.3333 credits
+最大误差 = 60 / 3600 * 4 = 0.0667 credits
+```
+
+### 6.2 K8s 事件丢失
+
+**场景：** Watch 连接断开时恰好错过了 sandbox 的状态变更。
+
+**恢复机制：**
+
+1. Watch 断开后，`start_sync_loop()` 会先执行一次完整的 `reconcile()`
+2. Reconcile 通过 List API 获取所有 sandbox CR 的当前状态，并与 DB 比对
+3. 如果发现 sandbox 已经 `stopped` 但 DB 仍为 `ready`，会更新 DB 状态
+4. 状态更新触发 `close_compute_session()`，关闭 open session
+5. 关闭时基于 `last_metered_at` 补算最后一段消耗
+
+此外，`_periodic_reconcile()` 每 300 秒运行一次兜底 reconcile，确保即使 Watch 看似正常运行但实际丢失了事件，状态也能最终一致。
+
+`reconcile_metering()` 会在每次 reconcile 后运行，检查计量状态与 sandbox 状态的一致性（详见 5.4 节）。
+
+### 6.3 `last_metered_at` 的幂等性保障
+
+`last_metered_at` 是计量系统的关键设计——它确保 tick 操作是**幂等安全的**：
+
+```
+每次 tick 的计量量 = (now - last_metered_at) × credit_rate_per_hour / 3600
+```
+
+- **正常 tick：** `last_metered_at` 距上次约 60 秒，计算 60 秒的增量
+- **补算 tick：** `last_metered_at` 距上次可能有几分钟，一次性补算全部
+- **重复 tick：** 如果 tick 刚刚执行过，`now - last_metered_at ≈ 0`，计量量趋近于 0
+- **乐观锁冲突：** UPDATE 的 WHERE 条件包含 `gmt_updated`，并发写入只有一个成功
+
+这个设计使得系统对 tick 的执行次数和时机具有鲁棒性——无论 tick 是准时、延迟、还是偶发多执行一次，计量结果都是正确的。
+
+### 6.4 时钟同步策略
+
+| 层面 | 策略 |
+|------|------|
+| 时区 | 所有时间戳使用 UTC（`DateTime(timezone=True)` + `datetime.now(UTC)`） |
+| 时间源 | `started_at`、`ended_at` 使用应用服务器时间（`utc_now()`），与现有 sandbox 模型一致 |
+| tick 增量计算 | 使用应用服务器时间差（`now - last_metered_at`），两个时间点来自同一服务器实例 |
+| 跨实例一致性 | Leader election 确保同一时刻只有一个实例执行 tick，不存在跨实例时钟比较 |
+| DB 默认值 | DDL 中的 `DEFAULT now()` 使用 DB 服务器时间，仅用于 `gmt_created` 兜底 |
+
+> **注意：** 如果未来需要多 leader 并行计量（如分片），则需要改为统一使用 DB 服务器时间（`SELECT now()` 或 `func.now()`），避免应用服务器之间的时钟偏移。当前单 leader 架构无此问题。
+
+---
+
+## 7. 月度重置对 ComputeSession 的影响
+
+### 7.1 问题
+
+用户的 sandbox 可能跨月运行。例如，一个 sandbox 从 3 月 28 日启动，持续运行到 4 月 2 日。月度额度在 4 月 1 日刷新，需要将跨月的 ComputeSession 正确分割。
+
+### 7.2 处理流程
+
+当 `tick_metering()` 检测到当前时间已超过用户的 `period_end`：
+
+```
+1. 关闭旧 ComputeSession
+   - ended_at = period_end
+   - 计算 last_metered_at → period_end 之间的最终消耗
+
+2. 重置 UserPlan 月度额度
+   - compute_credits_monthly_used = 0
+   - period_start = old period_end
+   - period_end = old period_end + 1 month
+
+3. 为仍在运行的 sandbox 创建新 ComputeSession
+   - started_at = new period_start (即旧 period_end)
+   - credit_rate_per_hour = 原费率（模板不变）
+   - credits_consumed = 0
+```
+
+### 7.3 实现伪代码
+
+```python
+async def handle_period_rollover(
+    session: AsyncSession,
+    cs: ComputeSession,
+    plan: UserPlan,
+) -> ComputeSession | None:
+    """处理跨月 session 分割。返回新创建的 session（如 sandbox 仍在运行）。"""
+    now = utc_now()
+    if now <= plan.period_end:
+        return None  # 未跨月
+
+    period_boundary = plan.period_end
+
+    # 1. 关闭旧 session，截止到 period_end
+    elapsed = (period_boundary - cs.last_metered_at).total_seconds()
+    if elapsed > 0:
+        final_credits = (
+            Decimal(str(elapsed)) / Decimal("3600") * cs.credit_rate_per_hour
+        )
+        consume_result = await consume_compute_credits(
+            session, cs.user_id, final_credits
+        )
+        cs.credits_consumed += final_credits
+        cs.credits_consumed_monthly += consume_result.monthly
+        cs.credits_consumed_extra += consume_result.extra
+
+    cs.ended_at = period_boundary
+    cs.last_metered_at = period_boundary
+    cs.gmt_updated = now
+    session.add(cs)
+
+    # 2. 重置月度额度
+    plan.compute_credits_monthly_used = Decimal("0")
+    plan.period_start = period_boundary
+    plan.period_end = period_boundary + relativedelta(months=1)
+    plan.gmt_updated = now
+    session.add(plan)
+
+    # 3. 检查 sandbox 是否仍在运行
+    sandbox = await session.get(Sandbox, cs.sandbox_id)
+    if sandbox is None or sandbox.status != SandboxStatus.READY:
+        return None
+
+    # 4. 创建新 session，从新周期起点开始
+    new_cs = ComputeSession(
+        sandbox_id=cs.sandbox_id,
+        user_id=cs.user_id,
+        template=cs.template,
+        credit_rate_per_hour=cs.credit_rate_per_hour,
+        started_at=period_boundary,
+        last_metered_at=period_boundary,
+        credits_consumed=Decimal("0"),
+        credits_consumed_monthly=Decimal("0"),
+        credits_consumed_extra=Decimal("0"),
+    )
+    session.add(new_cs)
+    await session.commit()
+
+    # 5. 新周期内 period_boundary → now 的消耗，交给下一次 tick 处理
+    return new_cs
+```
+
+### 7.4 时序示意
+
+```
+3月28日 10:00          3月31日 23:59:59         4月1日 00:00:00          4月2日 15:00
+    |                       |                       |                       |
+    |<-- ComputeSession A -->|                       |                       |
+    |   (3月度额度消费)      |                       |                       |
+    |                       |   <- period boundary   |                       |
+    |                       |                       |<-- ComputeSession B -->|
+    |                       |                       |   (4月度额度消费)      |
+```
+
+- Session A：`started_at = 3/28 10:00`，`ended_at = 4/1 00:00`
+- Session B：`started_at = 4/1 00:00`，`ended_at = 4/2 15:00`（sandbox 停止时关闭）
+
+---
+
+## 8. 与 SandboxService 的集成
+
+### 8.1 配额前置检查
+
+在 `sandbox_service.py` 的 `create()` 和 `start()` 方法中，增加配额检查逻辑，在实际创建/启动 K8s 资源之前拦截超额请求。
+
+#### 8.1.1 检查项
+
+| 检查 | 函数 | 失败时的错误 |
+|------|------|------------|
+| Compute 额度余量 | `check_compute_quota(user_id)` | `ComputeQuotaExceededError` (402) |
+| 并发 sandbox 数 | `check_concurrent_limit(user_id)` | `ConcurrentLimitExceededError` (429) |
+| 模板权限 | `check_template_allowed(user_id, template)` | `TemplateForbiddenError` (403) |
+
+#### 8.1.2 Error 子类定义
+
+```python
+class ComputeQuotaExceededError(TreadstoneError):
+    def __init__(self, user_id: str):
+        super().__init__(
+            code="compute_quota_exceeded",
+            message="Compute credit quota exceeded. Please upgrade your plan or purchase additional credits.",
+            status=402,
+        )
+
+
+class ConcurrentLimitExceededError(TreadstoneError):
+    def __init__(self, user_id: str, limit: int):
+        super().__init__(
+            code="concurrent_limit_exceeded",
+            message=f"Maximum concurrent sandbox limit ({limit}) reached.",
+            status=429,
+        )
+
+
+class TemplateForbiddenError(TreadstoneError):
+    def __init__(self, template: str, plan_name: str):
+        super().__init__(
+            code="template_forbidden",
+            message=f"Template '{template}' is not available on the {plan_name} plan.",
+            status=403,
+        )
+```
+
+#### 8.1.3 集成伪代码
+
+```python
+class SandboxService:
+    async def create(self, owner_id: str, template: str, ...) -> Sandbox:
+        # === 新增：配额前置检查 ===
+        await self._check_quotas(owner_id, template)
+
+        # === 原有逻辑 ===
+        sandbox_id = "sb" + random_id()
+        # ... (后续不变)
+
+    async def start(self, sandbox_id: str, owner_id: str) -> Sandbox:
+        sandbox = await self.get(sandbox_id, owner_id)
+        if sandbox is None:
+            raise SandboxNotFoundError(sandbox_id)
+
+        # === 新增：配额前置检查 ===
+        await self._check_quotas(owner_id, sandbox.template)
+
+        # === 原有逻辑 ===
+        if sandbox.status != SandboxStatus.STOPPED:
+            raise InvalidTransitionError(sandbox_id, sandbox.status, "ready")
+        # ... (后续不变)
+
+    async def _check_quotas(self, user_id: str, template: str) -> None:
+        plan = await get_user_plan(self.session, user_id)
+
+        # 1. 模板权限
+        if template not in plan.allowed_templates:
+            raise TemplateForbiddenError(template, plan.plan_name)
+
+        # 2. 并发 sandbox 数
+        active_count = await self._count_active_sandboxes(user_id)
+        if active_count >= plan.max_concurrent_sandboxes:
+            raise ConcurrentLimitExceededError(user_id, plan.max_concurrent_sandboxes)
+
+        # 3. Compute 额度余量
+        monthly_remaining = (
+            plan.compute_credits_monthly_limit - plan.compute_credits_monthly_used
+        )
+        extra_remaining = await self._sum_extra_credits(user_id, "compute")
+        total_remaining = monthly_remaining + extra_remaining
+        if total_remaining <= Decimal("0"):
+            raise ComputeQuotaExceededError(user_id)
+
+    async def _count_active_sandboxes(self, user_id: str) -> int:
+        result = await self.session.execute(
+            select(func.count(Sandbox.id)).where(
+                Sandbox.owner_id == user_id,
+                Sandbox.status.in_([
+                    SandboxStatus.CREATING,
+                    SandboxStatus.READY,
+                ]),
+            )
+        )
+        return result.scalar_one()
+
+    async def _sum_extra_credits(self, user_id: str, credit_type: str) -> Decimal:
+        now = utc_now()
+        result = await self.session.execute(
+            select(func.coalesce(func.sum(CreditGrant.remaining_amount), 0)).where(
+                CreditGrant.user_id == user_id,
+                CreditGrant.credit_type == credit_type,
+                CreditGrant.remaining_amount > 0,
+                or_(
+                    CreditGrant.expires_at.is_(None),
+                    CreditGrant.expires_at > now,
+                ),
+            )
+        )
+        return result.scalar_one()
+```
+
+### 8.2 审计日志集成
+
+配额检查失败时，需要记录审计事件：
+
+```python
+await record_audit_event(
+    session,
+    action="sandbox.create.quota_check_failed",
+    target_type="sandbox",
+    target_id=None,
+    actor_user_id=user_id,
+    metadata={
+        "reason": error.code,
+        "template": template,
+        "plan": plan.plan_name,
+    },
+    request=request,
+)
+```
+
+---
+
+## 9. Acceptance Scenarios
+
+### 场景 1：Free 用户使用 tiny 模板运行 2 小时
+
+**前提：** Free 用户月度额度 10 credits，已使用 0 credits。
+
+| 时间 | 事件 | credits_consumed | monthly_used |
+|------|------|-----------------|-------------|
+| T+0min | sandbox 创建，status=ready | 0 | 0 |
+| T+1min | tick #1 | 0.0042 | 0.0042 |
+| T+2min | tick #2 | 0.0083 | 0.0083 |
+| ... | ... | ... | ... |
+| T+120min | tick #120 | 0.5000 | 0.5000 |
+| T+120min | sandbox stop | 0.5000 (final) | 0.5000 |
+
+**期望结果：** 消耗 0.5 credits（0.25 credits/h × 2h），全部从月度额度扣除。
+
+### 场景 2：Pro 用户月度额度用完后自动切换到 Extra Credits
+
+**前提：** Pro 用户月度额度 100 credits，已使用 99.8 credits。持有一笔 50 credits 的 Extra Grant。使用 medium 模板（1 credit/h）。
+
+| 时间 | 事件 | monthly_consumed | extra_consumed | 说明 |
+|------|------|-----------------|---------------|------|
+| T+0min | sandbox ready | 0 | 0 | |
+| T+1min | tick #1 | 0.0167 | 0 | 月度剩余 0.2，足够 |
+| ... | ... | ... | ... | |
+| T+12min | tick #12 | 0.2 | 0 | 月度额度恰好用完 |
+| T+13min | tick #13 | 0 | 0.0167 | 自动切换到 Extra |
+| ... | ... | ... | ... | |
+| T+60min | tick #60 | 0.2 | 0.8 | |
+
+**期望结果：** 月度消耗 0.2 credits（刚好用完），Extra 消耗 0.8 credits。用户体验无中断。
+
+### 场景 3：跨月运行的 sandbox 正确分割 credits
+
+**前提：** 用户从 3 月 31 日 22:00 UTC 启动 large 模板（2 credits/h），运行到 4 月 1 日 02:00 UTC。
+
+| 时间 | 事件 | Session | 消耗 |
+|------|------|---------|------|
+| 3/31 22:00 | sandbox ready | Session A created | - |
+| 3/31 23:59 | 最后一次 3 月 tick | Session A | 3.97 credits (3月度) |
+| 4/1 00:00 | period rollover | Session A closed (ended_at=4/1 00:00), Session B created | A final = 4.0 credits |
+| 4/1 00:00 | 月度额度重置 | - | monthly_used = 0 |
+| 4/1 00:01 | 4 月首次 tick | Session B | 0.033 credits (4月度) |
+| 4/1 02:00 | sandbox stop | Session B closed | B final = 4.0 credits |
+
+**期望结果：** Session A 消耗 4.0 credits（计入 3 月），Session B 消耗 4.0 credits（计入 4 月）。
+
+### 场景 4：服务端崩溃后 tick 自动补算
+
+**前提：** small 模板（0.5 credits/h）sandbox 运行中。Leader 在 T+10min 崩溃，T+15min 新 leader 当选。
+
+| 时间 | 事件 | last_metered_at | credits_consumed |
+|------|------|----------------|-----------------|
+| T+9min | 最后成功 tick | T+9min | 0.075 |
+| T+10min | leader 崩溃 | (无变化) | 0.075 |
+| T+15min | 新 leader 首次 tick | T+15min | 0.125 |
+
+**期望结果：** 新 leader 的首次 tick 补算了 T+9min 到 T+15min 的 6 分钟消耗（0.05 credits），无需人工干预。最大漏计 = 60 秒 = 0.0083 credits。
+
+### 场景 5：并发 sandbox 数达到上限时拒绝创建
+
+**前提：** Free 用户并发上限 3 个 sandbox，当前已有 3 个处于 `ready` / `creating` 状态。
+
+| 操作 | 结果 |
+|------|------|
+| POST /sandboxes | 返回 429 `concurrent_limit_exceeded` |
+| 停止 1 个 sandbox | - |
+| POST /sandboxes | 返回 201 Created |
+
+**期望结果：** 配额检查在 K8s 资源创建之前执行，用户收到明确的错误信息。
+
+### 场景 6：Extra Credits 按过期时间优先消费
+
+**前提：** 用户月度额度已耗尽。持有两笔 Extra Grant：
+- Grant A：10 credits，expires_at = 4 月 15 日
+- Grant B：20 credits，expires_at = NULL（永不过期）
+
+消费 5 credits。
+
+| Grant | 消费前 remaining | 消费后 remaining |
+|-------|-----------------|-----------------|
+| Grant A (4/15 过期) | 10 | 5 |
+| Grant B (永不过期) | 20 | 20 |
+
+**期望结果：** 优先从即将过期的 Grant A 扣除，Grant B 保持不变。
+
+### 场景 7：模板权限检查阻止越权使用
+
+**前提：** Free 用户的 `allowed_templates = ["tiny", "small"]`。
+
+| 操作 | 结果 |
+|------|------|
+| POST /sandboxes {template:"tiny"} | 201 Created |
+| POST /sandboxes {template:"xlarge"} | 403 `template_forbidden` |
+
+**期望结果：** 用户无法使用超出其套餐权限的模板。
+
+### 场景 8：Watch 事件丢失后 Reconcile 修复计量
+
+**前提：** sandbox 实际已被 K8s 停止（replicas=0），但 Watch 事件丢失，DB 中仍为 `ready`。
+
+| 时间 | 事件 | 计量状态 |
+|------|------|---------|
+| T+0 | K8s 停止 sandbox，Watch 事件丢失 | session 仍 open，继续被 tick |
+| T+5min | periodic reconcile 运行 | reconcile 发现 CR replicas=0，更新 DB status=stopped |
+| T+5min | 状态变更触发 close_compute_session | session closed，ended_at = T+5min |
+
+**期望结果：** 最大多计 = reconcile 间隔（300 秒）。在 300 秒内，tick 按 `ready` 状态持续计量，直到 reconcile 修复。这是一个已知的、可接受的边界——实际的 K8s Watch 丢失率极低。
+
+---
+
+## 附录 A：费率计算函数
+
+```python
+from decimal import Decimal
+
+TEMPLATE_SPECS: dict[str, dict[str, Decimal]] = {
+    "tiny":   {"vcpu": Decimal("0.25"), "memory_gib": Decimal("0.5")},
+    "small":  {"vcpu": Decimal("0.5"),  "memory_gib": Decimal("1")},
+    "medium": {"vcpu": Decimal("1"),    "memory_gib": Decimal("2")},
+    "large":  {"vcpu": Decimal("2"),    "memory_gib": Decimal("4")},
+    "xlarge": {"vcpu": Decimal("4"),    "memory_gib": Decimal("8")},
+}
+
+
+def calculate_credit_rate(template: str) -> Decimal:
+    spec = TEMPLATE_SPECS.get(template)
+    if spec is None:
+        raise ValueError(f"Unknown template: {template}")
+    return max(spec["vcpu"], spec["memory_gib"] / Decimal("2"))
+```
+
+## 附录 B：关键 SQL 查询
+
+### B.1 查询用户当月 Compute 消耗明细
+
+```sql
+SELECT
+    cs.sandbox_id,
+    s.name AS sandbox_name,
+    cs.template,
+    cs.started_at,
+    cs.ended_at,
+    cs.credits_consumed,
+    cs.credits_consumed_monthly,
+    cs.credits_consumed_extra
+FROM compute_session cs
+JOIN sandbox s ON s.id = cs.sandbox_id
+WHERE cs.user_id = :user_id
+  AND cs.started_at >= :period_start
+  AND (cs.ended_at IS NULL OR cs.ended_at <= :period_end)
+ORDER BY cs.started_at DESC;
+```
+
+### B.2 查询当前所有 open sessions（tick_metering 核心查询）
+
+```sql
+SELECT * FROM compute_session
+WHERE ended_at IS NULL;
+```
+
+### B.3 查询用户可用 Extra Credits 总量
+
+```sql
+SELECT COALESCE(SUM(remaining_amount), 0) AS total_extra
+FROM credit_grant
+WHERE user_id = :user_id
+  AND credit_type = 'compute'
+  AND remaining_amount > 0
+  AND (expires_at IS NULL OR expires_at > now());
+```

--- a/docs/zh-CN/design/2026-03-26-metering-enforcement.md
+++ b/docs/zh-CN/design/2026-03-26-metering-enforcement.md
@@ -1,0 +1,2100 @@
+# 配额执行与 API 设计
+
+**日期：** 2026-03-26
+**状态：** 设计中
+**关联文档：** [计量系统总览](2026-03-26-metering-overview.md)
+
+---
+
+## 1. 配额检查总流程
+
+Sandbox 生命周期的关键节点需要执行配额检查，以确保用户在其 Tier 允许的范围内使用资源。
+
+### 1.1 Create Sandbox 时的检查
+
+创建 sandbox 是最严格的检查点，需要通过全部 5 项检查后才能继续：
+
+1. **check_template_allowed(user_id, template)** — 检查用户所属 Tier 是否有权使用目标模板（如 Free 用户不能使用 `medium` / `large` 模板）
+2. **check_compute_quota(user_id)** — 检查 Compute Credits 是否有剩余（月度额度 + Extra Credits 总余额 > 0）
+3. **check_concurrent_limit(user_id)** — 检查当前运行中（`status = creating | ready`）的 sandbox 数量是否已达到并发上限
+4. **if persist: check_storage_quota(user_id, size_gib)** — 仅当 `persist=True` 时，检查存储配额是否足够分配请求的空间
+5. **check_sandbox_duration(user_id, template)** — 获取 Tier 允许的最长运行时间并与模板默认时长对比，超出则拒绝
+
+所有检查通过后执行原有的 `SandboxService.create()` 逻辑，并在创建成功后记录存储分配。
+
+### 1.2 Start Sandbox 时的检查
+
+从 `stopped` 状态恢复时执行较轻量的检查：
+
+1. **check_compute_quota(user_id)** — 恢复运行需要 Compute Credits
+2. **check_concurrent_limit(user_id)** — 恢复后同样占用一个并发槽位
+
+不需要重复 template、storage、duration 检查（创建时已验证）。
+
+### 1.3 Stop / Delete Sandbox
+
+不需要任何配额检查，始终允许执行。用户在任何情况下都可以主动停止或删除自己的 sandbox，包括在 grace period 和 enforcement 状态下。
+
+### 1.4 Create Sandbox 配额检查流程图
+
+```mermaid
+flowchart TD
+    A[用户请求CreateSandbox] --> B{check_template_allowed}
+    B -->|不允许| B_ERR[TemplateNotAllowedError 403]
+    B -->|允许| C{check_compute_quota}
+    C -->|额度不足| C_ERR[ComputeQuotaExceededError 402]
+    C -->|额度充足| D{check_concurrent_limit}
+    D -->|达到上限| D_ERR[ConcurrentLimitError 429]
+    D -->|未达上限| E{persist?}
+    E -->|否| G{check_sandbox_duration}
+    E -->|是| F{check_storage_quota}
+    F -->|存储不足| F_ERR[StorageQuotaExceededError 402]
+    F -->|存储充足| G
+    G -->|超过最长时间| G_ERR[SandboxDurationExceededError 400]
+    G -->|允许| H[执行SandboxService.create]
+    H --> I{创建成功?}
+    I -->|是| J{persist?}
+    J -->|是| K[record_storage_allocation]
+    J -->|否| L[open_compute_session]
+    K --> L
+    L --> M[返回Sandbox]
+    I -->|否| N[原有错误处理]
+```
+
+### 1.5 检查顺序设计原则
+
+检查按照「用户可操作性」排序——越容易通过自助操作解决的错误越先检查：
+
+| 顺序 | 检查 | 用户自助解决方式 |
+|------|------|---------------|
+| 1 | template_allowed | 升级 Tier |
+| 2 | compute_quota | 等待月度重置，或购买 Extra Credits |
+| 3 | concurrent_limit | 停止已有 sandbox |
+| 4 | storage_quota | 删除已有持久化 sandbox |
+| 5 | sandbox_duration | 调小 auto_stop_interval |
+
+---
+
+## 2. 新增 Error 类型
+
+在 `treadstone/core/errors.py` 中新增以下错误类，全部继承自 `TreadstoneError` 基类，遵循统一 JSON envelope 格式。
+
+### 2.1 ComputeQuotaExceededError (HTTP 402)
+
+选择 402 (Payment Required) 是因为该错误本质上是「资源使用已达上限，需要付费购买更多额度」，未来对接支付后语义完全对应。
+
+```python
+class ComputeQuotaExceededError(TreadstoneError):
+    def __init__(
+        self,
+        monthly_used: float,
+        monthly_limit: float,
+        extra_remaining: float,
+    ):
+        super().__init__(
+            code="compute_quota_exceeded",
+            message=(
+                f"Compute credits exhausted. "
+                f"Monthly used: {monthly_used:.1f} / {monthly_limit:.1f} vCPU-hours, "
+                f"extra remaining: {extra_remaining:.1f} vCPU-hours. "
+                f"Please wait for the next billing cycle or purchase additional credits."
+            ),
+            status=402,
+        )
+```
+
+**响应示例：**
+
+```json
+{
+  "error": {
+    "code": "compute_quota_exceeded",
+    "message": "Compute credits exhausted. Monthly used: 100.0 / 100.0 vCPU-hours, extra remaining: 0.0 vCPU-hours. Please wait for the next billing cycle or purchase additional credits.",
+    "status": 402
+  }
+}
+```
+
+### 2.2 StorageQuotaExceededError (HTTP 402)
+
+```python
+class StorageQuotaExceededError(TreadstoneError):
+    def __init__(
+        self,
+        current_used_gib: int,
+        requested_gib: int,
+        total_quota_gib: int,
+    ):
+        super().__init__(
+            code="storage_quota_exceeded",
+            message=(
+                f"Storage quota exceeded. "
+                f"Current used: {current_used_gib} GiB, requested: {requested_gib} GiB, "
+                f"total quota: {total_quota_gib} GiB (available: {total_quota_gib - current_used_gib} GiB). "
+                f"Delete existing persistent sandboxes to free space, or upgrade your plan."
+            ),
+            status=402,
+        )
+```
+
+**响应示例：**
+
+```json
+{
+  "error": {
+    "code": "storage_quota_exceeded",
+    "message": "Storage quota exceeded. Current used: 8 GiB, requested: 5 GiB, total quota: 10 GiB (available: 2 GiB). Delete existing persistent sandboxes to free space, or upgrade your plan.",
+    "status": 402
+  }
+}
+```
+
+### 2.3 ConcurrentLimitError (HTTP 429)
+
+选择 429 (Too Many Requests) 是因为该错误表示「当前并发请求数过多」，与 HTTP 语义一致。客户端收到 429 后应停止已有 sandbox 再重试。
+
+```python
+class ConcurrentLimitError(TreadstoneError):
+    def __init__(self, current_running: int, max_concurrent: int):
+        super().__init__(
+            code="concurrent_limit_exceeded",
+            message=(
+                f"Concurrent sandbox limit reached. "
+                f"Running: {current_running} / {max_concurrent}. "
+                f"Stop an existing sandbox before creating a new one."
+            ),
+            status=429,
+        )
+```
+
+**响应示例：**
+
+```json
+{
+  "error": {
+    "code": "concurrent_limit_exceeded",
+    "message": "Concurrent sandbox limit reached. Running: 3 / 3. Stop an existing sandbox before creating a new one.",
+    "status": 429
+  }
+}
+```
+
+### 2.4 TemplateNotAllowedError (HTTP 403)
+
+```python
+class TemplateNotAllowedError(TreadstoneError):
+    def __init__(self, tier: str, template: str, allowed_templates: list[str]):
+        super().__init__(
+            code="template_not_allowed",
+            message=(
+                f"Template '{template}' is not available on the '{tier}' tier. "
+                f"Allowed templates: {', '.join(allowed_templates)}. "
+                f"Upgrade your plan to access this template."
+            ),
+            status=403,
+        )
+```
+
+**响应示例：**
+
+```json
+{
+  "error": {
+    "code": "template_not_allowed",
+    "message": "Template 'medium' is not available on the 'free' tier. Allowed templates: tiny, small. Upgrade your plan to access this template.",
+    "status": 403
+  }
+}
+```
+
+### 2.5 SandboxDurationExceededError (HTTP 400)
+
+```python
+class SandboxDurationExceededError(TreadstoneError):
+    def __init__(self, tier: str, max_duration_seconds: int):
+        hours = max_duration_seconds // 3600
+        minutes = (max_duration_seconds % 3600) // 60
+        duration_str = f"{hours}h{minutes}m" if minutes else f"{hours}h"
+        super().__init__(
+            code="sandbox_duration_exceeded",
+            message=(
+                f"Requested sandbox duration exceeds the '{tier}' tier maximum of {duration_str}. "
+                f"Reduce auto_stop_interval or upgrade your plan."
+            ),
+            status=400,
+        )
+```
+
+**响应示例：**
+
+```json
+{
+  "error": {
+    "code": "sandbox_duration_exceeded",
+    "message": "Requested sandbox duration exceeds the 'free' tier maximum of 2h. Reduce auto_stop_interval or upgrade your plan.",
+    "status": 400
+  }
+}
+```
+
+### 2.6 Error 类汇总
+
+| Error 类 | HTTP Status | code | 触发场景 |
+|----------|-------------|------|---------|
+| ComputeQuotaExceededError | 402 | compute_quota_exceeded | 月度 + extra 额度全部耗尽 |
+| StorageQuotaExceededError | 402 | storage_quota_exceeded | 存储已用 + 请求量 > 总配额 |
+| ConcurrentLimitError | 429 | concurrent_limit_exceeded | 运行中 sandbox 数达到上限 |
+| TemplateNotAllowedError | 403 | template_not_allowed | Tier 不允许使用目标模板 |
+| SandboxDurationExceededError | 400 | sandbox_duration_exceeded | 超过 Tier 最长运行时间 |
+
+所有错误均通过现有的 `TreadstoneError` 异常处理链（`main.py` 中的 `treadstone_error_handler`）自动转换为统一 JSON 格式。无需额外注册处理器。
+
+---
+
+## 3. Grace Period 状态机
+
+当 Compute Credits 完全耗尽（月度 + Extra 均为 0）时，系统不会立即强制停止所有运行中 sandbox，而是进入一个 Grace Period（宽限期），给用户时间保存工作。
+
+### 3.1 状态定义
+
+| 状态 | 条件 | 用户可执行操作 | 系统行为 |
+|------|------|--------------|---------|
+| **normal** | `monthly_used < 80% of limit`（或有足够的 extra） | 全部操作 | 无 |
+| **warning_80** | `monthly_used >= 80% of limit`（但 monthly + extra 仍有余额）| 全部操作 | 记录 `metering.compute_warning_80` 审计事件 |
+| **warning_100** | `monthly + extra` 全部耗尽 | 禁止 `create` / `start`；运行中 sandbox 继续运行 | 记录 `metering.compute_warning_100`；运行中 sandbox 进入 grace period |
+| **grace_period** | 耗尽后 grace period 倒计时中 | 禁止 `create` / `start`；可以 `stop` / `delete` | 记录 `metering.grace_period_started`；持续检查倒计时 |
+| **enforcement** | grace period 到期（或超过绝对上限） | 仅 `stop` / `delete` | 自动 stop 所有运行中 sandbox；记录 `metering.auto_stop` |
+
+### 3.2 Grace Period 时长
+
+不同 Tier 的 Grace Period 时长不同，在 TierTemplate 中配置：
+
+| Tier | Grace Period | 说明 |
+|------|-------------|------|
+| Free | 10 分钟 | 最短宽限，鼓励升级 |
+| Pro | 30 分钟 | 足够保存工作 |
+| Ultra | 60 分钟 | 充裕时间 |
+| Enterprise | 自定义（默认 120 分钟） | 通过 `overrides` 调整 |
+
+### 3.3 状态转换图
+
+```mermaid
+stateDiagram-v2
+    [*] --> Normal
+
+    Normal --> Warning80: monthly_used>=80%
+    Warning80 --> Normal: extra充值/月度重置
+    Warning80 --> Warning100: monthly+extra全部耗尽
+
+    Warning100 --> GracePeriod: 检测到运行中sandbox
+    Warning100 --> Normal: extra充值/月度重置
+
+    GracePeriod --> Enforcement: grace_period到期
+    GracePeriod --> Enforcement: 超过绝对上限(20%)
+    GracePeriod --> Normal: extra充值/月度重置
+
+    Enforcement --> Normal: extra充值/月度重置
+    Enforcement --> [*]: 所有sandbox已stop
+
+    note right of Normal
+        monthly_used < 80% of limit
+        或有足够 extra credits
+    end note
+
+    note right of GracePeriod
+        grace_period_started_at已设置
+        倒计时进行中
+    end note
+
+    note right of Enforcement
+        自动stop所有运行中sandbox
+        grace_period_started_at重置为null
+    end note
+```
+
+### 3.4 Grace Period 计时实现
+
+在 `UserPlan` 模型中添加字段：
+
+```python
+grace_period_started_at: Mapped[datetime | None] = mapped_column(
+    DateTime(timezone=True), nullable=True, default=None
+)
+```
+
+- `None` 表示当前不在 grace period 中
+- 非 `None` 表示 grace period 的起始时间
+
+### 3.5 tick_metering() 中的 Grace Period 检查
+
+`tick_metering()` 由 `sync_supervisor` 在 leader 节点上定期调用（建议间隔 60 秒），核心逻辑如下：
+
+```python
+async def check_grace_periods(self, session: AsyncSession) -> None:
+    """检查所有用户的 grace period 状态，执行自动 stop。"""
+    # 查询所有有运行中 sandbox 的用户
+    users_with_running = await self._get_users_with_running_sandboxes(session)
+
+    for user_id in users_with_running:
+        plan = await self.get_user_plan(session, user_id)
+        total_remaining = await self.get_total_compute_remaining(session, user_id)
+
+        if total_remaining <= 0:
+            # 额度耗尽
+            if plan.grace_period_started_at is None:
+                # 首次检测到耗尽 → 启动 grace period
+                plan.grace_period_started_at = utc_now()
+                session.add(plan)
+                await record_audit_event(
+                    session,
+                    action="metering.grace_period_started",
+                    target_type="user",
+                    target_id=user_id,
+                    actor_type=AuditActorType.SYSTEM.value,
+                    metadata={
+                        "tier": plan.tier,
+                        "grace_period_seconds": plan.grace_period_seconds,
+                        "monthly_used": float(plan.compute_credits_monthly_used),
+                        "monthly_limit": float(plan.compute_credits_monthly_limit),
+                    },
+                )
+                await session.commit()
+                continue
+
+            elapsed = (utc_now() - plan.grace_period_started_at).total_seconds()
+
+            # 检查绝对上限：grace period 内超额消耗不超过月度额度的 20%
+            overage = abs(total_remaining)  # total_remaining 为负数
+            absolute_cap = float(plan.compute_credits_monthly_limit) * 0.20
+            exceeded_absolute_cap = overage > absolute_cap
+
+            if elapsed > plan.grace_period_seconds or exceeded_absolute_cap:
+                # Grace period 到期或超过绝对上限 → 自动 stop
+                reason = "absolute_cap_exceeded" if exceeded_absolute_cap else "grace_period_expired"
+                sandboxes = await self._get_running_sandboxes(session, user_id)
+                for sandbox in sandboxes:
+                    await self._force_stop_sandbox(session, sandbox)
+                    await record_audit_event(
+                        session,
+                        action="metering.auto_stop",
+                        target_type="sandbox",
+                        target_id=sandbox.id,
+                        actor_type=AuditActorType.SYSTEM.value,
+                        metadata={
+                            "user_id": user_id,
+                            "tier": plan.tier,
+                            "reason": reason,
+                            "grace_elapsed_seconds": int(elapsed),
+                            "overage_vcpu_hours": float(overage),
+                        },
+                    )
+                plan.grace_period_started_at = None
+                session.add(plan)
+                await session.commit()
+        else:
+            # 额度恢复（比如 admin 手动添加了 extra credits）
+            if plan.grace_period_started_at is not None:
+                plan.grace_period_started_at = None
+                session.add(plan)
+                await record_audit_event(
+                    session,
+                    action="metering.grace_period_cleared",
+                    target_type="user",
+                    target_id=user_id,
+                    actor_type=AuditActorType.SYSTEM.value,
+                    metadata={
+                        "tier": plan.tier,
+                        "total_remaining": float(total_remaining),
+                    },
+                )
+                await session.commit()
+```
+
+### 3.6 绝对上限
+
+Grace Period 内允许的最大超额消耗 = **Tier 月度额度的 20%**。
+
+| Tier | 月度额度 | 绝对上限 (20%) | Grace Period |
+|------|---------|---------------|-------------|
+| Free | 10 vCPU-hours | 2 vCPU-hours | 10 分钟 |
+| Pro | 100 vCPU-hours | 20 vCPU-hours | 30 分钟 |
+| Ultra | 500 vCPU-hours | 100 vCPU-hours | 60 分钟 |
+| Enterprise | 自定义 | 自定义 × 20% | 自定义 |
+
+超过绝对上限时立即 stop 所有运行中 sandbox，不等 grace period 计时结束。这防止了长时间运行的高配 sandbox 在 grace period 内消耗过多资源。
+
+### 3.7 与 auto_stop_interval 的关系
+
+| 机制 | 作用域 | 触发条件 | 执行者 |
+|------|--------|---------|--------|
+| `auto_stop_interval` | 单个 sandbox | 该 sandbox 空闲超过指定分钟数 | K8s Sandbox Controller |
+| Grace Period | 用户级别（全局） | 用户 compute credits 耗尽 | MeteringService.check_grace_periods() |
+
+两者独立运行，互不干扰。当两者同时满足时，**取先到者执行 stop**：
+- 如果 sandbox 先空闲超时，K8s controller 会 scale 到 0，`k8s_sync` 会将状态同步为 `stopped`
+- 如果 grace period 先到期，`check_grace_periods()` 会通过 `_force_stop_sandbox()` 执行 stop
+
+### 3.8 create / start 时的 Grace Period 感知
+
+在 `check_compute_quota()` 中，如果 `total_remaining <= 0`，直接抛出 `ComputeQuotaExceededError`，不区分是否在 grace period 中。这意味着：
+
+- 用户在 grace period 中**无法**创建新 sandbox 或启动已停止的 sandbox
+- 用户在 grace period 中**可以**正常使用运行中的 sandbox、执行 stop、执行 delete
+- Grace period 只影响新增资源消耗，不影响释放资源
+
+---
+
+## 4. 通知事件
+
+Phase 1 通过审计日志（`audit_event` 表）记录计量通知事件。不发送邮件 / Webhook / 推送。未来 Phase 2 扩展通知渠道时，从审计日志中读取事件即可。
+
+### 4.1 事件列表
+
+| 事件 | action | 触发条件 | 严重程度 |
+|------|--------|---------|---------|
+| 80% 预警 | `metering.compute_warning_80` | `monthly_used >= 80% of monthly_limit`（首次跨越阈值时触发一次） | warning |
+| 100% 预警 | `metering.compute_warning_100` | `monthly + extra` 全部耗尽 | critical |
+| Grace Period 开始 | `metering.grace_period_started` | 首次检测到 credit 耗尽且有运行中 sandbox | critical |
+| Grace Period 恢复 | `metering.grace_period_cleared` | 在 grace period 中恢复了额度 | info |
+| 自动 Stop | `metering.auto_stop` | grace period 过期或超过绝对上限 | critical |
+| 存储超配 | `metering.storage_overcommit` | 月度重置后存储超出新配额（降级场景） | warning |
+| 月度重置 | `metering.monthly_reset` | 月度额度重置完成 | info |
+| Extra Credits 发放 | `metering.credits_granted` | admin 手动或批量发放 extra credits | info |
+
+### 4.2 事件 metadata 结构
+
+所有计量事件的 `event_metadata` 统一包含以下基础字段：
+
+```json
+{
+  "user_id": "user_abc123",
+  "tier": "pro",
+  "credits_monthly_used": 95.5,
+  "credits_monthly_limit": 100.0,
+  "credits_extra_remaining": 0.0,
+  "credits_total_remaining": 4.5,
+  "timestamp": "2026-03-26T10:30:00Z"
+}
+```
+
+不同事件会附加额外字段：
+
+**metering.grace_period_started** 额外字段：
+```json
+{
+  "grace_period_seconds": 1800,
+  "running_sandbox_count": 2,
+  "running_sandbox_ids": ["sb_xxx", "sb_yyy"]
+}
+```
+
+**metering.auto_stop** 额外字段：
+```json
+{
+  "reason": "grace_period_expired",
+  "grace_elapsed_seconds": 1823,
+  "stopped_sandbox_ids": ["sb_xxx", "sb_yyy"],
+  "overage_vcpu_hours": 5.2
+}
+```
+
+**metering.storage_overcommit** 额外字段：
+```json
+{
+  "current_storage_used_gib": 15,
+  "new_storage_quota_gib": 10,
+  "overcommit_gib": 5
+}
+```
+
+**metering.credits_granted** 额外字段：
+```json
+{
+  "grant_id": "cg_xxx",
+  "credit_type": "compute",
+  "amount": 100.0,
+  "grant_type": "admin_grant",
+  "granted_by": "user_admin_id",
+  "reason": "特殊支持",
+  "expires_at": "2026-06-01T00:00:00Z"
+}
+```
+
+### 4.3 防重复触发
+
+对于阈值类事件（`warning_80`、`warning_100`、`storage_overcommit`），使用 `UserPlan` 中的标志位避免在同一个 billing period 内重复触发：
+
+```python
+warning_80_notified_at: Mapped[datetime | None] = mapped_column(
+    DateTime(timezone=True), nullable=True, default=None
+)
+warning_100_notified_at: Mapped[datetime | None] = mapped_column(
+    DateTime(timezone=True), nullable=True, default=None
+)
+```
+
+月度重置时将这两个字段清零，确保下个周期可以重新触发。
+
+---
+
+## 5. Usage API
+
+新建 `treadstone/api/usage.py`，路由前缀 `/v1/usage`，`tags=["usage"]`。
+
+所有端点使用 `get_current_control_plane_user` 认证（支持 session cookie 和 `sk-` API Key）。
+
+### 5.1 GET /v1/usage — 使用概览
+
+返回当前用户的完整配额使用概览，是前端仪表盘和 CLI 的主要数据源。
+
+**认证**：`get_current_control_plane_user`
+
+**请求**：
+
+```
+GET /v1/usage HTTP/1.1
+Authorization: Bearer sk-xxxxxxxxxxxxxxxx
+```
+
+**成功响应**（200 OK）：
+
+```json
+{
+  "tier": "pro",
+  "billing_period": {
+    "start": "2026-03-01T00:00:00Z",
+    "end": "2026-04-01T00:00:00Z"
+  },
+  "compute": {
+    "monthly_limit": 100.0,
+    "monthly_used": 45.5,
+    "monthly_remaining": 54.5,
+    "extra_remaining": 50.0,
+    "total_remaining": 104.5,
+    "unit": "vCPU-hours"
+  },
+  "storage": {
+    "monthly_limit": 10,
+    "extra_remaining": 0,
+    "total_quota": 10,
+    "current_used": 5,
+    "available": 5,
+    "unit": "GiB"
+  },
+  "limits": {
+    "max_concurrent_running": 3,
+    "current_running": 1,
+    "max_sandbox_duration_seconds": 7200,
+    "allowed_templates": ["tiny", "small", "medium"]
+  },
+  "grace_period": {
+    "active": false,
+    "started_at": null,
+    "expires_at": null,
+    "grace_period_seconds": 1800
+  }
+}
+```
+
+**当 grace period 激活时**：
+
+```json
+{
+  "tier": "pro",
+  "billing_period": {
+    "start": "2026-03-01T00:00:00Z",
+    "end": "2026-04-01T00:00:00Z"
+  },
+  "compute": {
+    "monthly_limit": 100.0,
+    "monthly_used": 100.0,
+    "monthly_remaining": 0.0,
+    "extra_remaining": 0.0,
+    "total_remaining": -3.2,
+    "unit": "vCPU-hours"
+  },
+  "storage": {
+    "monthly_limit": 10,
+    "extra_remaining": 0,
+    "total_quota": 10,
+    "current_used": 5,
+    "available": 5,
+    "unit": "GiB"
+  },
+  "limits": {
+    "max_concurrent_running": 3,
+    "current_running": 2,
+    "max_sandbox_duration_seconds": 7200,
+    "allowed_templates": ["tiny", "small", "medium"]
+  },
+  "grace_period": {
+    "active": true,
+    "started_at": "2026-03-26T10:00:00Z",
+    "expires_at": "2026-03-26T10:30:00Z",
+    "grace_period_seconds": 1800
+  }
+}
+```
+
+**路由实现骨架**：
+
+```python
+@router.get("", tags=["usage"])
+async def get_usage(
+    user: User = Depends(get_current_control_plane_user),
+    session: AsyncSession = Depends(get_session),
+):
+    metering = MeteringService()
+    summary = await metering.get_usage_summary(session, user.id)
+    return summary
+```
+
+### 5.2 GET /v1/usage/plan — 完整 Plan 详情
+
+返回用户 `UserPlan` 的完整字段，包括所有配额数值、overrides、period 信息。
+
+**认证**：`get_current_control_plane_user`
+
+**请求**：
+
+```
+GET /v1/usage/plan HTTP/1.1
+Cookie: session=...
+```
+
+**成功响应**（200 OK）：
+
+```json
+{
+  "id": "plan_abc123",
+  "user_id": "user_abc123",
+  "tier": "pro",
+  "compute_credits_monthly_limit": 100.0,
+  "compute_credits_monthly_used": 45.5,
+  "storage_credits_monthly_limit": 10,
+  "max_concurrent_running": 3,
+  "max_sandbox_duration_seconds": 7200,
+  "allowed_templates": ["tiny", "small", "medium"],
+  "grace_period_seconds": 1800,
+  "overrides": {
+    "compute_credits_monthly_limit": 150
+  },
+  "billing_period_start": "2026-03-01T00:00:00Z",
+  "billing_period_end": "2026-04-01T00:00:00Z",
+  "grace_period_started_at": null,
+  "warning_80_notified_at": null,
+  "warning_100_notified_at": null,
+  "created_at": "2026-01-15T08:00:00Z",
+  "updated_at": "2026-03-01T00:00:00Z"
+}
+```
+
+**路由实现骨架**：
+
+```python
+@router.get("/plan", tags=["usage"])
+async def get_plan(
+    user: User = Depends(get_current_control_plane_user),
+    session: AsyncSession = Depends(get_session),
+):
+    metering = MeteringService()
+    plan = await metering.get_user_plan(session, user.id)
+    return plan.to_dict()
+```
+
+### 5.3 GET /v1/usage/sessions — Compute Session 列表
+
+返回用户的 ComputeSession 分页列表，每个 session 对应一次 sandbox 运行周期。
+
+**认证**：`get_current_control_plane_user`
+
+**Query 参数**：
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `status` | string | `"all"` | `"active"` / `"completed"` / `"all"` |
+| `limit` | int | 20 | 每页数量，最大 100 |
+| `offset` | int | 0 | 偏移量 |
+
+**请求**：
+
+```
+GET /v1/usage/sessions?status=active&limit=10&offset=0 HTTP/1.1
+Authorization: Bearer sk-xxxxxxxxxxxxxxxx
+```
+
+**成功响应**（200 OK）：
+
+```json
+{
+  "items": [
+    {
+      "id": "cs_abc123",
+      "sandbox_id": "sb_xxx",
+      "sandbox_name": "my-dev-env",
+      "template": "small",
+      "vcpu_millicores": 1000,
+      "started_at": "2026-03-26T08:00:00Z",
+      "ended_at": null,
+      "duration_seconds": 7200,
+      "credits_consumed": 2.0,
+      "status": "active"
+    },
+    {
+      "id": "cs_def456",
+      "sandbox_id": "sb_yyy",
+      "sandbox_name": "test-runner",
+      "template": "tiny",
+      "vcpu_millicores": 500,
+      "started_at": "2026-03-25T14:00:00Z",
+      "ended_at": "2026-03-25T16:30:00Z",
+      "duration_seconds": 9000,
+      "credits_consumed": 1.25,
+      "status": "completed"
+    }
+  ],
+  "total": 42,
+  "limit": 10,
+  "offset": 0
+}
+```
+
+**路由实现骨架**：
+
+```python
+@router.get("/sessions", tags=["usage"])
+async def list_compute_sessions(
+    user: User = Depends(get_current_control_plane_user),
+    session: AsyncSession = Depends(get_session),
+    status: str = Query(default="all", regex="^(active|completed|all)$"),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+):
+    metering = MeteringService()
+    items, total = await metering.list_compute_sessions(
+        session, user.id, status=status, limit=limit, offset=offset
+    )
+    return {"items": [s.to_dict() for s in items], "total": total, "limit": limit, "offset": offset}
+```
+
+### 5.4 GET /v1/usage/grants — Credit Grant 列表
+
+返回用户的所有 CreditGrant 记录，包括已用完和已过期的。
+
+**认证**：`get_current_control_plane_user`
+
+**请求**：
+
+```
+GET /v1/usage/grants HTTP/1.1
+Authorization: Bearer sk-xxxxxxxxxxxxxxxx
+```
+
+**成功响应**（200 OK）：
+
+```json
+{
+  "items": [
+    {
+      "id": "cg_abc123",
+      "credit_type": "compute",
+      "amount": 100.0,
+      "remaining": 50.0,
+      "grant_type": "admin_grant",
+      "reason": "特殊支持",
+      "granted_by": "user_admin_id",
+      "campaign_id": null,
+      "status": "active",
+      "created_at": "2026-03-01T00:00:00Z",
+      "expires_at": "2026-06-01T00:00:00Z"
+    },
+    {
+      "id": "cg_def456",
+      "credit_type": "compute",
+      "amount": 50.0,
+      "remaining": 0.0,
+      "grant_type": "campaign",
+      "reason": "春季促销活动",
+      "granted_by": "user_admin_id",
+      "campaign_id": "spring_2026_promo",
+      "status": "exhausted",
+      "created_at": "2026-02-15T00:00:00Z",
+      "expires_at": "2026-04-01T00:00:00Z"
+    },
+    {
+      "id": "cg_ghi789",
+      "credit_type": "storage",
+      "amount": 5,
+      "remaining": 5,
+      "grant_type": "admin_grant",
+      "reason": "额外存储需求",
+      "granted_by": "user_admin_id",
+      "campaign_id": null,
+      "status": "active",
+      "created_at": "2026-03-20T00:00:00Z",
+      "expires_at": null
+    }
+  ]
+}
+```
+
+**Grant status 计算规则**（虚拟字段，不存储在 DB）：
+
+| status | 条件 |
+|--------|------|
+| `active` | `remaining > 0` 且未过期 |
+| `exhausted` | `remaining <= 0` |
+| `expired` | `expires_at < now()` 且 `remaining > 0` |
+
+**路由实现骨架**：
+
+```python
+@router.get("/grants", tags=["usage"])
+async def list_credit_grants(
+    user: User = Depends(get_current_control_plane_user),
+    session: AsyncSession = Depends(get_session),
+):
+    metering = MeteringService()
+    grants = await metering.list_credit_grants(session, user.id)
+    return {"items": [g.to_response_dict() for g in grants]}
+```
+
+---
+
+## 6. Admin API
+
+新建 `treadstone/api/admin.py`，路由前缀 `/v1/admin`，`tags=["admin"]`。
+
+所有端点使用 `get_current_admin` 认证（检查 `user.role == "admin"`）。
+
+### 6.1 GET /v1/admin/users/{user_id}/usage — 查看任意用户使用概览
+
+管理员可以查看任意用户的使用情况，响应格式与 `GET /v1/usage` 完全一致。
+
+**认证**：`get_current_admin`
+
+**请求**：
+
+```
+GET /v1/admin/users/user_abc123/usage HTTP/1.1
+Authorization: Bearer sk-admin-key
+```
+
+**成功响应**（200 OK）：格式同 `GET /v1/usage`。
+
+**用户不存在时**（404）：
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "User 'user_abc123' not found.",
+    "status": 404
+  }
+}
+```
+
+**路由实现骨架**：
+
+```python
+@router.get("/users/{user_id}/usage", tags=["admin"])
+async def admin_get_user_usage(
+    user_id: str,
+    admin: User = Depends(get_current_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    target_user = await session.get(User, user_id)
+    if target_user is None:
+        raise NotFoundError("User", user_id)
+    metering = MeteringService()
+    return await metering.get_usage_summary(session, user_id)
+```
+
+### 6.2 PATCH /v1/admin/users/{user_id}/plan — 修改用户 Plan
+
+修改用户的 Tier 和/或 override 特定配额值。
+
+**认证**：`get_current_admin`
+
+**请求**：
+
+```
+PATCH /v1/admin/users/user_abc123/plan HTTP/1.1
+Authorization: Bearer sk-admin-key
+Content-Type: application/json
+
+{
+  "tier": "ultra",
+  "overrides": {
+    "compute_credits_monthly_limit": 500,
+    "max_concurrent_running": 10
+  }
+}
+```
+
+**Request Body 字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `tier` | string | 否 | 新的 Tier 名称，必须是已存在的 TierTemplate |
+| `overrides` | object | 否 | 覆盖特定配额值，key 为 UserPlan 字段名 |
+
+**合法的 overrides key**：
+
+- `compute_credits_monthly_limit` (float)
+- `storage_credits_monthly_limit` (int)
+- `max_concurrent_running` (int)
+- `max_sandbox_duration_seconds` (int)
+- `allowed_templates` (list[str])
+- `grace_period_seconds` (int)
+
+**处理逻辑**：
+
+1. 如果指定了 `tier`，从 `TierTemplate` 加载新 Tier 的默认值
+2. 将 TierTemplate 的默认值写入 UserPlan（覆盖旧值）
+3. 将 `overrides` 中的值叠加到 UserPlan 上（优先级最高）
+4. 将 `overrides` JSON 保存到 UserPlan.overrides 字段（用于审计和回溯）
+5. 记录审计事件 `admin.user.plan_updated`
+
+**成功响应**（200 OK）：返回更新后的完整 UserPlan。
+
+```json
+{
+  "id": "plan_abc123",
+  "user_id": "user_abc123",
+  "tier": "ultra",
+  "compute_credits_monthly_limit": 500.0,
+  "compute_credits_monthly_used": 45.5,
+  "storage_credits_monthly_limit": 50,
+  "max_concurrent_running": 10,
+  "max_sandbox_duration_seconds": 14400,
+  "allowed_templates": ["tiny", "small", "medium", "large"],
+  "grace_period_seconds": 3600,
+  "overrides": {
+    "compute_credits_monthly_limit": 500,
+    "max_concurrent_running": 10
+  },
+  "billing_period_start": "2026-03-01T00:00:00Z",
+  "billing_period_end": "2026-04-01T00:00:00Z",
+  "updated_at": "2026-03-26T12:00:00Z"
+}
+```
+
+**失败场景**：
+
+- Tier 不存在 → `NotFoundError("TierTemplate", tier_name)` (404)
+- overrides 中包含不合法的 key → `ValidationError` (422)
+
+### 6.3 POST /v1/admin/users/{user_id}/grants — 添加 Extra Credits
+
+管理员手动给用户添加 Extra Credits。
+
+**认证**：`get_current_admin`
+
+**请求**：
+
+```
+POST /v1/admin/users/user_abc123/grants HTTP/1.1
+Authorization: Bearer sk-admin-key
+Content-Type: application/json
+
+{
+  "credit_type": "compute",
+  "amount": 100,
+  "grant_type": "admin_grant",
+  "reason": "特殊支持",
+  "expires_at": "2026-06-01T00:00:00Z"
+}
+```
+
+**Request Body 字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `credit_type` | string | 是 | `"compute"` 或 `"storage"` |
+| `amount` | float | 是 | 发放数量（compute: vCPU-hours，storage: GiB）|
+| `grant_type` | string | 是 | `"admin_grant"` / `"campaign"` / `"compensation"` |
+| `reason` | string | 否 | 发放原因（纯文本记录） |
+| `campaign_id` | string | 否 | 营销活动 ID（仅 `grant_type=campaign` 时有意义） |
+| `expires_at` | datetime | 否 | 过期时间，null 表示永不过期 |
+
+**处理逻辑**：
+
+1. 创建 `CreditGrant` 记录，`granted_by = admin_user.id`，`remaining = amount`
+2. 如果用户当前在 grace period 中且 credit_type 为 compute，恢复的额度可能使 `total_remaining > 0`。下一次 `check_grace_periods()` 会自动清除 grace period
+3. 记录审计事件 `metering.credits_granted`
+
+**成功响应**（201 Created）：
+
+```json
+{
+  "id": "cg_new123",
+  "user_id": "user_abc123",
+  "credit_type": "compute",
+  "amount": 100.0,
+  "remaining": 100.0,
+  "grant_type": "admin_grant",
+  "reason": "特殊支持",
+  "granted_by": "user_admin_id",
+  "campaign_id": null,
+  "created_at": "2026-03-26T12:00:00Z",
+  "expires_at": "2026-06-01T00:00:00Z"
+}
+```
+
+### 6.4 GET /v1/admin/tier-templates — 获取所有 Tier 模板
+
+**认证**：`get_current_admin`
+
+**请求**：
+
+```
+GET /v1/admin/tier-templates HTTP/1.1
+Authorization: Bearer sk-admin-key
+```
+
+**成功响应**（200 OK）：
+
+```json
+{
+  "items": [
+    {
+      "tier": "free",
+      "compute_credits_monthly": 10.0,
+      "storage_credits_monthly": 1,
+      "max_concurrent_running": 1,
+      "max_sandbox_duration_seconds": 3600,
+      "allowed_templates": ["tiny"],
+      "grace_period_seconds": 600,
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "tier": "pro",
+      "compute_credits_monthly": 100.0,
+      "storage_credits_monthly": 10,
+      "max_concurrent_running": 3,
+      "max_sandbox_duration_seconds": 7200,
+      "allowed_templates": ["tiny", "small", "medium"],
+      "grace_period_seconds": 1800,
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "tier": "ultra",
+      "compute_credits_monthly": 500.0,
+      "storage_credits_monthly": 50,
+      "max_concurrent_running": 10,
+      "max_sandbox_duration_seconds": 14400,
+      "allowed_templates": ["tiny", "small", "medium", "large"],
+      "grace_period_seconds": 3600,
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "tier": "enterprise",
+      "compute_credits_monthly": 5000.0,
+      "storage_credits_monthly": 500,
+      "max_concurrent_running": 50,
+      "max_sandbox_duration_seconds": 86400,
+      "allowed_templates": ["tiny", "small", "medium", "large", "gpu"],
+      "grace_period_seconds": 7200,
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+### 6.5 PATCH /v1/admin/tier-templates/{tier_name} — 修改 Tier 模板
+
+修改 TierTemplate 的默认配额值。
+
+**认证**：`get_current_admin`
+
+**请求**：
+
+```
+PATCH /v1/admin/tier-templates/pro HTTP/1.1
+Authorization: Bearer sk-admin-key
+Content-Type: application/json
+
+{
+  "compute_credits_monthly": 150,
+  "storage_credits_monthly": 15,
+  "apply_to_existing": false
+}
+```
+
+**Request Body 字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `compute_credits_monthly` | float | 否 | 新的月度 compute credits |
+| `storage_credits_monthly` | int | 否 | 新的月度 storage credits |
+| `max_concurrent_running` | int | 否 | 新的并发上限 |
+| `max_sandbox_duration_seconds` | int | 否 | 新的最长运行时间 |
+| `allowed_templates` | list[str] | 否 | 新的允许模板列表 |
+| `grace_period_seconds` | int | 否 | 新的 grace period 时长 |
+| `apply_to_existing` | bool | 否 | 是否将变更应用到该 Tier 的所有现有用户，默认 `false` |
+
+**处理逻辑**：
+
+1. 更新 TierTemplate 的对应字段
+2. 如果 `apply_to_existing = true`：
+   - 查询所有 `tier = tier_name` 且没有 overrides 的用户
+   - 批量更新这些用户的 UserPlan 对应字段
+   - 有 overrides 的用户不受影响（override 优先）
+3. 记录审计事件 `admin.tier_template.updated`，metadata 中包含变更前后的值和影响的用户数
+
+**成功响应**（200 OK）：
+
+```json
+{
+  "tier": "pro",
+  "compute_credits_monthly": 150.0,
+  "storage_credits_monthly": 15,
+  "max_concurrent_running": 3,
+  "max_sandbox_duration_seconds": 7200,
+  "allowed_templates": ["tiny", "small", "medium"],
+  "grace_period_seconds": 1800,
+  "updated_at": "2026-03-26T12:00:00Z",
+  "users_affected": 0
+}
+```
+
+**当 `apply_to_existing = true` 时**：
+
+```json
+{
+  "tier": "pro",
+  "compute_credits_monthly": 150.0,
+  "storage_credits_monthly": 15,
+  "max_concurrent_running": 3,
+  "max_sandbox_duration_seconds": 7200,
+  "allowed_templates": ["tiny", "small", "medium"],
+  "grace_period_seconds": 1800,
+  "updated_at": "2026-03-26T12:00:00Z",
+  "users_affected": 127
+}
+```
+
+### 6.6 POST /v1/admin/grants/batch — 批量发放 Extra Credits
+
+用于营销活动、补偿等场景，一次性给多个用户发放 Extra Credits。
+
+**认证**：`get_current_admin`
+
+**请求**：
+
+```
+POST /v1/admin/grants/batch HTTP/1.1
+Authorization: Bearer sk-admin-key
+Content-Type: application/json
+
+{
+  "user_ids": ["user_abc1", "user_abc2", "user_abc3"],
+  "credit_type": "compute",
+  "amount": 50,
+  "grant_type": "campaign",
+  "campaign_id": "spring_2026_promo",
+  "reason": "春季促销活动",
+  "expires_at": "2026-06-01T00:00:00Z"
+}
+```
+
+**Request Body 字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `user_ids` | list[str] | 是 | 用户 ID 列表，最多 1000 个 |
+| `credit_type` | string | 是 | `"compute"` 或 `"storage"` |
+| `amount` | float | 是 | 每个用户发放的数量 |
+| `grant_type` | string | 是 | `"campaign"` / `"compensation"` / `"admin_grant"` |
+| `campaign_id` | string | 否 | 营销活动 ID |
+| `reason` | string | 否 | 发放原因 |
+| `expires_at` | datetime | 否 | 过期时间 |
+
+**处理逻辑**：
+
+1. 验证所有 `user_ids` 对应的用户存在（不存在的 ID 记录在 `failed` 列表中）
+2. 为每个存在的用户创建 `CreditGrant`
+3. 为每个成功的 grant 记录审计事件 `metering.credits_granted`
+4. 事务级别：每个用户的 grant 独立事务，部分失败不影响其他用户
+
+**成功响应**（200 OK）：
+
+```json
+{
+  "total_requested": 3,
+  "succeeded": 3,
+  "failed": 0,
+  "results": [
+    {
+      "user_id": "user_abc1",
+      "grant_id": "cg_001",
+      "status": "success"
+    },
+    {
+      "user_id": "user_abc2",
+      "grant_id": "cg_002",
+      "status": "success"
+    },
+    {
+      "user_id": "user_abc3",
+      "grant_id": "cg_003",
+      "status": "success"
+    }
+  ]
+}
+```
+
+**部分失败时**（200 OK，但 `failed > 0`）：
+
+```json
+{
+  "total_requested": 3,
+  "succeeded": 2,
+  "failed": 1,
+  "results": [
+    {
+      "user_id": "user_abc1",
+      "grant_id": "cg_001",
+      "status": "success"
+    },
+    {
+      "user_id": "user_nonexist",
+      "grant_id": null,
+      "status": "failed",
+      "error": "User not found"
+    },
+    {
+      "user_id": "user_abc3",
+      "grant_id": "cg_003",
+      "status": "success"
+    }
+  ]
+}
+```
+
+---
+
+## 7. MeteringService 方法签名与接口设计
+
+新建 `treadstone/services/metering_service.py`，包含所有配额检查、会话管理、Credit Grant 和后台任务的核心业务逻辑。
+
+### 7.1 完整方法签名
+
+```python
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from treadstone.models.metering import (
+    ComputeSession,
+    CreditGrant,
+    StorageLedger,
+    TierTemplate,
+    UserPlan,
+)
+from treadstone.models.sandbox import Sandbox
+
+
+class MeteringService:
+    """配额检查与计量核心服务。
+
+    所有方法接受 AsyncSession 作为参数（而非在构造时注入），
+    与 SandboxService 的模式保持一致。
+    """
+
+    # ── Plan Management ──
+
+    async def ensure_user_plan(
+        self, session: AsyncSession, user_id: str, tier: str = "free"
+    ) -> UserPlan:
+        """获取或创建用户的 UserPlan。
+        首次调用时从 TierTemplate 拷贝默认值。
+        幂等：如果 UserPlan 已存在则直接返回。
+        """
+        ...
+
+    async def get_user_plan(
+        self, session: AsyncSession, user_id: str
+    ) -> UserPlan:
+        """获取用户的 UserPlan，不存在时调用 ensure_user_plan 自动创建。"""
+        ...
+
+    async def update_user_tier(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        new_tier: str,
+        overrides: dict | None = None,
+    ) -> UserPlan:
+        """变更用户 Tier。
+        从 TierTemplate 加载新 Tier 的默认值，
+        然后叠加 overrides 中的覆盖值。
+        """
+        ...
+
+    # ── Quota Checks ──
+    # 检查通过时无返回值，不通过时抛出对应 TreadstoneError 子类。
+    # 抛异常而非返回 bool 的设计：调用方无需手动构建错误信息，
+    # 且异常会被 main.py 的全局处理器自动转为 JSON 响应。
+
+    async def check_compute_quota(
+        self, session: AsyncSession, user_id: str
+    ) -> None:
+        """检查用户 compute credits 是否有剩余。
+        total_remaining = monthly_remaining + extra_remaining
+        如果 total_remaining <= 0，抛出 ComputeQuotaExceededError。
+        """
+        ...
+
+    async def check_storage_quota(
+        self, session: AsyncSession, user_id: str, requested_gib: int
+    ) -> None:
+        """检查用户存储配额是否足够分配 requested_gib。
+        total_quota = monthly_limit + extra_storage
+        available = total_quota - current_used
+        如果 available < requested_gib，抛出 StorageQuotaExceededError。
+        """
+        ...
+
+    async def check_concurrent_limit(
+        self, session: AsyncSession, user_id: str
+    ) -> None:
+        """检查用户当前运行中 sandbox 数是否达到上限。
+        running = count(sandbox where owner_id=user_id and status in (creating, ready))
+        如果 running >= max_concurrent_running，抛出 ConcurrentLimitError。
+        """
+        ...
+
+    async def check_template_allowed(
+        self, session: AsyncSession, user_id: str, template: str
+    ) -> None:
+        """检查用户所属 Tier 是否允许使用目标模板。
+        如果 template not in allowed_templates，抛出 TemplateNotAllowedError。
+        """
+        ...
+
+    async def check_sandbox_duration(
+        self, session: AsyncSession, user_id: str
+    ) -> int:
+        """返回用户 Tier 允许的最大 sandbox 运行秒数。
+        调用方可用此值校验 auto_stop_interval。
+        """
+        ...
+
+    # ── Compute Session Management ──
+
+    async def open_compute_session(
+        self, session: AsyncSession, sandbox: Sandbox
+    ) -> ComputeSession:
+        """当 sandbox 进入 ready 状态时，打开一个 ComputeSession。
+        记录 sandbox 的 vCPU millicores、started_at 等信息。
+        由 k8s_sync 在状态变为 ready 时调用。
+        """
+        ...
+
+    async def close_compute_session(
+        self, session: AsyncSession, sandbox_id: str
+    ) -> ComputeSession:
+        """当 sandbox 进入 stopped/deleting 状态时，关闭 ComputeSession。
+        计算持续时间、消耗的 credits，并更新 UserPlan.compute_credits_monthly_used。
+        由 k8s_sync 在状态变为 stopped 时调用。
+        """
+        ...
+
+    # ── Storage Management ──
+
+    async def record_storage_allocation(
+        self, session: AsyncSession, sandbox: Sandbox
+    ) -> StorageLedger:
+        """当 persist sandbox 创建成功时，记录存储分配。
+        创建一条 event_type=allocate 的 StorageLedger 记录。
+        """
+        ...
+
+    async def record_storage_release(
+        self, session: AsyncSession, sandbox_id: str
+    ) -> StorageLedger:
+        """当 persist sandbox 删除时，记录存储释放。
+        创建一条 event_type=release 的 StorageLedger 记录。
+        """
+        ...
+
+    # ── Credit Grant Management ──
+
+    async def create_credit_grant(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        credit_type: str,
+        amount: float,
+        grant_type: str,
+        granted_by: str | None = None,
+        reason: str | None = None,
+        campaign_id: str | None = None,
+        expires_at: datetime | None = None,
+    ) -> CreditGrant:
+        """创建一条 CreditGrant 记录。
+        remaining 初始值等于 amount。
+        """
+        ...
+
+    async def list_credit_grants(
+        self, session: AsyncSession, user_id: str
+    ) -> list[CreditGrant]:
+        """返回用户的所有 CreditGrant，按 created_at 降序。"""
+        ...
+
+    # ── Background Tasks ──
+
+    async def tick_metering(self, session: AsyncSession) -> None:
+        """定期计量对账（建议 60 秒间隔）。
+        遍历所有活跃 ComputeSession，更新 credits_consumed。
+        遍历所有用户，检查 80%/100% 阈值并记录通知事件。
+        """
+        ...
+
+    async def tick_storage_metering(self, session: AsyncSession) -> None:
+        """定期存储计量更新。
+        遍历所有活跃的存储分配，更新 gib_hours_consumed。
+        """
+        ...
+
+    async def check_grace_periods(self, session: AsyncSession) -> None:
+        """检查并执行 grace period 逻辑。
+        详见第 3.5 节。
+        """
+        ...
+
+    async def reset_monthly_credits(self, session: AsyncSession) -> None:
+        """月度重置。
+        将所有 UserPlan 的 compute_credits_monthly_used 归零，
+        更新 billing_period_start/end，
+        清除 warning_80_notified_at 和 warning_100_notified_at。
+        不影响 extra credits。
+        存储配额 current_used 不重置（持久化 sandbox 持续占用）。
+        """
+        ...
+
+    # ── Usage Queries ──
+
+    async def get_usage_summary(
+        self, session: AsyncSession, user_id: str
+    ) -> dict:
+        """聚合用户的完整使用概览（供 GET /v1/usage 使用）。
+        返回结构详见第 5.1 节。
+        """
+        ...
+
+    async def get_total_compute_remaining(
+        self, session: AsyncSession, user_id: str
+    ) -> Decimal:
+        """计算用户的 compute 总剩余额度。
+        = (monthly_limit - monthly_used) + sum(active_extra_grants.remaining)
+        注意：结果可能为负数（grace period 超额场景）。
+        """
+        ...
+
+    async def get_total_storage_quota(
+        self, session: AsyncSession, user_id: str
+    ) -> int:
+        """计算用户的 storage 总配额 (GiB)。
+        = monthly_limit + sum(active_storage_grants.remaining)
+        """
+        ...
+
+    async def get_current_storage_used(
+        self, session: AsyncSession, user_id: str
+    ) -> int:
+        """获取用户当前实际占用的存储 (GiB)。
+        = sum(sandbox.storage_size where persist=true and status != deleting)
+        """
+        ...
+
+    async def list_compute_sessions(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        status: str = "all",
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[ComputeSession], int]:
+        """分页查询用户的 ComputeSession 列表。"""
+        ...
+
+    # ── Internal Helpers ──
+
+    async def _get_users_with_running_sandboxes(
+        self, session: AsyncSession
+    ) -> list[str]:
+        """查询所有有运行中 sandbox 的 user_id。"""
+        ...
+
+    async def _get_running_sandboxes(
+        self, session: AsyncSession, user_id: str
+    ) -> list[Sandbox]:
+        """查询用户所有 status in (creating, ready) 的 sandbox。"""
+        ...
+
+    async def _force_stop_sandbox(
+        self, session: AsyncSession, sandbox: Sandbox
+    ) -> None:
+        """强制 stop sandbox（grace period enforcement 用）。
+        直接通过 K8s client scale 到 0 并更新 DB 状态。
+        """
+        ...
+
+    async def _consume_extra_credits(
+        self, session: AsyncSession, user_id: str, amount: Decimal
+    ) -> Decimal:
+        """从 extra credits 中扣减。
+        按 FIFO（expires_at ASC）顺序消耗 grants。
+        返回实际扣减的数量。
+        """
+        ...
+```
+
+### 7.2 Extra Credits 消费策略
+
+Extra Credits 的消费遵循以下优先级：
+
+1. **先消耗月度额度**：当 `monthly_remaining > 0` 时，优先从月度额度扣减
+2. **月度耗尽后消耗 Extra**：当 `monthly_remaining <= 0` 时，从 `CreditGrant` 扣减
+3. **Extra 内部 FIFO**：多个 CreditGrant 按 `expires_at ASC`（先过期的先消耗）排序消耗
+4. **跳过已过期的 Grant**：`expires_at < now()` 的 grant 不参与消费
+
+```python
+async def _consume_extra_credits(
+    self, session: AsyncSession, user_id: str, amount: Decimal
+) -> Decimal:
+    grants = await session.execute(
+        select(CreditGrant)
+        .where(
+            CreditGrant.user_id == user_id,
+            CreditGrant.credit_type == "compute",
+            CreditGrant.remaining > 0,
+            or_(
+                CreditGrant.expires_at.is_(None),
+                CreditGrant.expires_at > utc_now(),
+            ),
+        )
+        .order_by(CreditGrant.expires_at.asc().nullslast())
+    )
+    remaining_to_consume = amount
+    for grant in grants.scalars().all():
+        if remaining_to_consume <= 0:
+            break
+        deduction = min(grant.remaining, remaining_to_consume)
+        grant.remaining -= deduction
+        remaining_to_consume -= deduction
+        session.add(grant)
+    return amount - remaining_to_consume  # 实际消耗量
+```
+
+---
+
+## 8. 与 SandboxService 的集成方式
+
+### 8.1 SandboxService 改造
+
+在 `SandboxService` 中注入 `MeteringService`，在生命周期关键节点调用配额检查。
+
+**改造后的 `SandboxService.__init__`**：
+
+```python
+class SandboxService:
+    def __init__(
+        self,
+        session: AsyncSession,
+        k8s_client: K8sClientProtocol | None = None,
+        metering: MeteringService | None = None,
+    ):
+        self.session = session
+        self.k8s = k8s_client or get_k8s_client()
+        self._metering = metering or MeteringService()
+```
+
+### 8.2 create() 集成
+
+```python
+async def create(
+    self,
+    owner_id: str,
+    template: str,
+    name: str | None = None,
+    labels: dict | None = None,
+    auto_stop_interval: int = 15,
+    auto_delete_interval: int = -1,
+    persist: bool = False,
+    storage_size: str | None = None,
+) -> Sandbox:
+    # ── Phase 1: 配额检查 ──
+    await self._metering.check_template_allowed(self.session, owner_id, template)
+    await self._metering.check_compute_quota(self.session, owner_id)
+    await self._metering.check_concurrent_limit(self.session, owner_id)
+
+    effective_storage_size = storage_size or settings.sandbox_default_storage_size
+    if persist:
+        size_gib = self._parse_storage_size_gib(effective_storage_size)
+        await self._metering.check_storage_quota(self.session, owner_id, size_gib)
+
+    max_duration = await self._metering.check_sandbox_duration(self.session, owner_id)
+    if auto_stop_interval > 0 and (auto_stop_interval * 60) > max_duration:
+        raise SandboxDurationExceededError(
+            tier=(await self._metering.get_user_plan(self.session, owner_id)).tier,
+            max_duration_seconds=max_duration,
+        )
+
+    # ── Phase 2: 原有创建逻辑（不变） ──
+    if persist:
+        await self._ensure_persistent_storage_backend_ready()
+
+    sandbox = Sandbox()
+    # ... (原有字段赋值逻辑不变) ...
+
+    self.session.add(sandbox)
+    try:
+        await self.session.commit()
+    except IntegrityError:
+        await self.session.rollback()
+        raise SandboxNameConflictError(sandbox_name)
+    await self.session.refresh(sandbox)
+
+    try:
+        if persist:
+            await self._create_direct(sandbox, template, effective_storage_size)
+        else:
+            await self._create_via_claim(sandbox, template)
+    except TemplateNotFoundError:
+        await self.session.delete(sandbox)
+        await self.session.commit()
+        raise
+    except Exception:
+        logger.exception("Failed to create K8s resource for sandbox %s", sandbox.id)
+        sandbox.status = SandboxStatus.ERROR
+        sandbox.status_message = "Failed to create resource"
+        sandbox.version += 1
+        self.session.add(sandbox)
+        await self.session.commit()
+
+    # ── Phase 3: 记录计量事件 ──
+    if persist:
+        await self._metering.record_storage_allocation(self.session, sandbox)
+
+    return sandbox
+```
+
+### 8.3 start() 集成
+
+```python
+async def start(self, sandbox_id: str, owner_id: str) -> Sandbox:
+    sandbox = await self.get(sandbox_id, owner_id)
+    if sandbox is None:
+        raise SandboxNotFoundError(sandbox_id)
+
+    if sandbox.status != SandboxStatus.STOPPED:
+        raise InvalidTransitionError(sandbox_id, sandbox.status, "ready")
+
+    # ── 配额检查 ──
+    await self._metering.check_compute_quota(self.session, owner_id)
+    await self._metering.check_concurrent_limit(self.session, owner_id)
+
+    # ── 原有 start 逻辑（不变） ──
+    sandbox.status = SandboxStatus.CREATING
+    sandbox.gmt_started = utc_now()
+    sandbox.version += 1
+    self.session.add(sandbox)
+    await self.session.commit()
+
+    k8s_name = sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.id
+    try:
+        await self.k8s.scale_sandbox(name=k8s_name, namespace=sandbox.k8s_namespace, replicas=1)
+    except Exception:
+        logger.exception("Failed to scale sandbox %s to 1", sandbox_id)
+        sandbox.status = SandboxStatus.ERROR
+        sandbox.status_message = "Failed to start sandbox"
+        sandbox.version += 1
+        self.session.add(sandbox)
+        await self.session.commit()
+
+    return sandbox
+```
+
+### 8.4 delete() 集成
+
+```python
+async def delete(self, sandbox_id: str, owner_id: str) -> None:
+    # ... (原有删除逻辑不变) ...
+
+    # 删除成功后释放存储
+    if sandbox.persist:
+        await self._metering.record_storage_release(self.session, sandbox_id)
+```
+
+### 8.5 k8s_sync 集成
+
+在 `k8s_sync.py` 的 `handle_watch_event` 中，sandbox 状态变为 `ready` 时打开 ComputeSession，变为 `stopped` / `deleting` 时关闭：
+
+```python
+# 在状态变更成功后
+if new_status == SandboxStatus.READY and sandbox.status != SandboxStatus.READY:
+    metering = MeteringService()
+    await metering.open_compute_session(session, sandbox)
+
+if new_status in (SandboxStatus.STOPPED, SandboxStatus.DELETING) and sandbox.status == SandboxStatus.READY:
+    metering = MeteringService()
+    await metering.close_compute_session(session, sandbox.id)
+```
+
+### 8.6 sync_supervisor 集成
+
+在 `LeaderControlledSyncSupervisor` 中添加定期计量任务：
+
+```python
+class LeaderControlledSyncSupervisor:
+    def __init__(self, *, elector, sync_loop_factory, session_factory) -> None:
+        # ...
+        self._session_factory = session_factory
+
+    async def run(self) -> None:
+        metering_task = None
+        try:
+            while not self._stopping:
+                # ... (原有 leader election 逻辑) ...
+                if state == LeadershipState.LEADER:
+                    if metering_task is None:
+                        metering_task = asyncio.create_task(
+                            self._metering_tick_loop()
+                        )
+                else:
+                    if metering_task is not None:
+                        metering_task.cancel()
+                        metering_task = None
+        finally:
+            if metering_task is not None:
+                metering_task.cancel()
+            await self.shutdown()
+
+    async def _metering_tick_loop(self) -> None:
+        """定期执行计量相关的后台任务。"""
+        metering = MeteringService()
+        while True:
+            try:
+                async with self._session_factory() as session:
+                    await metering.tick_metering(session)
+                    await metering.tick_storage_metering(session)
+                    await metering.check_grace_periods(session)
+            except Exception:
+                logger.exception("Metering tick failed")
+            await asyncio.sleep(60)
+```
+
+---
+
+## 9. 文件变更汇总
+
+| 文件 | 变更类型 | 说明 |
+|------|---------|------|
+| `treadstone/models/metering.py` | **新增** | UserPlan、ComputeSession、StorageLedger、CreditGrant、TierTemplate 五张表 |
+| `treadstone/models/__init__.py` | **修改** | 导出新模型：UserPlan, ComputeSession, StorageLedger, CreditGrant, TierTemplate |
+| `alembic/versions/xxx_add_metering_tables.py` | **新增** | 新增 5 张表的迁移脚本 + 初始 TierTemplate seed 数据 |
+| `treadstone/services/metering_service.py` | **新增** | MeteringService 核心计量服务，含配额检查、会话管理、后台任务 |
+| `treadstone/services/sandbox_service.py` | **修改** | 构造函数增加 `metering` 参数；create/start/delete 中增加配额检查和计量集成 |
+| `treadstone/services/k8s_sync.py` | **修改** | 在 handle_watch_event 中状态变更时调用 open/close_compute_session |
+| `treadstone/services/sync_supervisor.py` | **修改** | 增加 `_metering_tick_loop` 定期任务（tick、grace period、月度重置） |
+| `treadstone/core/errors.py` | **修改** | 新增 5 个错误类：ComputeQuotaExceededError、StorageQuotaExceededError、ConcurrentLimitError、TemplateNotAllowedError、SandboxDurationExceededError |
+| `treadstone/api/usage.py` | **新增** | Usage API 路由：GET /v1/usage, /plan, /sessions, /grants |
+| `treadstone/api/admin.py` | **新增** | Admin API 路由：GET/PATCH users/{id}/usage/plan, POST grants, tier-templates |
+| `treadstone/api/schemas.py` | **修改** | 新增 Usage 和 Admin API 的 Pydantic request/response 模型 |
+| `treadstone/main.py` | **修改** | 注册 usage_router 和 admin_router |
+| `tests/unit/test_metering_service.py` | **新增** | MeteringService 单元测试（配额检查、grace period 逻辑） |
+| `tests/api/test_usage_api.py` | **新增** | Usage API 路由测试 |
+| `tests/api/test_admin_api.py` | **新增** | Admin API 路由测试 |
+
+### 9.1 main.py 路由注册
+
+```python
+from treadstone.api.usage import router as usage_router
+from treadstone.api.admin import router as admin_router
+
+# ── Routes ──
+app.include_router(usage_router)
+app.include_router(admin_router)
+# ... (原有路由) ...
+```
+
+### 9.2 数据库迁移 Seed 数据
+
+`alembic/versions/xxx_add_metering_tables.py` 除了建表外，需要插入初始 TierTemplate 数据：
+
+```python
+def upgrade() -> None:
+    # ... 建表 DDL ...
+
+    # Seed TierTemplate
+    op.execute("""
+    INSERT INTO tier_template (tier, compute_credits_monthly, storage_credits_monthly,
+        max_concurrent_running, max_sandbox_duration_seconds, allowed_templates,
+        grace_period_seconds, gmt_created, gmt_updated)
+    VALUES
+        ('free',       10,    1,  1,  3600,  '["tiny"]',                                600,  NOW(), NOW()),
+        ('pro',        100,   10, 3,  7200,  '["tiny","small","medium"]',                1800, NOW(), NOW()),
+        ('ultra',      500,   50, 10, 14400, '["tiny","small","medium","large"]',        3600, NOW(), NOW()),
+        ('enterprise', 5000,  500,50, 86400, '["tiny","small","medium","large","gpu"]',  7200, NOW(), NOW())
+    """)
+```
+
+---
+
+## 10. Acceptance Scenarios
+
+以下验收场景覆盖配额执行系统的核心功能，每个场景给出前置条件、操作、期望结果。
+
+### Scenario 1: Free 用户创建 medium sandbox 被拒绝
+
+**前置条件**：
+- 用户 Tier = Free
+- Free Tier 的 allowed_templates = ["tiny"]
+
+**操作**：
+```
+POST /v1/sandboxes
+{"template": "medium", "name": "my-medium-box"}
+```
+
+**期望结果**：
+```json
+{
+  "error": {
+    "code": "template_not_allowed",
+    "message": "Template 'medium' is not available on the 'free' tier. Allowed templates: tiny. Upgrade your plan to access this template.",
+    "status": 403
+  }
+}
+```
+
+### Scenario 2: Pro 用户月度额度耗尽，Extra Credits 接管
+
+**前置条件**：
+- 用户 Tier = Pro，monthly_limit = 100
+- monthly_used = 100（月度耗尽）
+- 有一个活跃的 CreditGrant：compute, amount=50, remaining=50
+
+**操作**：
+```
+POST /v1/sandboxes
+{"template": "small", "name": "overflow-box"}
+```
+
+**期望结果**：
+- 创建成功（HTTP 202）
+- `check_compute_quota` 计算 `total_remaining = 0 + 50 = 50 > 0`，通过
+- 后续消耗从 CreditGrant 中扣减
+
+**验证**：
+```
+GET /v1/usage
+```
+响应中 `compute.monthly_remaining = 0.0`，`compute.extra_remaining = 50.0`，`compute.total_remaining = 50.0`
+
+### Scenario 3: Grace Period 到期自动 Stop
+
+**前置条件**：
+- 用户 Tier = Pro，grace_period_seconds = 1800（30 分钟）
+- monthly + extra 全部耗尽（total_remaining = 0）
+- 用户有 2 个运行中 sandbox
+- grace_period_started_at 已设置且距今已过 1800+ 秒
+
+**操作**：`check_grace_periods()` 定时任务执行
+
+**期望结果**：
+- 2 个 sandbox 均被自动 stop
+- 审计日志中记录 2 条 `metering.auto_stop` 事件
+- `grace_period_started_at` 重置为 null
+
+**验证**：
+```
+GET /v1/usage
+```
+响应中 `grace_period.active = false`，`limits.current_running = 0`
+
+### Scenario 4: Admin 添加 Extra Credits 恢复用户
+
+**前置条件**：
+- 用户 Tier = Pro，月度 + extra 全部耗尽
+- 用户处于 grace period 中（`grace_period_started_at != null`）
+- 用户无法 create/start（被 `ComputeQuotaExceededError` 拒绝）
+
+**操作**：
+```
+POST /v1/admin/users/user_abc/grants
+{"credit_type": "compute", "amount": 100, "grant_type": "admin_grant", "reason": "特殊支持"}
+```
+
+**期望结果**：
+- CreditGrant 创建成功（HTTP 201）
+- 下一次 `check_grace_periods()` 检测到 `total_remaining = 100 > 0`
+- `grace_period_started_at` 被清零
+- 用户可以再次 create/start sandbox
+
+**验证**：
+```
+GET /v1/usage
+```
+响应中 `compute.extra_remaining = 100.0`，`grace_period.active = false`
+
+### Scenario 5: Admin 修改 TierTemplate 是否影响已有用户
+
+**前置条件**：
+- Pro Tier 的 compute_credits_monthly = 100
+- 有 50 个 Pro 用户，其中 5 个有 overrides
+
+**操作 A（不影响已有用户）**：
+```
+PATCH /v1/admin/tier-templates/pro
+{"compute_credits_monthly": 150, "apply_to_existing": false}
+```
+
+**期望结果 A**：
+- TierTemplate 更新为 150
+- 所有现有 Pro 用户的 UserPlan 不变，仍为 100
+- 新注册的 Pro 用户将获得 150
+
+**操作 B（影响已有用户）**：
+```
+PATCH /v1/admin/tier-templates/pro
+{"compute_credits_monthly": 150, "apply_to_existing": true}
+```
+
+**期望结果 B**：
+- TierTemplate 更新为 150
+- 45 个无 overrides 的 Pro 用户的 compute_credits_monthly_limit 更新为 150
+- 5 个有 overrides 的 Pro 用户不受影响
+- 响应中 `users_affected = 45`
+
+### Scenario 6: 并发限制
+
+**前置条件**：
+- 用户 Tier = Pro，max_concurrent_running = 3
+- 已有 3 个 sandbox，状态分别为 ready、ready、creating
+
+**操作**：
+```
+POST /v1/sandboxes
+{"template": "small", "name": "fourth-box"}
+```
+
+**期望结果**：
+```json
+{
+  "error": {
+    "code": "concurrent_limit_exceeded",
+    "message": "Concurrent sandbox limit reached. Running: 3 / 3. Stop an existing sandbox before creating a new one.",
+    "status": 429
+  }
+}
+```
+
+### Scenario 7: GET /v1/usage 返回正确的双池余额
+
+**前置条件**：
+- 用户 Tier = Pro，monthly_limit = 100，monthly_used = 60
+- 有 2 个活跃的 CreditGrant：
+  - compute: amount=50, remaining=30（部分消耗）
+  - compute: amount=20, remaining=20（未消耗）
+
+**操作**：
+```
+GET /v1/usage
+```
+
+**期望结果**：
+```json
+{
+  "compute": {
+    "monthly_limit": 100.0,
+    "monthly_used": 60.0,
+    "monthly_remaining": 40.0,
+    "extra_remaining": 50.0,
+    "total_remaining": 90.0,
+    "unit": "vCPU-hours"
+  }
+}
+```
+
+其中 `extra_remaining = 30 + 20 = 50`，`total_remaining = 40 + 50 = 90`。
+
+### Scenario 8: 批量 Grant 营销活动 Credits
+
+**前置条件**：
+- 3 个用户：user1（存在）、user2（存在）、user_nonexist（不存在）
+
+**操作**：
+```
+POST /v1/admin/grants/batch
+{
+  "user_ids": ["user1", "user2", "user_nonexist"],
+  "credit_type": "compute",
+  "amount": 50,
+  "grant_type": "campaign",
+  "campaign_id": "spring_2026_promo",
+  "reason": "春季促销活动",
+  "expires_at": "2026-06-01T00:00:00Z"
+}
+```
+
+**期望结果**：
+- HTTP 200
+- `succeeded = 2`，`failed = 1`
+- user1 和 user2 各获得 50 compute credits
+- user_nonexist 在 results 中标记为 `status: "failed"`
+- 审计日志中有 2 条 `metering.credits_granted` 事件
+
+### Scenario 9: 月度重置后 Credits 正确归零，Extra 不受影响
+
+**前置条件**：
+- 用户 Tier = Pro，monthly_limit = 100，monthly_used = 85
+- 有一个活跃 CreditGrant：compute, remaining = 30
+- warning_80_notified_at 已设置
+
+**操作**：`reset_monthly_credits()` 月度定时任务执行
+
+**期望结果**：
+- `compute_credits_monthly_used` 重置为 0
+- `billing_period_start` 更新为新月度起始
+- `billing_period_end` 更新为新月度结束
+- `warning_80_notified_at` 和 `warning_100_notified_at` 重置为 null
+- CreditGrant 的 remaining 保持 30 不变
+- 审计日志中记录 `metering.monthly_reset` 事件
+
+**验证**：
+```
+GET /v1/usage
+```
+响应中 `compute.monthly_used = 0.0`，`compute.extra_remaining = 30.0`
+
+### Scenario 10: Storage 超配状态下的行为
+
+**前置条件**：
+- 用户原 Tier = Ultra，storage_monthly_limit = 50 GiB
+- 用户有 40 GiB 的持久化 sandbox 在运行
+- Admin 将用户降级为 Pro（storage_monthly_limit = 10 GiB）
+- 降级后 current_used (40) > total_quota (10)，即存储超配
+
+**期望结果**：
+- 审计日志记录 `metering.storage_overcommit` 事件
+- 已有的持久化 sandbox **不会被自动删除**（避免数据丢失）
+- 用户**无法创建新的**持久化 sandbox（`check_storage_quota` 拒绝）
+- 用户可以正常 stop/delete 现有 sandbox
+- 当用户删除部分 sandbox 释放存储后，available > 0，才能再次创建持久化 sandbox
+
+**验证**：
+```
+GET /v1/usage
+```
+响应中 `storage.current_used = 40`，`storage.total_quota = 10`，`storage.available = -30`（负数表示超配）

--- a/docs/zh-CN/design/2026-03-26-metering-overview.md
+++ b/docs/zh-CN/design/2026-03-26-metering-overview.md
@@ -1,0 +1,1191 @@
+# 计量系统总览设计
+
+**日期：** 2026-03-26
+**状态：** 设计中
+**关联文档：**
+- [Compute 计量详细设计](2026-03-26-metering-compute.md)
+- [Storage 计量详细设计](2026-03-26-metering-storage.md)
+- [配额执行与 API 设计](2026-03-26-metering-enforcement.md)
+
+---
+
+## 1. 系统概述与设计目标
+
+Treadstone 是一个面向 AI Agent 的 sandbox 平台，为用户提供按需创建、运行和管理 sandbox 的能力。随着平台从内部工具演进为 SaaS 服务，需要建立一套完整的计量系统来追踪资源使用、执行配额限制，并为未来的计费能力奠定基础。
+
+### 1.1 为什么需要计量系统
+
+当前 Treadstone 没有任何资源使用追踪或配额控制机制。任何注册用户都可以无限制地创建和运行 sandbox，这在以下方面带来了风险：
+
+- **资源耗尽**：有限的服务器资源（当前 1.5 台 16 核 32G 云服务器，约 24 vCPU / 48 GiB 可用于 sandbox）可能被少数用户独占
+- **成本失控**：云服务器按时计费，无法追踪哪些用户消耗了多少资源
+- **无法运营**：缺乏用户分层和配额体系，无法区分免费体验用户和付费用户
+- **无法定价**：没有用量数据，无法制定合理的定价策略
+
+### 1.2 分阶段目标
+
+| Phase | 目标 | 范围 |
+|-------|------|------|
+| **Phase 1（当前）** | 计量（Metering） | 数据模型、Tier 体系、双池 Credit、配额执行、Usage API、Grace Period |
+| **Phase 2（未来）** | 计费（Billing） | Stripe 支付集成、钱包/充值、发票/账单、自助 Tier 升级 |
+| **Phase 3（远期）** | 高级运营 | 冷存储迁移、用量预测、动态定价、推荐奖励体系 |
+
+Phase 1 的核心原则：**数据模型必须为 Phase 2 做好准备**，但不实现任何支付逻辑。所有计量数据（Compute Credits 消耗、Storage GiB-hours 累积）从第一天开始完整记录，确保未来计费上线时有历史数据可用。
+
+### 1.3 设计原则
+
+| 原则 | 说明 |
+|------|------|
+| 基于 K8s request 计费 | Kubernetes 调度以 Pod 的 resource request 为依据进行节点分配。request 是为 Pod 保底预留的资源量，无论用户是否用满都已占用集群容量。因此计费基于 request，不基于 limit |
+| 简单对用户透明 | 用户只需理解 4 个概念：Tier、Compute Credits、Storage Credits、Grace Period |
+| 灵活对运营友好 | Tier 配额存储在数据库而非代码中，管理员可通过 API 动态调整，无需重新部署 |
+| 不强杀但有兜底 | 额度耗尽时不立即终止运行中的 sandbox，但有 Grace Period 时限兜底，防止无限透支 |
+| 双池消费 | Monthly Credits 和 Extra Credits 分开管理，消费顺序明确，减少用户困惑 |
+
+---
+
+## 2. 双池 Credit 模型
+
+这是计量系统的核心设计。每个用户同时拥有两个额度池，每个池又分为 Compute 和 Storage 两个独立维度。
+
+### 2.1 模型总览
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                     用户额度全景                                  │
+│                                                                  │
+│  ┌─────────────── Compute Credits ──────────────┐               │
+│  │                                               │               │
+│  │  ┌─────────────────┐  ┌────────────────────┐ │               │
+│  │  │ Monthly Pool    │  │ Extra Pool         │ │               │
+│  │  │                 │  │                    │ │               │
+│  │  │ · Tier 决定额度 │  │ · CreditGrant 记录 │ │               │
+│  │  │ · 每月1日重置   │  │ · 永不自动刷新     │ │               │
+│  │  │ · 优先消费      │  │ · 按过期时间排序   │ │               │
+│  │  │                 │  │ · 用完即止         │ │               │
+│  │  │ 单位: vCPU-hour │  │ 单位: vCPU-hour    │ │               │
+│  │  └─────────────────┘  └────────────────────┘ │               │
+│  └───────────────────────────────────────────────┘               │
+│                                                                  │
+│  ┌─────────────── Storage Credits ──────────────┐               │
+│  │                                               │               │
+│  │  ┌─────────────────┐  ┌────────────────────┐ │               │
+│  │  │ Monthly Pool    │  │ Extra Pool         │ │               │
+│  │  │                 │  │                    │ │               │
+│  │  │ · Tier 决定额度 │  │ · CreditGrant 记录 │ │               │
+│  │  │ · 每月1日重置   │  │ · 永不自动刷新     │ │               │
+│  │  │ · Phase 1: GiB  │  │ · 按过期时间排序   │ │               │
+│  │  │   容量上限      │  │ · 用完即止         │ │               │
+│  │  │                 │  │                    │ │               │
+│  │  │ 单位: GiB       │  │ 单位: GiB          │ │               │
+│  │  └─────────────────┘  └────────────────────┘ │               │
+│  └───────────────────────────────────────────────┘               │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Monthly Credits（月度额度）
+
+Monthly Credits 是用户订阅 Tier 后每月自动获得的基础额度，是用户的"保底资源"。
+
+| 属性 | 说明 |
+|------|------|
+| 来源 | 由用户所属的 Tier 决定，从 `TierTemplate` 拷贝到 `UserPlan` |
+| 刷新周期 | 每月 1 日 00:00 UTC 重置为 Tier 定义的上限 |
+| 首月处理 | 新用户注册时，无论当月还剩几天，直接给满当月完整额度（不按比例折算） |
+| 结转 | 不结转。月度额度不累积到下月——用不完就作废 |
+| 消费优先级 | **优先消费**。当 Monthly 和 Extra 同时存在时，先消费 Monthly |
+| 分为两个维度 | Compute Credits（vCPU-hours）和 Storage Credits（GiB） |
+
+**为什么先消费 Monthly？**
+
+Monthly Credits 到月末必然重置，未用完的部分等于浪费。而 Extra Credits 没有月度重置机制，消费顺序为"先 Monthly 后 Extra"可以最大化保留 Extra Credits 的价值。这与手机流量套餐的消费逻辑一致——先用赠送流量，再用购买流量。
+
+### 2.3 Extra Credits（额外额度）
+
+Extra Credits 是通过各种渠道一次性发放给用户的额外资源，不会自动刷新。每一笔发放都以独立的 `CreditGrant` 记录存储。
+
+| 属性 | 说明 |
+|------|------|
+| 来源 | Welcome Bonus、营销活动、管理员手动授予、推荐奖励、未来的充值购买 |
+| 刷新 | 不自动刷新，用完即止 |
+| 过期 | 每笔 CreditGrant 有独立的 `expires_at`，支持永不过期（`NULL`） |
+| 消费优先级 | Monthly 耗尽后再消费 Extra。Extra 内部按 `expires_at` 升序（即将过期的先消费） |
+| 记录粒度 | 每笔发放独立记录原始发放量、剩余量、来源类型、过期时间 |
+| 分为两个维度 | Compute Credits 和 Storage Credits 分开记录，不可混用 |
+
+**CreditGrant 的来源类型**：
+
+| grant_type | 说明 | 典型 expires_at |
+|------------|------|----------------|
+| `welcome_bonus` | 新用户注册自动发放 | 注册后 90 天 |
+| `campaign` | 营销活动批量发放 | 活动结束后 30-90 天 |
+| `admin_grant` | 管理员手动授予（特殊支持、补偿） | 视情况而定，可永不过期 |
+| `referral` | 用户推荐奖励 | 发放后 180 天 |
+| `purchase` | 用户付费购买（Phase 2） | 永不过期 |
+
+### 2.4 消费顺序
+
+Compute Credits 和 Storage Credits 各自独立消费，互不干扰。但两者遵循相同的消费优先级规则：
+
+```mermaid
+flowchart TD
+    Start["需要消费N个Credits"] --> CheckMonthly{"Monthly池剩余>=N?"}
+
+    CheckMonthly -->|是| DeductMonthly["从Monthly池扣除N"]
+    DeductMonthly --> Done["消费完成"]
+
+    CheckMonthly -->|否| PartialMonthly["从Monthly池扣除全部剩余<br/>remaining=N-monthly_remaining"]
+    PartialMonthly --> QueryGrants["查询Extra池中的CreditGrant<br/>WHERE credit_type匹配<br/>AND remaining_amount>0<br/>AND未过期<br/>ORDER BY expires_at ASC NULLS LAST"]
+
+    QueryGrants --> LoopStart{"还有剩余需求<br/>且有可用Grant?"}
+    LoopStart -->|是| DeductGrant["从当前Grant扣除<br/>deduct=min(grant.remaining,需求)"]
+    DeductGrant --> LoopStart
+
+    LoopStart -->|否| CheckShortfall{"是否有shortfall?"}
+    CheckShortfall -->|无| Done
+    CheckShortfall -->|有| Shortfall["记录shortfall<br/>触发Grace Period检查"]
+    Shortfall --> Done
+```
+
+**消费顺序总结**：
+
+1. 先消费当月 Monthly Credits（`UserPlan.compute_credits_monthly_used` 递增）
+2. Monthly 耗尽后，消费 Extra Credits（遍历 `CreditGrant` 表，按 `expires_at ASC, NULLS LAST` 排序）
+3. Extra 中优先消费即将过期的 Grant（FIFO by expiry）
+4. 跳过已过期的 Grant（`expires_at < now()`）
+5. 永不过期的 Grant（`expires_at IS NULL`）排在最后
+6. 两个池都耗尽 → `shortfall > 0` → 触发 Grace Period 机制
+
+### 2.5 Compute Credits vs Storage Credits 的区别
+
+| 维度 | Compute Credits | Storage Credits |
+|------|----------------|----------------|
+| 衡量对象 | CPU + 内存 × 运行时间 | 持久存储容量 |
+| 消耗方式 | 随时间持续扣减（消耗型） | 分配时占用，释放时归还（占用型，Phase 1） |
+| 关联资源 | Running sandbox 的 vCPU 和内存 | 持久化 sandbox 的 PVC 磁盘 |
+| sandbox stop 影响 | 停止消耗 | 不影响，PVC 仍存在，仍占用配额 |
+| sandbox delete 影响 | 停止消耗 | 释放配额 |
+| 月度重置 | `monthly_used` 归零，重新开始消耗 | 配额上限刷新，但已有 PVC 的占用不变 |
+| 单位 | vCPU-hour（1 Credit = 1 vCPU 运行 1 小时） | GiB（1 Credit = 1 GiB 持久存储容量） |
+| Phase 2 演进 | 按秒计费，对接支付 | 演进为 GiB-月计费单位 |
+
+```
+Compute Credits（消耗型）：
+
+  ┌─ running ────────────────────── stopped ─┐
+  │ ████████████████████████████████          │  ← 持续消耗 credits
+  │ 每秒扣减 credit_rate / 3600              │
+  └──────────────────────────────────────────┘
+
+Storage Credits（占用型 — Phase 1）：
+
+  ┌─ created ─────────────────── deleted ────┐
+  │ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓          │  ← 容量占用
+  │ 分配时占用, 删除时归还                      │
+  │ 不随时间消耗更多                            │
+  │ stopped 状态 PVC 仍在 → 仍占用             │
+  └──────────────────────────────────────────┘
+```
+
+---
+
+## 3. Tier 产品模型
+
+### 3.1 Tier 定义
+
+Treadstone 提供 4 个产品层级，覆盖从免费体验到企业定制的全部场景：
+
+| Tier | 可用模板 | 并发运行数 | 单次最长运行 | 月度 Compute Credits | 月度 Storage Credits (GiB) | Grace Period | 定位 |
+|------|---------|--------:|----------:|-------------------:|-------------------------:|------------:|------|
+| **Free** | tiny, small | 1 | 30 分钟 | 10 | 0 | 10 分钟 | 默认注册用户，免费体验 |
+| **Pro** | tiny, small, medium | 3 | 2 小时 | 100 | 10 | 30 分钟 | 认真使用的个人用户 |
+| **Ultra** | tiny, small, medium, large | 5 | 8 小时 | 300 | 20 | 60 分钟 | 高活跃 / 高价值用户 |
+| **Enterprise** | 全部（含 xlarge） | 自定义 | 自定义 | 自定义 | 自定义 | 自定义 | 手工审批，非自助 |
+
+**Free Tier 的额度换算**：10 Compute Credits = 40 小时 tiny 运行时间 = 20 小时 small 运行时间，足够每天约 1 小时的 tiny sandbox 使用，满足评估和轻度试用需求。
+
+**Pro Tier 的额度换算**：100 Compute Credits = 400 小时 tiny = 200 小时 small = 100 小时 medium，满足日常开发和 AI Agent 工作负载。
+
+**Ultra Tier 的额度换算**：300 Compute Credits = 150 小时 medium = 75 小时 large，面向重度用户和持续运行的 Agent 场景。
+
+### 3.2 Tier 模板的可配置性
+
+**关键设计决策**：Tier 的默认配额不硬编码在 Python 代码中，而是存储在数据库的 `TierTemplate` 表中。
+
+这个决策的背景是：Treadstone 是单人项目，服务器资源有限且会随用户增长逐步扩容。Tier 配额需要能够在以下场景中快速调整：
+
+| 场景 | 操作 |
+|------|------|
+| 服务器从 1.5 台扩容到 4.5 台 | 通过管理员 API 提高所有 Tier 的并发数和 Compute Credits |
+| 竞品降价或提高免费额度 | 通过管理员 API 提高 Free Tier 的额度以保持竞争力 |
+| 节假日/新年促销活动 | 通过管理员 API 临时提高额度，活动结束后恢复 |
+| 发现某个 Tier 的用户流失率高 | 通过管理员 API 调整配额，观察留存变化 |
+| 特定用户需要超配 | 通过 UserPlan.overrides 字段单独调整，不影响其他用户 |
+
+**配额生效流程**：
+
+```mermaid
+flowchart LR
+    TT["TierTemplate表<br/>(管理员可修改)"] -->|用户注册或Tier变更时| UP["UserPlan<br/>(拷贝TierTemplate的值)"]
+    OV["overrides JSON<br/>(管理员针对特定用户)"] -->|叠加覆盖| UP
+    UP -->|配额检查时读取| MS["MeteringService"]
+```
+
+1. 管理员通过 `PATCH /v1/admin/tier-templates/{tier_name}` 修改 TierTemplate 的默认值
+2. 用户注册（或 Tier 变更）时，从 TierTemplate 拷贝当前默认值到 UserPlan
+3. 如果管理员通过 `PATCH /v1/admin/users/{user_id}/plan` 设置了 overrides，则 overrides 中的值优先
+4. MeteringService 的所有配额检查都从 UserPlan 读取，不直接查 TierTemplate
+
+**TierTemplate 更新是否影响现有用户？** 默认不影响——已创建的 UserPlan 是快照。管理员可以通过 `apply_to_existing=true` 参数批量更新（仅更新没有 overrides 的用户）。
+
+### 3.3 Welcome Bonus
+
+新注册用户自动获得 **50 Compute Credits** 的 Extra Credits，以独立的 `CreditGrant` 记录发放。
+
+| 属性 | 值 |
+|------|------|
+| credit_type | `compute` |
+| grant_type | `welcome_bonus` |
+| original_amount | `50.0` |
+| expires_at | 注册后 90 天（推荐，可通过配置调整） |
+| granted_by | `NULL`（系统自动发放） |
+
+**Welcome Bonus 的额度换算**：50 Compute Credits = 200 小时 tiny = 100 小时 small = 50 小时 medium。结合 Free Tier 每月 10 Credits，新用户首月实际可用 60 Credits（240 小时 tiny），足够充分评估平台。
+
+**为什么不赠送 Storage Credits？** Free Tier 不允许创建持久化 sandbox（`storage_credits_monthly = 0`），因此赠送 Storage Credits 对 Free 用户无意义。当用户升级到 Pro 后，已有月度 10 GiB 的 Storage Credits。
+
+**与竞品对标**：
+
+| 平台 | 新用户免费额度 | 等价 Treadstone tiny 小时数 |
+|------|--------------|--------------------------|
+| Daytona | $200 一次性 credit | ~4,000 小时 |
+| E2B | $100 一次性 credit | ~2,000 小时 |
+| **Treadstone** | **50 Credits + 10/月** | **200 + 40/月** |
+| GitHub Codespaces | 120 core-hours/月 | ~480 小时/月 |
+
+Treadstone 的一次性赠送量低于 Daytona/E2B，但有持续的月度额度补充。Daytona/E2B 的大额一次性赠送本质上是获客成本（CAC），大部分用户不会用完——Treadstone 作为单人项目，无需在这方面硬拼。
+
+### 3.4 Enterprise Tier 的定位
+
+Enterprise 不是公开售卖的自助计划。它是管理员手工创建的超配版本，用于：
+
+- 与 Treadstone 有深度合作的团队或项目
+- 需要 xlarge 模板（4 vCPU / 8 GiB）的用户
+- 需要超过 Ultra 配额的高频用户
+- 内部测试或 demo 用途
+
+创建 Enterprise 用户的流程：管理员通过 `PATCH /v1/admin/users/{user_id}/plan` 将用户的 Tier 设为 `enterprise`，并在 overrides 中指定具体配额。
+
+---
+
+## 4. 计费周期
+
+### 4.1 周期规则
+
+| 属性 | 规则 |
+|------|------|
+| 周期长度 | 自然月（每月 1 日 00:00 UTC 至次月 1 日 00:00 UTC） |
+| 重置时间 | 每月 1 日 00:00 UTC |
+| 首月处理 | 注册时直接给满当月完整额度，不按剩余天数折算 |
+| 重置内容 | `compute_credits_monthly_used` 归零；`warning_80_notified_at` 和 `warning_100_notified_at` 清零 |
+| 不重置内容 | Extra Credits（CreditGrant）不受月度重置影响 |
+| Storage 月度重置 | 配额上限刷新，但已有 PVC 的占用不变（可能出现降级后的超配） |
+
+### 4.2 为什么选择「自然月 + 首月给满」
+
+**对比其他方案**：
+
+| 方案 | 优点 | 缺点 |
+|------|------|------|
+| 滚动 30 天（从注册日算起） | 最公平，每个用户完整 30 天 | 每个用户周期不同，运维复杂，对账困难 |
+| 自然月 + 首月按比例 | 精确，不多给 | 月末注册用户体验差（3 月 28 日注册只得 3 天额度） |
+| **自然月 + 首月给满** | **简单，用户体验好** | 月末注册用户多享几天——但这是正面体验 |
+
+选择「自然月 + 首月给满」的理由：
+
+1. **简单**：所有用户统一在每月 1 日重置，后台任务和查询逻辑简化
+2. **用户友好**：月末注册的用户获得"额外几天"的额度，是正面体验而非损失
+3. **未来友好**：Stripe 等支付系统原生支持自然月出账周期，Phase 2 对接时无需迁移
+4. **运营友好**：统一出账日便于月度用量报表、成本核算和容量规划
+
+### 4.3 月度重置流程
+
+后台任务在每月 1 日 00:05 UTC 执行（留 5 分钟余量确保所有时区已进入新月）：
+
+```mermaid
+sequenceDiagram
+    participant BG as BackgroundTask
+    participant DB as Database
+    participant Meter as MeteringService
+
+    Note over BG: 每月1日 00:05 UTC
+
+    BG->>DB: SELECT UserPlan WHERE period_end<=now()
+    DB-->>BG: 需要重置的用户列表
+
+    loop 每个需要重置的用户
+        BG->>Meter: handle_period_rollover(user_id)
+
+        Note over Meter: 1.处理跨月运行的sandbox
+        Meter->>DB: 关闭旧ComputeSession(ended_at=period_end)
+        Meter->>DB: 创建新ComputeSession(started_at=new_period_start)
+
+        Note over Meter: 2.重置月度额度
+        Meter->>DB: UPDATE UserPlan SET<br/>monthly_used=0,<br/>period_start=new,<br/>period_end=new,<br/>warning_80_notified_at=NULL,<br/>warning_100_notified_at=NULL,<br/>grace_period_started_at=NULL
+
+        Note over Meter: 3.记录审计事件
+        Meter->>DB: INSERT audit_event(metering.monthly_reset)
+    end
+```
+
+### 4.4 跨月 ComputeSession 分割
+
+当 sandbox 从 3 月持续运行到 4 月时：
+
+```
+3月28日                    4月1日 00:00 UTC              4月5日
+  |──── 旧 Session ────────|──── 新 Session ────────────|
+  │ ended_at = 4/1 00:00   │ started_at = 4/1 00:00    │
+  │ credits → 3月月度/Extra │ credits → 4月月度/Extra    │
+```
+
+1. 旧 Session 在 `period_end` 时刻关闭，最后一段消耗计入 3 月
+2. UserPlan 的月度额度重置
+3. 为仍在运行的 sandbox 创建新 Session，`started_at = new_period_start`
+4. 新 Session 的消耗从 4 月月度额度开始扣除
+
+详见 [Compute 计量设计 — 第 7 节：月度重置](2026-03-26-metering-compute.md)。
+
+---
+
+## 5. 完整数据模型总览
+
+计量系统引入 5 张新表，不修改任何现有表。
+
+### 5.0 ER 关系图
+
+```mermaid
+erDiagram
+    User ||--o| UserPlan : "has one"
+    User ||--o{ CreditGrant : "receives many"
+    User ||--o{ ComputeSession : "owns many"
+    User ||--o{ StorageLedger : "owns many"
+    Sandbox ||--o{ ComputeSession : "generates many"
+    Sandbox ||--o| StorageLedger : "has one (if persist)"
+    TierTemplate ||--o{ UserPlan : "defines defaults for"
+
+    TierTemplate {
+        string id PK
+        string tier_name UK
+        decimal compute_credits_monthly
+        int storage_credits_monthly
+        int max_concurrent_running
+        int max_sandbox_duration_seconds
+        json allowed_templates
+        int grace_period_seconds
+        bool is_active
+    }
+
+    UserPlan {
+        string id PK
+        string user_id FK_UK
+        string tier
+        decimal compute_credits_monthly_limit
+        int storage_credits_monthly_limit
+        int max_concurrent_running
+        int max_sandbox_duration_seconds
+        json allowed_templates
+        int grace_period_seconds
+        datetime period_start
+        datetime period_end
+        decimal compute_credits_monthly_used
+        json overrides
+        datetime grace_period_started_at
+        datetime warning_80_notified_at
+        datetime warning_100_notified_at
+    }
+
+    CreditGrant {
+        string id PK
+        string user_id FK
+        string credit_type
+        string grant_type
+        string campaign_id
+        decimal original_amount
+        decimal remaining_amount
+        string reason
+        string granted_by
+        datetime granted_at
+        datetime expires_at
+    }
+
+    ComputeSession {
+        string id PK
+        string sandbox_id FK
+        string user_id FK
+        string template
+        decimal credit_rate_per_hour
+        datetime started_at
+        datetime ended_at
+        datetime last_metered_at
+        decimal credits_consumed
+        decimal credits_consumed_monthly
+        decimal credits_consumed_extra
+    }
+
+    StorageLedger {
+        string id PK
+        string user_id FK
+        string sandbox_id FK
+        int size_gib
+        string storage_state
+        datetime allocated_at
+        datetime released_at
+        datetime archived_at
+        decimal gib_hours_consumed
+        datetime last_metered_at
+    }
+```
+
+### 5.1 TierTemplate 表
+
+存储每个 Tier 的默认配额值，是 Tier 体系的"模板"。管理员可通过 Admin API 修改，修改后新注册用户（或手动触发的批量更新）将使用新值。
+
+#### SQL DDL
+
+```sql
+CREATE TABLE tier_template (
+    id                           VARCHAR(24)   PRIMARY KEY,
+    tier_name                    VARCHAR(16)   NOT NULL UNIQUE,
+    compute_credits_monthly      DECIMAL(10,4) NOT NULL,
+    storage_credits_monthly      INTEGER       NOT NULL,
+    max_concurrent_running       INTEGER       NOT NULL,
+    max_sandbox_duration_seconds INTEGER       NOT NULL,
+    allowed_templates            JSONB         NOT NULL DEFAULT '[]',
+    grace_period_seconds         INTEGER       NOT NULL,
+    is_active                    BOOLEAN       NOT NULL DEFAULT TRUE,
+    gmt_created                  TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    gmt_updated                  TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX ix_tier_template_name ON tier_template(tier_name);
+```
+
+#### SQLAlchemy 模型
+
+```python
+class TierTemplate(Base):
+    __tablename__ = "tier_template"
+
+    id: Mapped[str] = mapped_column(
+        String(24), primary_key=True, default=lambda: "tt" + random_id()
+    )
+    tier_name: Mapped[str] = mapped_column(
+        String(16), unique=True, nullable=False
+    )
+    compute_credits_monthly: Mapped[Decimal] = mapped_column(
+        Numeric(10, 4), nullable=False
+    )
+    storage_credits_monthly: Mapped[int] = mapped_column(
+        Integer, nullable=False
+    )
+    max_concurrent_running: Mapped[int] = mapped_column(
+        Integer, nullable=False
+    )
+    max_sandbox_duration_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False
+    )
+    allowed_templates: Mapped[list] = mapped_column(
+        JSON, nullable=False, default=list
+    )
+    grace_period_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True
+    )
+    gmt_created: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+    gmt_updated: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+```
+
+#### 字段说明
+
+| 字段 | 类型 | 约束 | 设计意图 |
+|------|------|------|---------|
+| `id` | String(24) | PK | 前缀 `tt`，如 `tt3a8f9b2c1d4e5f67` |
+| `tier_name` | String(16) | UNIQUE, NOT NULL | 枚举值：`free` / `pro` / `ultra` / `enterprise` |
+| `compute_credits_monthly` | Decimal(10,4) | NOT NULL | 该 Tier 的月度 Compute Credit 上限。Decimal 精度避免浮点误差 |
+| `storage_credits_monthly` | Integer | NOT NULL | 该 Tier 的月度 Storage Credit 上限（GiB）。Free = 0 表示不允许持久存储 |
+| `max_concurrent_running` | Integer | NOT NULL | 同时运行的 sandbox 上限 |
+| `max_sandbox_duration_seconds` | Integer | NOT NULL | 单个 sandbox 最长运行时间（秒）。Free = 1800（30分钟） |
+| `allowed_templates` | JSON | NOT NULL | 可使用的模板名称列表，如 `["tiny", "small"]` |
+| `grace_period_seconds` | Integer | NOT NULL | Credit 耗尽后的宽限期时长（秒） |
+| `is_active` | Boolean | NOT NULL, DEFAULT TRUE | 软删除标记。置 false 后该 Tier 不可再分配给新用户 |
+| `gmt_created` | DateTime(tz) | NOT NULL | 记录创建时间 |
+| `gmt_updated` | DateTime(tz) | NOT NULL | 记录最后修改时间 |
+
+#### 初始数据（Alembic migration 中 seed）
+
+```python
+TIER_DEFAULTS = [
+    {
+        "tier_name": "free",
+        "compute_credits_monthly": Decimal("10"),
+        "storage_credits_monthly": 0,
+        "max_concurrent_running": 1,
+        "max_sandbox_duration_seconds": 1800,
+        "allowed_templates": ["tiny", "small"],
+        "grace_period_seconds": 600,
+    },
+    {
+        "tier_name": "pro",
+        "compute_credits_monthly": Decimal("100"),
+        "storage_credits_monthly": 10,
+        "max_concurrent_running": 3,
+        "max_sandbox_duration_seconds": 7200,
+        "allowed_templates": ["tiny", "small", "medium"],
+        "grace_period_seconds": 1800,
+    },
+    {
+        "tier_name": "ultra",
+        "compute_credits_monthly": Decimal("300"),
+        "storage_credits_monthly": 20,
+        "max_concurrent_running": 5,
+        "max_sandbox_duration_seconds": 28800,
+        "allowed_templates": ["tiny", "small", "medium", "large"],
+        "grace_period_seconds": 3600,
+    },
+    {
+        "tier_name": "enterprise",
+        "compute_credits_monthly": Decimal("5000"),
+        "storage_credits_monthly": 500,
+        "max_concurrent_running": 50,
+        "max_sandbox_duration_seconds": 86400,
+        "allowed_templates": ["tiny", "small", "medium", "large", "xlarge"],
+        "grace_period_seconds": 7200,
+    },
+]
+```
+
+### 5.2 UserPlan 表
+
+每个用户一行，记录用户当前的 Tier、各项配额值、本周期用量和管理状态。是计量系统的核心读写表。
+
+#### SQL DDL
+
+```sql
+CREATE TABLE user_plan (
+    id                             VARCHAR(24)   PRIMARY KEY,
+    user_id                        VARCHAR(24)   NOT NULL UNIQUE REFERENCES "user"(id) ON DELETE CASCADE,
+    tier                           VARCHAR(16)   NOT NULL,
+
+    -- Entitlements (copied from TierTemplate, can be overridden)
+    compute_credits_monthly_limit  DECIMAL(10,4) NOT NULL,
+    storage_credits_monthly_limit  INTEGER       NOT NULL,
+    max_concurrent_running         INTEGER       NOT NULL,
+    max_sandbox_duration_seconds   INTEGER       NOT NULL,
+    allowed_templates              JSONB         NOT NULL DEFAULT '[]',
+    grace_period_seconds           INTEGER       NOT NULL,
+
+    -- Current period state
+    period_start                   TIMESTAMPTZ   NOT NULL,
+    period_end                     TIMESTAMPTZ   NOT NULL,
+    compute_credits_monthly_used   DECIMAL(10,4) NOT NULL DEFAULT 0,
+
+    -- Admin overrides
+    overrides                      JSONB,
+
+    -- Grace Period tracking
+    grace_period_started_at        TIMESTAMPTZ,
+
+    -- Notification dedup
+    warning_80_notified_at         TIMESTAMPTZ,
+    warning_100_notified_at        TIMESTAMPTZ,
+
+    -- Timestamps
+    gmt_created                    TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    gmt_updated                    TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX ix_user_plan_user ON user_plan(user_id);
+```
+
+#### SQLAlchemy 模型
+
+```python
+class UserPlan(Base):
+    __tablename__ = "user_plan"
+
+    id: Mapped[str] = mapped_column(
+        String(24), primary_key=True, default=lambda: "plan" + random_id()
+    )
+    user_id: Mapped[str] = mapped_column(
+        String(24), ForeignKey("user.id", ondelete="CASCADE"),
+        unique=True, nullable=False,
+    )
+    tier: Mapped[str] = mapped_column(String(16), nullable=False)
+
+    # Entitlements
+    compute_credits_monthly_limit: Mapped[Decimal] = mapped_column(
+        Numeric(10, 4), nullable=False
+    )
+    storage_credits_monthly_limit: Mapped[int] = mapped_column(
+        Integer, nullable=False
+    )
+    max_concurrent_running: Mapped[int] = mapped_column(
+        Integer, nullable=False
+    )
+    max_sandbox_duration_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False
+    )
+    allowed_templates: Mapped[list] = mapped_column(
+        JSON, nullable=False, default=list
+    )
+    grace_period_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False
+    )
+
+    # Current period state
+    period_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    period_end: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    compute_credits_monthly_used: Mapped[Decimal] = mapped_column(
+        Numeric(10, 4), nullable=False, default=Decimal("0")
+    )
+
+    # Admin overrides
+    overrides: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
+    # Grace Period tracking
+    grace_period_started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+
+    # Notification dedup
+    warning_80_notified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+    warning_100_notified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+
+    # Timestamps
+    gmt_created: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+    gmt_updated: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+```
+
+#### 字段说明
+
+| 字段 | 类型 | 约束 | 设计意图 |
+|------|------|------|---------|
+| `id` | String(24) | PK | 前缀 `plan`，如 `plan3a8f9b2c1d4e5f67` |
+| `user_id` | String(24) | FK → user.id, UNIQUE | 一个用户只有一个 UserPlan。CASCADE 删除 |
+| `tier` | String(16) | NOT NULL | 当前 Tier 名称，与 TierTemplate.tier_name 对应 |
+| `compute_credits_monthly_limit` | Decimal(10,4) | NOT NULL | 本月 Compute Credit 上限。创建时从 TierTemplate 拷贝，可被 overrides 覆盖 |
+| `storage_credits_monthly_limit` | Integer | NOT NULL | 本月 Storage Credit 上限（GiB）。创建时从 TierTemplate 拷贝 |
+| `max_concurrent_running` | Integer | NOT NULL | 允许同时运行的 sandbox 上限 |
+| `max_sandbox_duration_seconds` | Integer | NOT NULL | 单个 sandbox 最长运行时间（秒） |
+| `allowed_templates` | JSON | NOT NULL | 该用户可使用的模板名称列表 |
+| `grace_period_seconds` | Integer | NOT NULL | Credit 耗尽后的宽限期时长（秒） |
+| `period_start` | DateTime(tz) | NOT NULL | 当前计费周期开始时间。首次创建时为当月 1 日 00:00 UTC |
+| `period_end` | DateTime(tz) | NOT NULL | 当前计费周期结束时间。首次创建时为次月 1 日 00:00 UTC |
+| `compute_credits_monthly_used` | Decimal(10,4) | NOT NULL, DEFAULT 0 | 本月已消耗的 Compute Credits。由 `tick_metering()` 和 `close_compute_session()` 递增 |
+| `overrides` | JSON | nullable | 管理员设置的配额覆盖，格式如 `{"compute_credits_monthly_limit": 150}`。优先级最高 |
+| `grace_period_started_at` | DateTime(tz) | nullable | Grace Period 开始时间。`NULL` 表示不在 Grace Period 中 |
+| `warning_80_notified_at` | DateTime(tz) | nullable | 80% 用量预警的触发时间。月度重置时清零，防止同一周期内重复触发 |
+| `warning_100_notified_at` | DateTime(tz) | nullable | 100% 用量预警的触发时间。月度重置时清零 |
+| `gmt_created` | DateTime(tz) | NOT NULL | UserPlan 创建时间 |
+| `gmt_updated` | DateTime(tz) | NOT NULL | 最后更新时间 |
+
+> **为什么 Storage 用量不存为字段？**
+>
+> Storage 的当前占用量需要实时反映 PVC 的存在状态。如果把它缓存在 UserPlan 中，每次 sandbox 创建/删除都要同步更新 UserPlan，增加了一致性维护成本。当前设计选择在配额检查时从 `StorageLedger` 实时计算：`SELECT SUM(size_gib) FROM storage_ledger WHERE user_id = ? AND storage_state = 'active'`。StorageLedger 表有 `(user_id, storage_state)` 复合索引，查询性能足够。
+>
+> 如果未来用户量增长到需要优化这一查询，可以在 UserPlan 中添加缓存字段，但 Phase 1 不需要。
+
+#### 创建时机
+
+UserPlan 在以下时机自动创建：
+
+1. **用户注册时**：`UserManager.on_after_register()` 调用 `MeteringService.ensure_user_plan()`
+2. **首次 OAuth 登录时**：同上，通过 `on_after_register` hook
+
+```python
+async def ensure_user_plan(
+    session: AsyncSession,
+    user_id: str,
+    tier: str = "free",
+) -> UserPlan:
+    existing = await session.execute(
+        select(UserPlan).where(UserPlan.user_id == user_id)
+    )
+    if existing.scalar_one_or_none() is not None:
+        return existing.scalar_one()
+
+    template = await session.execute(
+        select(TierTemplate).where(TierTemplate.tier_name == tier)
+    )
+    tt = template.scalar_one()
+
+    now = utc_now()
+    period_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if now.month == 12:
+        period_end = period_start.replace(year=now.year + 1, month=1)
+    else:
+        period_end = period_start.replace(month=now.month + 1)
+
+    plan = UserPlan(
+        user_id=user_id,
+        tier=tt.tier_name,
+        compute_credits_monthly_limit=tt.compute_credits_monthly,
+        storage_credits_monthly_limit=tt.storage_credits_monthly,
+        max_concurrent_running=tt.max_concurrent_running,
+        max_sandbox_duration_seconds=tt.max_sandbox_duration_seconds,
+        allowed_templates=tt.allowed_templates,
+        grace_period_seconds=tt.grace_period_seconds,
+        period_start=period_start,
+        period_end=period_end,
+    )
+    session.add(plan)
+
+    # Welcome Bonus
+    if tier == "free":
+        grant = CreditGrant(
+            user_id=user_id,
+            credit_type="compute",
+            grant_type="welcome_bonus",
+            original_amount=Decimal("50"),
+            remaining_amount=Decimal("50"),
+            reason="Welcome bonus for new users",
+            granted_at=now,
+            expires_at=now + timedelta(days=90),
+        )
+        session.add(grant)
+
+    await session.commit()
+    return plan
+```
+
+### 5.3 CreditGrant 表
+
+记录每一笔 Extra Credits 的发放。支持 welcome bonus、营销活动、管理员手动授予等多种来源。是双池模型中 Extra 池的底层数据存储。
+
+#### SQL DDL
+
+```sql
+CREATE TABLE credit_grant (
+    id               VARCHAR(24)    PRIMARY KEY,
+    user_id          VARCHAR(24)    NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+    credit_type      VARCHAR(16)    NOT NULL,
+    grant_type       VARCHAR(32)    NOT NULL,
+    campaign_id      VARCHAR(64),
+    original_amount  DECIMAL(10,4)  NOT NULL,
+    remaining_amount DECIMAL(10,4)  NOT NULL,
+    reason           TEXT,
+    granted_by       VARCHAR(24),
+    granted_at       TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    expires_at       TIMESTAMPTZ,
+    gmt_created      TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    gmt_updated      TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ix_credit_grant_user_type ON credit_grant(user_id, credit_type);
+CREATE INDEX ix_credit_grant_expires   ON credit_grant(expires_at) WHERE remaining_amount > 0;
+```
+
+#### SQLAlchemy 模型
+
+```python
+class CreditGrant(Base):
+    __tablename__ = "credit_grant"
+    __table_args__ = (
+        Index("ix_credit_grant_user_type", "user_id", "credit_type"),
+        Index(
+            "ix_credit_grant_expires", "expires_at",
+            postgresql_where=text("remaining_amount > 0"),
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(24), primary_key=True, default=lambda: "cg" + random_id()
+    )
+    user_id: Mapped[str] = mapped_column(
+        String(24), ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    credit_type: Mapped[str] = mapped_column(
+        String(16), nullable=False
+    )
+    grant_type: Mapped[str] = mapped_column(
+        String(32), nullable=False
+    )
+    campaign_id: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
+    original_amount: Mapped[Decimal] = mapped_column(
+        Numeric(10, 4), nullable=False
+    )
+    remaining_amount: Mapped[Decimal] = mapped_column(
+        Numeric(10, 4), nullable=False
+    )
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    granted_by: Mapped[str | None] = mapped_column(
+        String(24), nullable=True
+    )
+    granted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=utc_now
+    )
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    gmt_created: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+    gmt_updated: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+```
+
+#### 字段说明
+
+| 字段 | 类型 | 约束 | 设计意图 |
+|------|------|------|---------|
+| `id` | String(24) | PK | 前缀 `cg`，如 `cg3a8f9b2c1d4e5f67` |
+| `user_id` | String(24) | FK → user.id, INDEX | 接收 credit 的用户 |
+| `credit_type` | String(16) | NOT NULL | `"compute"` 或 `"storage"`，区分两个维度，不可混用 |
+| `grant_type` | String(32) | NOT NULL | 来源类型标记，方便统计各渠道发放量 |
+| `campaign_id` | String(64) | nullable | 关联的营销活动 ID，`grant_type = "campaign"` 时有意义 |
+| `original_amount` | Decimal(10,4) | NOT NULL | 初始发放量，**不可变**，用于审计和对账 |
+| `remaining_amount` | Decimal(10,4) | NOT NULL | 剩余量，消费时递减。当 `= 0` 时表示已用完 |
+| `reason` | Text | nullable | 人类可读的发放原因，如 "Welcome bonus for new users" |
+| `granted_by` | String(24) | nullable | 管理员手动发放时记录操作者的 user_id。系统自动发放时为 NULL |
+| `granted_at` | DateTime(tz) | NOT NULL | 发放时间 |
+| `expires_at` | DateTime(tz) | nullable | 过期时间。`NULL` = 永不过期。消费时优先使用即将过期的 grant |
+| `gmt_created` | DateTime(tz) | NOT NULL | 记录创建时间 |
+| `gmt_updated` | DateTime(tz) | NOT NULL | 记录最后更新时间 |
+
+#### 索引说明
+
+| 索引名 | 列 | 用途 |
+|--------|------|------|
+| `ix_credit_grant_user_type` | `(user_id, credit_type)` | 查询用户某类型的所有 grant（配额检查和消费的热路径） |
+| `ix_credit_grant_expires` | `(expires_at) WHERE remaining_amount > 0` | 部分索引，加速"按过期时间排序消费未用完的 grant"查询，同时方便清理过期记录 |
+
+### 5.4 ComputeSession 表
+
+追踪每个 sandbox 的每次运行期间的计算资源消耗。一个 sandbox 的生命周期中可能产生多个 ComputeSession（每次 start/stop 循环产生一个，跨月分割也会产生新 session）。
+
+#### SQL DDL
+
+```sql
+CREATE TABLE compute_session (
+    id                       VARCHAR(24)    PRIMARY KEY,
+    sandbox_id               VARCHAR(24)    NOT NULL REFERENCES sandbox(id),
+    user_id                  VARCHAR(24)    NOT NULL REFERENCES "user"(id),
+    template                 VARCHAR(32)    NOT NULL,
+    credit_rate_per_hour     DECIMAL(10,4)  NOT NULL,
+    started_at               TIMESTAMPTZ    NOT NULL,
+    ended_at                 TIMESTAMPTZ,
+    last_metered_at          TIMESTAMPTZ    NOT NULL,
+    credits_consumed         DECIMAL(10,4)  NOT NULL DEFAULT 0,
+    credits_consumed_monthly DECIMAL(10,4)  NOT NULL DEFAULT 0,
+    credits_consumed_extra   DECIMAL(10,4)  NOT NULL DEFAULT 0,
+    gmt_created              TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    gmt_updated              TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ix_compute_session_sandbox ON compute_session(sandbox_id);
+CREATE INDEX ix_compute_session_user    ON compute_session(user_id);
+CREATE INDEX ix_compute_session_open    ON compute_session(ended_at) WHERE ended_at IS NULL;
+```
+
+#### 字段说明
+
+| 字段 | 类型 | 约束 | 设计意图 |
+|------|------|------|---------|
+| `id` | String(24) | PK | 前缀 `cs`，如 `cs3a8f9b2c1d4e5f67` |
+| `sandbox_id` | String(24) | FK → sandbox.id, INDEX | 关联的 sandbox |
+| `user_id` | String(24) | FK → user.id, INDEX | 冗余存储 owner_id，避免 tick 时 JOIN sandbox 表 |
+| `template` | String(32) | NOT NULL | 冗余存储模板名称，方便按模板维度统计 |
+| `credit_rate_per_hour` | Decimal(10,4) | NOT NULL | session 创建时锁定的费率。即使模板后续调价，已有 session 不受影响 |
+| `started_at` | DateTime(tz) | NOT NULL | sandbox 进入 `ready` 状态的时刻 |
+| `ended_at` | DateTime(tz) | nullable | sandbox 离开 `ready` 状态的时刻。`NULL` 表示仍在运行 |
+| `last_metered_at` | DateTime(tz) | NOT NULL | 上次 tick 计量的时间点，用于增量计算 `(now - last_metered_at) * rate` |
+| `credits_consumed` | Decimal(10,4) | NOT NULL, DEFAULT 0 | 累计消耗的 credit 总量 = monthly + extra |
+| `credits_consumed_monthly` | Decimal(10,4) | NOT NULL, DEFAULT 0 | 其中从月度额度扣除的部分 |
+| `credits_consumed_extra` | Decimal(10,4) | NOT NULL, DEFAULT 0 | 其中从 Extra Credits（CreditGrant）扣除的部分 |
+| `gmt_created` | DateTime(tz) | NOT NULL | 记录创建时间 |
+| `gmt_updated` | DateTime(tz) | NOT NULL | 最后更新时间。兼作乐观锁版本标记——tick 更新时 WHERE 条件包含此字段 |
+
+#### 索引说明
+
+| 索引名 | 列 | 用途 |
+|--------|------|------|
+| `ix_compute_session_sandbox` | `(sandbox_id)` | 通过 sandbox 查找其所有 session（包括历史） |
+| `ix_compute_session_user` | `(user_id)` | 查询用户的 session 列表（Usage API） |
+| `ix_compute_session_open` | `(ended_at) WHERE ended_at IS NULL` | 部分索引，快速找到所有运行中的 session（tick_metering 热路径） |
+
+详见 [Compute 计量详细设计](2026-03-26-metering-compute.md)。
+
+### 5.5 StorageLedger 表
+
+追踪每个持久卷（PVC）的完整生命周期。是 Storage 配额检查和未来 GiB-月计费的底层数据。
+
+#### SQL DDL
+
+```sql
+CREATE TABLE storage_ledger (
+    id                VARCHAR(24)    PRIMARY KEY,
+    user_id           VARCHAR(24)    NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+    sandbox_id        VARCHAR(24)    REFERENCES sandbox(id) ON DELETE SET NULL,
+    size_gib          INTEGER        NOT NULL,
+    storage_state     VARCHAR(16)    NOT NULL DEFAULT 'active',
+    allocated_at      TIMESTAMPTZ    NOT NULL,
+    released_at       TIMESTAMPTZ,
+    archived_at       TIMESTAMPTZ,
+    gib_hours_consumed DECIMAL(10,4) NOT NULL DEFAULT 0,
+    last_metered_at   TIMESTAMPTZ    NOT NULL,
+    gmt_created       TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    gmt_updated       TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ix_storage_ledger_user_state ON storage_ledger(user_id, storage_state);
+CREATE INDEX ix_storage_ledger_sandbox    ON storage_ledger(sandbox_id);
+```
+
+#### 字段说明
+
+| 字段 | 类型 | 约束 | 设计意图 |
+|------|------|------|---------|
+| `id` | String(24) | PK | 前缀 `sl`，如 `sl3a8f9b2c1d4e5f67` |
+| `user_id` | String(24) | FK → user.id, INDEX | 存储所属用户 |
+| `sandbox_id` | String(24) | FK → sandbox.id (ON DELETE SET NULL) | 关联的 sandbox。sandbox 被硬删除后置 NULL，但 ledger 记录保留用于计费对账 |
+| `size_gib` | Integer | NOT NULL | 分配的 PVC 大小（GiB），从 sandbox 的 `storage_size` 解析 |
+| `storage_state` | String(16) | NOT NULL, DEFAULT 'active' | 状态机：`active` → `archived` → `deleted`，或 `active` → `deleted` |
+| `allocated_at` | DateTime(tz) | NOT NULL | PVC 创建时间 |
+| `released_at` | DateTime(tz) | nullable | PVC 删除时间。`NULL` 表示仍在占用 |
+| `archived_at` | DateTime(tz) | nullable | 迁移到冷存储的时间（Phase 3 远期功能） |
+| `gib_hours_consumed` | Decimal(10,4) | NOT NULL, DEFAULT 0 | 累计 GiB-hours，后台 tick 持续更新，为 Phase 2 GiB-月计费准备 |
+| `last_metered_at` | DateTime(tz) | NOT NULL | 上次 tick 更新 gib_hours 的时间点 |
+| `gmt_created` | DateTime(tz) | NOT NULL | 记录创建时间 |
+| `gmt_updated` | DateTime(tz) | NOT NULL | 记录最后更新时间 |
+
+#### 索引说明
+
+| 索引名 | 列 | 用途 |
+|--------|------|------|
+| `ix_storage_ledger_user_state` | `(user_id, storage_state)` | 查询用户的活跃存储占用——配额检查热路径 |
+| `ix_storage_ledger_sandbox` | `(sandbox_id)` | 通过 sandbox 查找其存储记录 |
+
+详见 [Storage 计量详细设计](2026-03-26-metering-storage.md)。
+
+### 5.6 Alembic Migration 策略
+
+所有 5 张表在同一个 Alembic migration 中创建，连同 TierTemplate 的初始 seed 数据。migration 应紧随当前 head `2457b93fc846`（cli_login_flow）。
+
+```python
+def upgrade():
+    # 1. CREATE TABLE tier_template
+    # 2. CREATE TABLE user_plan
+    # 3. CREATE TABLE credit_grant
+    # 4. CREATE TABLE compute_session
+    # 5. CREATE TABLE storage_ledger
+    # 6. INSERT tier_template (4 rows: free, pro, ultra, enterprise)
+```
+
+> **不需要为现有用户回填 UserPlan。** 部署后，当现有用户首次执行需要配额检查的操作（如 create sandbox）时，`ensure_user_plan()` 会自动为其创建 Free UserPlan。这避免了批量数据迁移的复杂性。
+
+---
+
+## 6. 竞品对比
+
+### 6.1 对比矩阵
+
+| 维度 | Daytona | E2B | GitHub Codespaces | Vercel Sandbox | **Treadstone** |
+|------|---------|-----|-------------------|----------------|---------------|
+| **产品定位** | AI Agent sandbox | AI Agent sandbox | 云开发环境 | 全栈应用沙箱 | **AI Agent sandbox** |
+| **计费粒度** | 按秒 | 按秒 | 按小时 | 按秒（CPU-ms 级） | **按秒（内部），分钟（展示）** |
+| **CPU 单价** | ~$0.05/h/vCPU | ~$0.05/h/vCPU | $0.09/h/core | 按区域 | **Phase 1 不直接定价** |
+| **存储计费** | $0.000108/h/GiB (5GiB 免费) | 免费 (10-20GiB) | $0.07/GB-月 | 快照按 GB/月 | **Phase 1 配额控制，Phase 2 GiB-月** |
+| **免费额度** | $200 一次性 | $100 一次性 | 120 core-hours/月 | Hobby 限额 | **10 Credits/月 + 50 Welcome Bonus** |
+| **额度耗尽** | 通知 + 自动充值 | 封锁账户 | 阻止新建 | 暂停到下周期 | **阻止新建 + Grace Period + 自动 stop** |
+| **暂停/停止** | Stop/Archive | Pause/Auto-pause | 手动停止 | 超时 + 手动 | **Stop + auto_stop_interval + Grace Period 自动 stop** |
+| **Tier 模型** | 4 级资源上限 (Tier 1-4) | 3 档 (Hobby/Pro/Enterprise) | 无 Tier（按量） | 3 档 (Hobby/Pro/Enterprise) | **4 档 (Free/Pro/Ultra/Enterprise)** |
+| **并发限制** | 10-500+ | 20-1,100+ | 无明确限制 | 10-2,000 | **1-50+** |
+| **钱包/充值** | 组织钱包 + 自动充值 | 月度后付费 | 月度后付费 | 月度后付费 | **Phase 1 不涉及，Phase 2 引入** |
+
+### 6.2 Treadstone 的差异化
+
+1. **双池额度模型**：Monthly Credits + Extra Credits 的设计在竞品中独特。Daytona 用钱包余额（单池），E2B 用一次性 credit + 月度订阅（但 credit 和订阅是分开的概念）。Treadstone 的双池模型统一了月度配额和一次性赠送，消费逻辑透明。
+
+2. **Tier 配额动态可调**：所有竞品的 Tier 配额都硬编码在代码或配置中。Treadstone 存储在数据库中，通过 Admin API 可实时调整。这对单人项目至关重要——可以快速响应用户反馈和市场变化。
+
+3. **Grace Period 机制**：E2B 在额度耗尽时直接封锁账户（对 AI Agent 不友好）；Daytona 依赖自动充值（需要绑定支付方式）；GitHub Codespaces 阻止新建但不影响运行中的。Treadstone 的 Grace Period 给用户保存工作的缓冲时间，同时通过时限和绝对上限（月度额度的 20%）防止无限透支。
+
+4. **基于 K8s request 计费**：与 AWS Fargate / GCP Cloud Run 的理念一致。Daytona 和 E2B 的计费基础不公开，但推测也是基于分配资源（而非实际使用量）。
+
+5. **专注 AI Agent 场景**：比 GitHub Codespaces 更轻量（sandbox 而非完整开发环境），比 Vercel Sandbox 更专注（不做 Active CPU / 网络 / 快照的多维度计量）。
+
+---
+
+## 7. 架构总览
+
+### 7.1 组件交互图
+
+```mermaid
+flowchart TB
+    subgraph UserFacing["用户侧"]
+        API["FastAPI Routes<br/>/v1/sandboxes<br/>/v1/usage"]
+        CLI["CLI (treadstone-cli)"]
+        SDK["SDK (treadstone-sdk)"]
+    end
+
+    subgraph MeteringCore["计量核心"]
+        MS["MeteringService<br/>· ensure_user_plan()<br/>· check_*_quota()<br/>· consume_*_credits()<br/>· open/close_session()<br/>· tick_metering()"]
+        SBS["SandboxService<br/>· create() → 配额检查<br/>· start() → 配额检查<br/>· delete() → 释放存储"]
+    end
+
+    subgraph Background["后台任务 (Leader Only)"]
+        Tick["tick_metering()<br/>每 60 秒"]
+        Grace["check_grace_periods()<br/>每 60 秒"]
+        Reset["reset_monthly_credits()<br/>每月 1 日"]
+        Sync["K8s Sync<br/>Watch + Reconcile"]
+    end
+
+    subgraph DataStore["数据存储 (Neon PostgreSQL)"]
+        TT["TierTemplate"]
+        UP["UserPlan"]
+        CG["CreditGrant"]
+        CS["ComputeSession"]
+        SL["StorageLedger"]
+        AE["AuditEvent"]
+    end
+
+    subgraph AdminFacing["管理员侧"]
+        AdminAPI["Admin API<br/>/v1/admin/tier-templates<br/>/v1/admin/users/{id}/plan<br/>/v1/admin/users/{id}/grants"]
+    end
+
+    subgraph K8s["Kubernetes"]
+        SandboxCR["Sandbox CR"]
+        Pod["Sandbox Pod"]
+    end
+
+    CLI --> API
+    SDK --> API
+    API --> SBS
+    SBS --> MS
+    MS --> UP
+    MS --> CG
+    MS --> CS
+    MS --> SL
+    MS --> TT
+
+    Sync --> MS
+    Sync -->|Watch/Reconcile| SandboxCR
+    SandboxCR --> Pod
+
+    Tick --> MS
+    Grace --> MS
+    Reset --> MS
+
+    MS -->|审计事件| AE
+
+    AdminAPI --> TT
+    AdminAPI --> UP
+    AdminAPI --> CG
+```
+
+### 7.2 数据流：创建 Sandbox 的完整链路
+
+```mermaid
+sequenceDiagram
+    participant User as 用户/Agent
+    participant API as FastAPI
+    participant SBS as SandboxService
+    participant MS as MeteringService
+    participant DB as Neon_DB
+    participant K8S as Kubernetes
+    participant Sync as K8sSync(Leader)
+
+    User->>API: POST /v1/sandboxes {template:"small", persist:true, storage_size:"5Gi"}
+    API->>SBS: create(owner_id, template, persist, storage_size)
+
+    SBS->>MS: check_template_allowed(user_id, "small")
+    MS->>DB: SELECT UserPlan WHERE user_id=?
+    MS-->>SBS: allowed
+
+    SBS->>MS: check_compute_quota(user_id)
+    MS->>DB: SELECT monthly_used, monthly_limit FROM UserPlan
+    MS->>DB: SELECT SUM(remaining) FROM CreditGrant WHERE compute
+    MS-->>SBS: allowed (remaining=104.5)
+
+    SBS->>MS: check_concurrent_limit(user_id)
+    MS->>DB: SELECT COUNT(*) FROM sandbox WHERE status IN (creating,ready)
+    MS-->>SBS: allowed (0/3)
+
+    SBS->>MS: check_storage_quota(user_id, 5)
+    MS->>DB: SELECT SUM(size_gib) FROM StorageLedger WHERE active
+    MS->>DB: SELECT remaining FROM CreditGrant WHERE storage
+    MS-->>SBS: allowed (0/10 used)
+
+    SBS->>DB: INSERT sandbox (status=creating)
+    SBS->>K8S: Create Sandbox CR (with PVC)
+    SBS->>MS: record_storage_allocation(sandbox_id, user_id, 5)
+    MS->>DB: INSERT StorageLedger (state=active, size_gib=5)
+
+    API-->>User: 201 Created {id:"sb...", status:"creating"}
+
+    Note over K8S,Sync: K8s controller creates Pod, sandbox becomes ready
+
+    K8S-->>Sync: Watch: Sandbox CR → Ready
+    Sync->>DB: UPDATE sandbox SET status=ready
+    Sync->>MS: open_compute_session(sandbox)
+    MS->>DB: INSERT ComputeSession (started_at=now, rate=0.5)
+
+    Note over Sync,DB: tick_metering() runs every 60s
+    loop 每60秒
+        Sync->>MS: tick_metering()
+        MS->>DB: UPDATE ComputeSession SET credits+=delta
+        MS->>DB: UPDATE UserPlan SET monthly_used+=delta
+    end
+```
+
+### 7.3 系统边界
+
+| 组件 | 属于计量系统 | 说明 |
+|------|:-----------:|------|
+| MeteringService | 是 | 新建。计量系统的核心业务逻辑 |
+| TierTemplate / UserPlan / CreditGrant / ComputeSession / StorageLedger | 是 | 新建。计量数据模型 |
+| Usage API (`/v1/usage/*`) | 是 | 新建。用量查询端点 |
+| Admin API (`/v1/admin/*`) | 是 | 新建。管理员工具 |
+| SandboxService | 否（被修改） | 现有。create/start/delete 方法中插入配额检查和存储记录 |
+| K8s Sync | 否（被修改） | 现有。状态变更时触发 session open/close |
+| sync_supervisor | 否（被修改） | 现有。添加 tick_metering 定期任务 |
+| errors.py | 否（被修改） | 现有。添加 5 种新错误类型 |
+| AuditEvent | 否（被使用） | 现有。记录计量通知事件 |
+
+---
+
+## 8. 关联文档
+
+本文档定义了计量系统的全局设计——Tier 模型、双池 Credit 体系、数据模型、计费周期和架构总览。以下 3 份子文档分别提供各模块的详细实现设计：
+
+| 文档 | 主题 | 核心内容 |
+|------|------|---------|
+| [Compute 计量详细设计](2026-03-26-metering-compute.md) | Compute Credits 的完整实现 | Credit 定义与费率公式、ComputeSession 生命周期、双池消费算法（consume_compute_credits）、后台 tick_metering、K8s Sync 集成、崩溃容错与对账、月度重置对 session 的影响 |
+| [Storage 计量详细设计](2026-03-26-metering-storage.md) | Storage Credits 的完整实现 | Storage Credits 定义（Phase 1 配额 / Phase 2 GiB-月）、双池 Storage 模型、StorageLedger 状态机、配额检查流程、后台 gib_hours 累积、冷存储迁移路径 |
+| [配额执行与 API 设计](2026-03-26-metering-enforcement.md) | 配额执行和用户/管理员接口 | Create/Start 配额检查流程、Error 类型定义、Grace Period 状态机、通知事件、Usage API（GET /v1/usage 等）、Admin API（修改 Plan / 发放 Grant / 管理 TierTemplate） |
+
+**阅读顺序建议**：先读本文档了解全貌，然后根据实现需要按顺序阅读 Compute → Storage → Enforcement。

--- a/docs/zh-CN/design/2026-03-26-metering-storage.md
+++ b/docs/zh-CN/design/2026-03-26-metering-storage.md
@@ -1,0 +1,1066 @@
+# Storage 计量设计
+
+**日期：** 2026-03-26
+**状态：** 设计中
+**关联文档：** [计量系统总览](2026-03-26-metering-overview.md)
+
+---
+
+## 1. Storage Credits 定义
+
+Storage Credits 是 Treadstone 计量系统中与 Compute Credits 并列的第二个维度。Compute Credits 衡量的是"运行时间"（CPU + 内存），而 Storage Credits 衡量的是"持久存储容量"（PVC 磁盘空间）。
+
+### 1.1 Phase 1：配额模型（当前实现目标）
+
+在 Phase 1 中，Storage Credits 表现为 **GiB 容量上限**——一个纯配额概念：
+
+- **1 Storage Credit = 1 GiB 的持久存储容量**
+- 用户的总可用存储 = Monthly Storage Credits + Extra Storage Credits
+- 只要 PVC 存在（即使 sandbox 已 stopped），就持续占用 Storage Credits
+- 删除 sandbox（同时删除 PVC）后，对应 Credits 立即释放
+- 非持久 sandbox（`persist=False`）不产生任何 Storage Credits 消耗
+
+```
+用户配额模型：
+
+┌─────────────────────────────────────────────────────┐
+│           Total Storage Quota (GiB)                 │
+│  ┌──────────────────────┐  ┌─────────────────────┐  │
+│  │ Monthly Storage       │  │ Extra Storage       │  │
+│  │ Credits               │  │ Credits             │  │
+│  │ (Tier 决定, 月初重置) │  │ (Grant 授予, 可过期)│  │
+│  └──────────────────────┘  └─────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+
+存储占用 = SUM(所有 active StorageLedger 的 size_gib)
+可用空间 = Total Storage Quota - 存储占用
+```
+
+### 1.2 Phase 2：GiB-月计费模型（未来演进）
+
+Phase 2 中，Storage Credits 演进为 **GiB-月** 计费单位，即同时考虑"容量"和"持续时间"：
+
+- 1 GiB 分配 1 个月 = 1 GiB-月
+- 按比例计算：10 GiB 分配 15 天 ≈ 5 GiB-月
+- 更精确的单位：1 GiB-月 ≈ 720 GiB-hours
+- 后台通过 `StorageLedger.gib_hours_consumed` 字段持续追踪
+
+**定价参考（Phase 2 使用）：**
+
+| 平台 | 持久存储定价 |
+|------|-------------|
+| GitHub Codespaces | $0.07 / GiB-月 |
+| Daytona | ~$0.08 / GiB-月 |
+| Gitpod | $0.30 / GiB-月（含备份） |
+
+Phase 1 已在数据模型中预留 `gib_hours_consumed` 字段并在后台 tick 中持续累积，确保 Phase 2 上线时有历史数据可用。
+
+---
+
+## 2. 双池 Storage Credits 模型
+
+与 Compute Credits 类似，Storage 也采用 **双池** 设计：Monthly 池 + Extra 池。
+
+### 2.1 Monthly Storage Credits
+
+| 属性 | 说明 |
+|------|------|
+| 来源 | 用户所属 Tier（订阅等级）自动授予 |
+| 重置周期 | 每月 1 日 00:00 UTC 重置上限 |
+| 首月处理 | 注册时直接给满当月配额 |
+| 不可转让 | Monthly Credits 不可转赠、不可提现 |
+
+**各 Tier 的 Monthly Storage Credits：**
+
+| Tier | Monthly Storage Credits (GiB) | 说明 |
+|------|------------------------------|------|
+| Free | 0 | 不允许创建持久 sandbox |
+| Pro | 10 | 最多 10 GiB 持久存储 |
+| Ultra | 20 | 最多 20 GiB 持久存储 |
+| Enterprise | 自定义 | 按合同约定 |
+
+### 2.2 Extra Storage Credits
+
+| 属性 | 说明 |
+|------|------|
+| 来源 | `CreditGrant`（`credit_type = "storage"`） |
+| 触发来源 | 营销活动、管理员手动授予、付费购买 |
+| 过期机制 | 每条 Grant 有 `expires_at`，过期后不再计入配额 |
+| Welcome Bonus | **暂不赠送** Storage Credits（Free 用户不允许 persist，无意义） |
+
+### 2.3 Storage 配额计算公式
+
+```python
+def calculate_storage_quota(user_id: str, plan: Plan, session: AsyncSession) -> StorageQuota:
+    # Monthly 配额（由 Tier 决定）
+    monthly_quota = plan.storage_credits_monthly_limit
+
+    # Extra 配额（来自未过期的 storage CreditGrant）
+    extra_quota = await session.execute(
+        select(func.coalesce(func.sum(CreditGrant.remaining_amount), 0))
+        .where(
+            CreditGrant.user_id == user_id,
+            CreditGrant.credit_type == "storage",
+            CreditGrant.expires_at > utc_now(),
+        )
+    )
+    extra_quota_value = extra_quota.scalar_one()
+
+    total_quota = monthly_quota + extra_quota_value
+
+    # 当前已用（所有 active 状态的 StorageLedger）
+    current_used = await session.execute(
+        select(func.coalesce(func.sum(StorageLedger.size_gib), 0))
+        .where(
+            StorageLedger.user_id == user_id,
+            StorageLedger.storage_state == "active",
+        )
+    )
+    current_used_value = current_used.scalar_one()
+
+    available = total_quota - current_used_value
+
+    return StorageQuota(
+        monthly_quota=monthly_quota,
+        extra_quota=extra_quota_value,
+        total_quota=total_quota,
+        current_used=current_used_value,
+        available=available,
+    )
+```
+
+### 2.4 与 Compute Credits 的关键区别
+
+```
+Compute Credits（消耗型）：
+
+  ┌─ running ────────────────────── stopped ─┐
+  │ ████████████████████████████████          │  ← 持续消耗
+  │ 每秒扣减 credits_per_second              │
+  └──────────────────────────────────────────┘
+
+Storage Credits（占用型 — Phase 1）：
+
+  ┌─ created ─────────────────── deleted ────┐
+  │ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓          │  ← 容量占用
+  │ 分配时占用, 释放时归还                      │
+  │ 不随时间消耗更多                            │
+  │ stopped 状态 PVC 仍存在 → 仍占用           │
+  └──────────────────────────────────────────┘
+```
+
+| 维度 | Compute Credits | Storage Credits (Phase 1) |
+|------|----------------|--------------------------|
+| 消耗方式 | 随时间持续扣减 | 分配时一次性占用 |
+| 关联资源 | Running sandbox (CPU + Mem) | PVC (磁盘) |
+| stop 影响 | 停止消耗 | 不影响，仍占用 |
+| 释放条件 | sandbox stopped | sandbox deleted (PVC 删除) |
+| 月度重置 | monthly_used 归零 | 上限刷新，已有分配不变 |
+
+---
+
+## 3. StorageLedger 表设计
+
+`StorageLedger` 追踪每个持久卷的完整生命周期，是 Storage 计量的核心数据模型。
+
+### 3.1 表结构
+
+```python
+class StorageState(StrEnum):
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+    DELETED = "deleted"
+
+
+class StorageLedger(Base):
+    __tablename__ = "storage_ledger"
+    __table_args__ = (
+        Index("ix_storage_ledger_user_state", "user_id", "storage_state"),
+        Index("ix_storage_ledger_sandbox", "sandbox_id"),
+    )
+
+    # ── 主键 ──
+    id: Mapped[str] = mapped_column(
+        String(24), primary_key=True, default=lambda: "sl" + random_id()
+    )
+
+    # ── 关联 ──
+    user_id: Mapped[str] = mapped_column(
+        String(24), ForeignKey("user.id", ondelete="CASCADE"), nullable=False
+    )
+    sandbox_id: Mapped[str] = mapped_column(
+        String(24), ForeignKey("sandbox.id", ondelete="SET NULL"), nullable=True
+    )
+
+    # ── 容量 ──
+    size_gib: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # ── 状态 ──
+    storage_state: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=StorageState.ACTIVE
+    )
+
+    # ── 生命周期时间戳 ──
+    allocated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    released_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # ── 计量字段（为 Phase 2 准备） ──
+    gib_hours_consumed: Mapped[Decimal] = mapped_column(
+        Numeric(10, 4), nullable=False, default=Decimal("0")
+    )
+    last_metered_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    # ── 审计 ──
+    gmt_created: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+    gmt_updated: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+    )
+```
+
+### 3.2 字段说明
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | String(24) | 主键，前缀 `sl`，如 `sl3a8f9b2c1d4e5f67` |
+| `user_id` | String(24) | 存储所属用户，FK → `user.id` |
+| `sandbox_id` | String(24) | 关联 sandbox，FK → `sandbox.id`（sandbox 被硬删除后置 NULL） |
+| `size_gib` | Integer | 分配的 PVC 大小，单位 GiB（5 / 10 / 20） |
+| `storage_state` | String(16) | 状态机：`active` → `archived` → `deleted`，或 `active` → `deleted` |
+| `allocated_at` | DateTime(tz) | PVC 创建时间（分配时间点） |
+| `released_at` | DateTime(tz) | PVC 删除时间（释放时间点），NULL 表示仍在占用 |
+| `archived_at` | DateTime(tz) | 迁移到冷存储的时间（远期功能使用） |
+| `gib_hours_consumed` | Decimal(10,4) | 累计 GiB-hours，后台 tick 持续更新 |
+| `last_metered_at` | DateTime(tz) | 上次 tick 更新时间，用于增量计算 |
+| `gmt_created` | DateTime(tz) | 记录创建时间 |
+| `gmt_updated` | DateTime(tz) | 记录最后更新时间 |
+
+### 3.3 索引设计
+
+| 索引名 | 列 | 用途 |
+|--------|------|------|
+| `ix_storage_ledger_user_state` | `(user_id, storage_state)` | 查询用户的活跃存储占用（配额检查热路径） |
+| `ix_storage_ledger_sandbox` | `(sandbox_id)` | 通过 sandbox 查找其对应的存储记录 |
+
+### 3.4 状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> active: PVC创建
+    active --> archived: 冷存储迁移(远期)
+    active --> deleted: sandbox删除/PVC释放
+    archived --> active: 从冷存储恢复
+    archived --> deleted: 归档数据彻底清理
+    deleted --> [*]
+```
+
+**状态含义：**
+
+| 状态 | 含义 | 占用配额 | PVC 存在 |
+|------|------|---------|---------|
+| `active` | PVC 存在并可用 | 是 | 是 |
+| `archived` | 数据已迁移到对象存储 | 否（或减少费率） | 否 |
+| `deleted` | PVC 已删除，存储已释放 | 否 | 否 |
+
+---
+
+## 4. 存储配额检查流程
+
+当用户请求创建 `persist=True` 的 sandbox 时，必须在 K8s 资源创建之前完成配额检查。
+
+### 4.1 检查伪代码
+
+```python
+class StorageQuotaExceededError(TreadstoneError):
+    def __init__(self, used: int, requested: int, quota: int):
+        super().__init__(
+            code="storage_quota_exceeded",
+            message=(
+                f"Storage quota exceeded. "
+                f"Used: {used} GiB, Requested: {requested} GiB, "
+                f"Quota: {quota} GiB. "
+                f"Delete unused persistent sandboxes or upgrade your plan."
+            ),
+            status=403,
+        )
+
+
+async def check_storage_quota(
+    user_id: str,
+    requested_gib: int,
+    session: AsyncSession,
+) -> None:
+    """在创建持久 sandbox 前检查存储配额。超出则抛出异常。"""
+
+    # 1. 获取用户 Plan
+    plan = await get_user_plan(user_id, session)
+
+    # 2. 计算总配额
+    monthly_quota = plan.storage_credits_monthly_limit
+
+    extra_result = await session.execute(
+        select(func.coalesce(func.sum(CreditGrant.remaining_amount), 0))
+        .where(
+            CreditGrant.user_id == user_id,
+            CreditGrant.credit_type == "storage",
+            CreditGrant.expires_at > utc_now(),
+        )
+    )
+    extra_quota = extra_result.scalar_one()
+    total_quota = monthly_quota + extra_quota
+
+    # 3. 计算当前已用
+    used_result = await session.execute(
+        select(func.coalesce(func.sum(StorageLedger.size_gib), 0))
+        .where(
+            StorageLedger.user_id == user_id,
+            StorageLedger.storage_state == "active",
+        )
+    )
+    current_used = used_result.scalar_one()
+
+    # 4. 检查是否超出
+    if current_used + requested_gib > total_quota:
+        raise StorageQuotaExceededError(
+            used=current_used,
+            requested=requested_gib,
+            quota=total_quota,
+        )
+```
+
+### 4.2 特殊情况处理
+
+| 场景 | monthly | extra | 已用 | 请求 | 结果 |
+|------|---------|-------|------|------|------|
+| Free 用户请求 persist | 0 | 0 | 0 | 5 | **拒绝** (0 + 5 > 0) |
+| Pro 用户首次请求 5 GiB | 10 | 0 | 0 | 5 | 允许 (0 + 5 ≤ 10) |
+| Pro 用户已用 8 GiB，请求 5 GiB | 10 | 0 | 8 | 5 | **拒绝** (8 + 5 > 10) |
+| Pro 用户已用 8 GiB，有 5 GiB extra，请求 5 GiB | 10 | 5 | 8 | 5 | 允许 (8 + 5 ≤ 15) |
+| Ultra 用户请求 20 GiB | 20 | 0 | 0 | 20 | 允许 (0 + 20 ≤ 20) |
+
+### 4.3 配额检查在请求流程中的位置
+
+```mermaid
+flowchart TD
+    A[用户请求创建sandbox<br/>persist=true] --> B{Free tier?}
+    B -->|是| Z1[返回403<br/>StorageQuotaExceededError]
+    B -->|否| C[解析storage_size<br/>转换为GiB整数]
+    C --> D[查询用户Plan<br/>获取monthly配额]
+    D --> E[查询未过期的<br/>extra storage grants]
+    E --> F[查询active状态的<br/>StorageLedger总和]
+    F --> G{used+requested<br/><=quota?}
+    G -->|否| Z2[返回403<br/>StorageQuotaExceededError]
+    G -->|是| H[检查StorageClass<br/>是否存在]
+    H --> I[创建Sandbox记录<br/>status=creating]
+    I --> J[创建K8s<br/>SandboxCR+PVC]
+    J --> K[INSERT<br/>StorageLedger<br/>state=active]
+    K --> L[返回Sandbox]
+```
+
+### 4.4 storage_size 字符串到 GiB 整数的转换
+
+```python
+def parse_storage_size_gib(size_str: str) -> int:
+    """将 '5Gi', '10Gi', '20Gi' 等转换为整数 GiB 值。"""
+    if size_str.endswith("Gi"):
+        return int(size_str[:-2])
+    if size_str.endswith("Ti"):
+        return int(size_str[:-2]) * 1024
+    raise BadRequestError(f"Unsupported storage size format: {size_str}")
+```
+
+---
+
+## 5. 存储分配与释放流程
+
+### 5.1 分配流程（sandbox create with persist=True）
+
+```mermaid
+sequenceDiagram
+    participant Client as 客户端
+    participant API as API层
+    participant SVC as SandboxService
+    participant Quota as 配额检查
+    participant DB as PostgreSQL
+    participant K8s as Kubernetes
+
+    Client->>API: POST /sandboxes {persist:true, storage_size:"10Gi"}
+    API->>SVC: create(persist=true, storage_size="10Gi")
+
+    SVC->>Quota: check_storage_quota(user_id, 10)
+    Quota->>DB: SELECT plan + grants + active ledger
+    DB-->>Quota: quota=15, used=3
+    Quota-->>SVC: OK (3+10 ≤ 15)
+
+    SVC->>K8s: get_storage_class("treadstone-workspace")
+    K8s-->>SVC: exists
+
+    SVC->>DB: INSERT sandbox (status=creating)
+    SVC->>K8s: create_sandbox(volumeClaimTemplates)
+    K8s-->>SVC: created
+
+    SVC->>DB: INSERT storage_ledger (state=active, size_gib=10)
+    SVC-->>API: sandbox created
+    API-->>Client: 201 Created
+```
+
+**关键实现细节：**
+
+```python
+async def create(self, owner_id: str, ..., persist: bool = False, storage_size: str | None = None) -> Sandbox:
+    effective_storage_size = storage_size or settings.sandbox_default_storage_size
+    size_gib = parse_storage_size_gib(effective_storage_size)
+
+    if persist:
+        # 配额检查 — 必须在任何资源创建之前
+        await check_storage_quota(owner_id, size_gib, self.session)
+        await self._ensure_persistent_storage_backend_ready()
+
+    # ... 创建 sandbox 记录 ...
+    # ... 创建 K8s 资源 ...
+
+    if persist:
+        # 创建 StorageLedger 记录
+        ledger = StorageLedger(
+            user_id=owner_id,
+            sandbox_id=sandbox.id,
+            size_gib=size_gib,
+            storage_state=StorageState.ACTIVE,
+            allocated_at=utc_now(),
+            last_metered_at=utc_now(),
+        )
+        self.session.add(ledger)
+        await self.session.commit()
+
+    return sandbox
+```
+
+### 5.2 释放流程（sandbox delete）
+
+```mermaid
+sequenceDiagram
+    participant Client as 客户端
+    participant API as API层
+    participant SVC as SandboxService
+    participant DB as PostgreSQL
+    participant K8s as Kubernetes
+
+    Client->>API: DELETE /sandboxes/{id}
+    API->>SVC: delete(sandbox_id, owner_id)
+
+    SVC->>DB: 查询sandbox (persist=true)
+
+    SVC->>DB: UPDATE storage_ledger<br/>SET state='deleted',<br/>released_at=now(),<br/>计算最终gib_hours
+    Note over DB: Credits释放，配额恢复
+
+    SVC->>DB: UPDATE sandbox SET status='deleting'
+    SVC->>K8s: delete_sandbox (删除CR+PVC)
+    K8s-->>SVC: deleted
+
+    SVC-->>API: 204 No Content
+    API-->>Client: 204
+```
+
+**关键实现细节：**
+
+```python
+async def delete(self, sandbox_id: str, owner_id: str) -> None:
+    sandbox = await self.get(sandbox_id, owner_id)
+    if sandbox is None:
+        raise SandboxNotFoundError(sandbox_id)
+
+    # ... 状态转换检查 ...
+
+    if sandbox.persist:
+        # 释放存储记录
+        result = await self.session.execute(
+            select(StorageLedger).where(
+                StorageLedger.sandbox_id == sandbox_id,
+                StorageLedger.storage_state == StorageState.ACTIVE,
+            )
+        )
+        ledger = result.scalar_one_or_none()
+        if ledger is not None:
+            now = utc_now()
+            # 最终计算 gib_hours
+            elapsed_seconds = (now - ledger.last_metered_at).total_seconds()
+            final_gib_hours = ledger.size_gib * elapsed_seconds / 3600
+            ledger.gib_hours_consumed += Decimal(str(final_gib_hours))
+            ledger.last_metered_at = now
+
+            ledger.storage_state = StorageState.DELETED
+            ledger.released_at = now
+            self.session.add(ledger)
+
+    # ... 更新 sandbox 状态为 deleting ...
+    # ... 删除 K8s 资源 ...
+```
+
+### 5.3 Sandbox stop/start 对存储计量的影响
+
+**核心原则：stop/start 不影响存储计量。**
+
+| 操作 | PVC 状态 | StorageLedger.storage_state | 占用配额 |
+|------|---------|---------------------------|---------|
+| create (persist=true) | 创建 | `active` | 是 |
+| stop | 不变（PVC 仍存在） | `active`（不变） | 是 |
+| start | 不变 | `active`（不变） | 是 |
+| delete | 删除 | → `deleted` | 否 |
+
+```mermaid
+gantt
+    title PVC生命周期与存储占用
+    dateFormat X
+    axisFormat %s
+
+    section PVC存在
+    PVC created → deleted    :active, 0, 100
+
+    section Sandbox状态
+    creating   :crit, 0, 5
+    ready      :done, 5, 30
+    stopped    :30, 60
+    ready      :done, 60, 80
+    deleting   :crit, 80, 100
+
+    section 存储配额占用
+    占用credits :active, 0, 100
+```
+
+stop 后 PVC 仍然存在（K8s 只是将 Pod 副本数缩至 0，PVC 保留），因此 `storage_state` 保持 `active`，存储配额持续占用。这与 Compute Credits 不同——Compute 在 stop 后停止消耗。
+
+---
+
+## 6. GiB-Hours 追踪（为未来计费准备）
+
+虽然 Phase 1 采用纯配额模型，但从 Day 1 开始就在后台追踪 GiB-hours，为 Phase 2 的按量计费做数据准备。
+
+### 6.1 后台 Tick 逻辑
+
+与 Compute Credits 的 tick 使用同一个定时循环（每 60 秒执行一次），确保不引入额外的调度复杂度：
+
+```python
+async def tick_storage_metering(session: AsyncSession) -> int:
+    """更新所有 active 存储条目的 GiB-hours。返回更新条目数。"""
+    now = utc_now()
+    updated = 0
+
+    result = await session.execute(
+        select(StorageLedger).where(
+            StorageLedger.storage_state == StorageState.ACTIVE
+        )
+    )
+    active_entries = result.scalars().all()
+
+    for entry in active_entries:
+        elapsed_seconds = (now - entry.last_metered_at).total_seconds()
+        if elapsed_seconds <= 0:
+            continue
+
+        new_gib_hours = entry.size_gib * elapsed_seconds / 3600
+        entry.gib_hours_consumed += Decimal(str(round(new_gib_hours, 4)))
+        entry.last_metered_at = now
+        updated += 1
+
+    if updated > 0:
+        await session.commit()
+
+    return updated
+```
+
+### 6.2 Tick 调度集成
+
+```python
+async def metering_tick():
+    """统一计量 tick，同时处理 Compute 和 Storage。"""
+    async with async_session_factory() as session:
+        # Compute tick（已有）
+        await tick_compute_metering(session)
+
+        # Storage tick（新增）
+        count = await tick_storage_metering(session)
+        if count > 0:
+            logger.debug("Storage metering tick: updated %d entries", count)
+```
+
+### 6.3 GiB-Hours 到 GiB-月的换算
+
+```
+1 GiB-月 = 30 天 × 24 小时 = 720 GiB-hours
+
+示例：
+- 10 GiB 存储运行 30 天 = 10 × 720 = 7200 GiB-hours = 10 GiB-月
+- 5 GiB 存储运行 15 天 = 5 × 360 = 1800 GiB-hours = 2.5 GiB-月
+- 20 GiB 存储运行 3 天 = 20 × 72 = 1440 GiB-hours = 2 GiB-月
+```
+
+### 6.4 精度保证
+
+- `gib_hours_consumed` 使用 `Decimal(10,4)`，精度 0.0001 GiB-hours ≈ 0.36 秒
+- tick 间隔 60 秒，误差窗口 < 60 秒（在 PVC 创建/删除边界）
+- 删除 sandbox 时执行最终计算，消除最后一个 tick 的误差
+
+---
+
+## 7. Storage 月度重置逻辑
+
+Storage 的月度重置与 Compute 有本质区别。
+
+### 7.1 Compute vs Storage 的月度重置对比
+
+```
+Compute 月度重置：
+  月末: monthly_used = 850 / 1000 credits
+  月初: monthly_used → 0 / 1000 credits  ← 清零，重新给一池水
+
+Storage 月度重置：
+  月末: 已分配 8 GiB / quota 15 GiB (monthly=10, extra=5)
+  月初: 已分配 8 GiB / quota 10 GiB (monthly=10, extra=5过期→0)
+  注意: 已有 PVC 不动! 只是上限可能变化
+```
+
+### 7.2 重置逻辑详解
+
+Storage 月度重置不需要任何主动操作——它是**自然发生的**：
+
+1. Monthly Storage Credits 每月重置为 Tier 定义的值（本质上不变，因为本来就是固定值）
+2. Extra Storage Credits 可能因 Grant 过期而减少
+3. 已有的 `StorageLedger` 记录和 PVC **不受任何影响**
+
+```python
+# 月度重置不需要存储相关的特殊逻辑
+# 配额自然通过查询实时计算：
+# total_quota = plan.monthly_limit + SUM(unexpired grants)
+# 如果 grants 过期了，total_quota 自然降低
+```
+
+### 7.3 超配（Over-Provisioned）状态
+
+当月度重置或 Grant 过期导致 `current_used > total_quota` 时，进入超配状态。
+
+```mermaid
+flowchart TD
+    A[月度重置 / Grant过期] --> B{current_used > total_quota?}
+    B -->|否| C[正常状态<br/>可继续创建持久sandbox]
+    B -->|是| D[超配状态]
+    D --> E[不允许新建持久sandbox]
+    D --> F[不删除已有PVC]
+    D --> G[用户收到通知]
+    G --> H{用户操作}
+    H -->|删除sandbox| I[current_used降低<br/>恢复正常]
+    H -->|购买extra credits| J[total_quota提升<br/>恢复正常]
+    H -->|不操作| K[维持超配<br/>已有数据安全]
+```
+
+**超配处理规则：**
+
+| 规则 | 说明 |
+|------|------|
+| 不删除 PVC | 用户数据安全是第一优先级，绝不自动删除 |
+| 不降级 PVC | 不会自动缩减已有 PVC 的大小 |
+| 阻止新建 | `check_storage_quota` 对新请求返回 403 |
+| 通知用户 | 通过 API 响应 / 控制台 / 邮件提示超配状态 |
+| 宽限期（可选） | 超配 N 天后可考虑强制 stop sandbox（不删除）以降低 Compute 消耗 |
+
+---
+
+## 8. 冷存储迁移设计（远期）
+
+### 8.1 目标
+
+长时间未使用的持久 sandbox 的存储自动迁移到低成本的对象存储（如 S3、阿里云 OSS 等），显著降低存储成本。
+
+**成本对比（估算）：**
+
+| 存储类型 | 单价（大致） | 20 GiB 月成本 |
+|---------|------------|-------------|
+| SSD 块存储 (PVC) | $0.10 / GiB-月 | $2.00 |
+| 对象存储 (S3/OSS) | $0.005 / GiB-月 | $0.10 |
+| 差额 | 20 倍 | $1.90 / 月 |
+
+对于个人项目来说，冷存储可以带来 **90-95%** 的存储成本降低。
+
+### 8.2 归档流程
+
+```mermaid
+sequenceDiagram
+    participant Cron as 定时任务
+    participant DB as PostgreSQL
+    participant K8s as Kubernetes
+    participant S3 as 对象存储
+
+    Cron->>DB: 查询候选sandbox<br/>(stopped > 30天,<br/>storage_state=active)
+    DB-->>Cron: [sandbox_1, sandbox_2]
+
+    loop 对每个候选sandbox
+        Cron->>K8s: 创建VolumeSnapshot
+        K8s-->>Cron: snapshot ready
+
+        Cron->>K8s: 创建数据导出Job<br/>(snapshot → tar.gz)
+        Cron->>S3: 上传 tar.gz
+        S3-->>Cron: upload complete
+
+        Cron->>K8s: 删除PVC + VolumeSnapshot
+        Cron->>DB: UPDATE storage_ledger<br/>SET state='archived',<br/>archived_at=now()
+
+        Note over DB: 配额释放(或按低费率计)
+    end
+```
+
+**归档触发条件：**
+
+```python
+ARCHIVE_THRESHOLD_DAYS = 30
+
+async def find_archive_candidates(session: AsyncSession) -> list[StorageLedger]:
+    cutoff = utc_now() - timedelta(days=ARCHIVE_THRESHOLD_DAYS)
+    result = await session.execute(
+        select(StorageLedger)
+        .join(Sandbox, StorageLedger.sandbox_id == Sandbox.id)
+        .where(
+            StorageLedger.storage_state == StorageState.ACTIVE,
+            Sandbox.status == SandboxStatus.STOPPED,
+            Sandbox.gmt_stopped < cutoff,
+        )
+    )
+    return list(result.scalars().all())
+```
+
+### 8.3 恢复流程
+
+```mermaid
+sequenceDiagram
+    participant Client as 客户端
+    participant API as API层
+    participant SVC as SandboxService
+    participant DB as PostgreSQL
+    participant S3 as 对象存储
+    participant K8s as Kubernetes
+
+    Client->>API: POST /sandboxes/{id}/start
+    API->>SVC: start(sandbox_id)
+    SVC->>DB: 查询StorageLedger
+
+    alt storage_state == 'archived'
+        SVC->>S3: 下载归档数据 tar.gz
+        SVC->>K8s: 创建新PVC
+        SVC->>K8s: 创建恢复Job<br/>(tar.gz → PVC)
+        K8s-->>SVC: 恢复完成
+
+        SVC->>DB: UPDATE storage_ledger<br/>SET state='active',<br/>allocated_at=now()
+        SVC->>S3: 标记归档数据可删除<br/>(保留N天后清理)
+    end
+
+    SVC->>K8s: scale_sandbox(replicas=1)
+    SVC-->>Client: sandbox starting
+```
+
+### 8.4 对计量的影响
+
+| 状态 | 配额占用 | GiB-hours 追踪 |
+|------|---------|---------------|
+| `active` | 完整占用 `size_gib` | 按 `size_gib` 累积 |
+| `archived` | 不占用配额（或按 1/10 费率） | 停止累积 active GiB-hours |
+| `deleted` | 不占用 | 停止 |
+
+### 8.5 为什么要现在预留
+
+虽然冷存储迁移是远期功能，但在 Phase 1 的 `StorageLedger` 表设计中就预留了关键字段：
+
+- `storage_state`：三态枚举 `active / archived / deleted`，零运行时成本
+- `archived_at`：nullable 时间戳，仅在归档时填充
+- 后续实现冷存储时**无需 schema 变更**（无 Alembic migration）
+- 对象存储成本约为块存储的 1/10 ~ 1/20，对单人项目的成本优化意义重大
+
+---
+
+## 9. storage_size 枚举值与 Tier 的关系
+
+### 9.1 当前配置
+
+`config.py` 中定义：
+
+```python
+SANDBOX_STORAGE_SIZE_VALUES = ("5Gi", "10Gi", "20Gi")
+```
+
+`settings.sandbox_default_storage_size` 默认为 `"5Gi"`。
+
+### 9.2 Tier 控制总配额，不控制单个 PVC 大小
+
+**核心原则：** Tier 控制的是用户的总存储配额（Total Storage Quota），而非单个 PVC 允许的大小选项。用户可以自由选择枚举值中的任意大小，只要总占用不超过配额。
+
+```
+Pro 用户 (quota = 10 GiB):
+
+  合法方案 A: 2 × 5Gi = 10 GiB ✓
+  合法方案 B: 1 × 10Gi = 10 GiB ✓
+  合法方案 C: 1 × 5Gi = 5 GiB ✓ (未用满)
+  非法方案 D: 1 × 20Gi = 20 GiB ✗ (超出配额)
+  非法方案 E: 3 × 5Gi = 15 GiB ✗ (超出配额)
+```
+
+### 9.3 Size 选项与配额的交互矩阵
+
+| Tier | 配额 (GiB) | 可选 5Gi | 可选 10Gi | 可选 20Gi |
+|------|-----------|---------|----------|----------|
+| Free | 0 | 不可 | 不可 | 不可 |
+| Pro | 10 | 最多 2 个 | 最多 1 个 | 不可 |
+| Ultra | 20 | 最多 4 个 | 最多 2 个 | 最多 1 个 |
+| Enterprise | 自定义 | 取决于配额 | 取决于配额 | 取决于配额 |
+
+### 9.4 未来扩展
+
+Phase 2 可考虑更细粒度的 size 选项：
+
+```python
+# 未来可能的扩展
+SANDBOX_STORAGE_SIZE_VALUES = ("1Gi", "2Gi", "5Gi", "10Gi", "20Gi", "50Gi")
+```
+
+扩展 size 选项不影响 `StorageLedger` 表结构（`size_gib` 是 Integer，不是枚举）。
+
+---
+
+## 10. Acceptance Scenarios
+
+以下验收场景覆盖 Storage 计量系统的核心功能路径。
+
+### 场景 1：Free 用户创建 persist=True 的 sandbox
+
+```
+Given: Free tier 用户 (monthly_storage = 0, extra_storage = 0)
+When:  请求创建 sandbox (persist=true, storage_size="5Gi")
+Then:  返回 403 StorageQuotaExceededError
+       消息: "Storage quota exceeded. Used: 0 GiB, Requested: 5 GiB, Quota: 0 GiB."
+       不创建 K8s 资源
+       不创建 StorageLedger 记录
+```
+
+### 场景 2：Pro 用户存储配额不足
+
+```
+Given: Pro tier 用户 (monthly_storage = 10)
+       已有 2 个持久 sandbox: 5Gi + 3Gi = 8 GiB 已用
+When:  请求创建 sandbox (persist=true, storage_size="5Gi")
+Then:  返回 403 StorageQuotaExceededError
+       消息: "Storage quota exceeded. Used: 8 GiB, Requested: 5 GiB, Quota: 10 GiB."
+```
+
+### 场景 3：Extra Credits 扩展配额
+
+```
+Given: Pro tier 用户 (monthly_storage = 10)
+       Extra storage grant: 5 GiB (未过期)
+       已有 8 GiB 存储已用
+When:  请求创建 sandbox (persist=true, storage_size="5Gi")
+Then:  允许创建 (8 + 5 = 13 ≤ 10 + 5 = 15)
+       K8s 创建 Sandbox CR + PVC (5Gi)
+       StorageLedger 写入: state=active, size_gib=5
+```
+
+### 场景 4：删除持久 sandbox 释放配额
+
+```
+Given: Pro tier 用户，已有 10 GiB 存储 (1 × 10Gi sandbox)
+       StorageLedger: state=active, size_gib=10, gib_hours=120.0000
+When:  删除该 sandbox
+Then:  StorageLedger 更新:
+         state → deleted
+         released_at = now()
+         gib_hours_consumed = 最终值（含最后一个 tick 的增量）
+       K8s 删除 Sandbox CR + PVC
+       用户配额恢复: current_used = 0, available = 10 GiB
+```
+
+### 场景 5：Sandbox stopped 后存储仍占用配额
+
+```
+Given: Pro tier 用户，1 个 running 持久 sandbox (5Gi)
+When:  stop 该 sandbox
+Then:  Sandbox status → stopped
+       K8s Pod 副本 → 0
+       PVC 仍然存在
+       StorageLedger state 仍为 active
+       current_used 仍为 5 GiB
+       gib_hours 继续在后台 tick 中累积
+```
+
+### 场景 6：月度重置后的超配状态
+
+```
+Given: Pro tier 用户 (monthly=10)
+       Extra storage grant: 5 GiB (3月31日过期)
+       已有 12 GiB 存储 (quota 15, 未超配)
+When:  4月1日 grant 过期
+Then:  total_quota = 10 + 0 = 10 GiB
+       current_used = 12 GiB
+       12 > 10 → 进入超配状态
+       已有 PVC 不受影响，数据安全
+       新的 persist=true 请求被拒绝
+       用户收到超配通知
+```
+
+### 场景 7：GiB-hours 持续累积
+
+```
+Given: 持久 sandbox (size_gib=10, gib_hours=0, last_metered=T0)
+When:  后台 tick 在 T0+60s 执行
+Then:  new_gib_hours = 10 × 60 / 3600 = 0.1667
+       gib_hours_consumed = 0.1667
+       last_metered_at = T0+60s
+
+When:  经过 24 小时 (1440 次 tick)
+Then:  gib_hours_consumed ≈ 10 × 24 = 240.0000
+```
+
+### 场景 8：Extra Storage Credits 过期后总配额降低
+
+```
+Given: Ultra tier 用户 (monthly=20)
+       Extra storage grant A: 10 GiB (过期时间: 明天)
+       Extra storage grant B: 5 GiB (过期时间: 下月)
+       已有 25 GiB 存储
+       当前配额: 20 + 10 + 5 = 35 GiB → 未超配
+When:  Grant A 过期
+Then:  新配额: 20 + 0 + 5 = 25 GiB
+       current_used = 25 GiB = 25 GiB → 恰好不超配
+       但无法新建任何持久 sandbox (available = 0)
+When:  Grant B 也过期
+Then:  新配额: 20 GiB
+       current_used = 25 GiB > 20 GiB → 超配
+       已有 PVC 安全，阻止新建
+```
+
+---
+
+## 附录 A：完整数据流总览
+
+```mermaid
+flowchart TB
+    subgraph 用户操作
+        Create[创建persist=true<br/>sandbox]
+        Delete[删除sandbox]
+        Stop[停止sandbox]
+        Start[启动sandbox]
+    end
+
+    subgraph 配额检查
+        QuotaCheck{配额检查<br/>used+req<=quota?}
+    end
+
+    subgraph 数据存储
+        SandboxTable[(sandbox表)]
+        LedgerTable[(storage_ledger表)]
+        GrantTable[(credit_grant表)]
+        PlanTable[(用户Plan)]
+    end
+
+    subgraph Kubernetes
+        PVC[PVC<br/>treadstone-workspace]
+        SandboxCR[Sandbox CR]
+    end
+
+    subgraph 后台任务
+        Tick[计量tick<br/>每60秒]
+    end
+
+    Create --> QuotaCheck
+    QuotaCheck -->|查询| PlanTable
+    QuotaCheck -->|查询| GrantTable
+    QuotaCheck -->|查询| LedgerTable
+    QuotaCheck -->|通过| SandboxTable
+    QuotaCheck -->|通过| SandboxCR
+    QuotaCheck -->|通过| PVC
+    QuotaCheck -->|通过| LedgerTable
+
+    Delete -->|更新state=deleted| LedgerTable
+    Delete -->|删除| PVC
+    Delete -->|删除| SandboxCR
+
+    Stop -->|不影响| LedgerTable
+    Stop -->|不影响| PVC
+    Stop -->|replicas=0| SandboxCR
+
+    Start -->|不影响| LedgerTable
+    Start -->|不影响| PVC
+    Start -->|replicas=1| SandboxCR
+
+    Tick -->|更新gib_hours| LedgerTable
+```
+
+## 附录 B：API 接口变更
+
+Storage 计量引入后，以下 API 需要变更：
+
+### B.1 新增：获取存储配额
+
+```
+GET /api/v1/metering/storage/quota
+
+Response:
+{
+    "monthly_quota_gib": 10,
+    "extra_quota_gib": 5,
+    "total_quota_gib": 15,
+    "current_used_gib": 8,
+    "available_gib": 7,
+    "is_over_provisioned": false,
+    "active_volumes": [
+        {
+            "sandbox_id": "sb3a8f9b2c1d4e5f",
+            "sandbox_name": "my-project",
+            "size_gib": 5,
+            "allocated_at": "2026-03-15T10:00:00Z",
+            "gib_hours_consumed": 1320.5000
+        },
+        ...
+    ]
+}
+```
+
+### B.2 变更：创建 sandbox 响应增加配额信息
+
+```
+POST /api/v1/sandboxes
+Request: { "persist": true, "storage_size": "10Gi", ... }
+
+Response (201):
+{
+    "id": "sb...",
+    "persist": true,
+    "storage_size": "10Gi",
+    "storage_quota_after": {
+        "total_quota_gib": 15,
+        "current_used_gib": 13,
+        "available_gib": 2
+    },
+    ...
+}
+```
+
+### B.3 错误响应
+
+```
+POST /api/v1/sandboxes
+Request: { "persist": true, "storage_size": "10Gi", ... }
+
+Response (403):
+{
+    "error": {
+        "code": "storage_quota_exceeded",
+        "message": "Storage quota exceeded. Used: 8 GiB, Requested: 10 GiB, Quota: 10 GiB. Delete unused persistent sandboxes or upgrade your plan.",
+        "status": 403
+    }
+}
+```


### PR DESCRIPTION
## Summary
- Add four zh-CN design documents for metering: overview, compute, storage, and enforcement.

## Test Plan
- [x] `git diff --check` (whitespace)
- Docs-only change; no runtime code changes.

Made with [Cursor](https://cursor.com)