### PR TITLE
feat: implement metering Layer 2 quota checks (F10-F14)

### DIFF
--- a/docs/zh-CN/design/2026-03-26-metering-execution-plan.md
+++ b/docs/zh-CN/design/2026-03-26-metering-execution-plan.md
@@ -245,19 +245,19 @@ F01 → F02 → F03 → F04 → F05 → F06 → F07 → F08 → F09
 
 ### Layer 1 — MeteringService 核心
 
-- [ ] **F05** MeteringService 骨架 + ensure_user_plan + get_user_plan + update_user_tier
-- [ ] **F06** Welcome Bonus（注册 hook 中自动发放 50 Compute Credits）
-- [ ] **F07** consume_compute_credits（双池消费算法，含 FOR UPDATE 行锁）
-- [ ] **F08** open_compute_session / close_compute_session
-- [ ] **F09** record_storage_allocation / record_storage_release
+- [x] **F05** MeteringService 骨架 + ensure_user_plan + get_user_plan + update_user_tier
+- [x] **F06** Welcome Bonus（注册 hook 中自动发放 50 Compute Credits）
+- [x] **F07** consume_compute_credits（双池消费算法，含 FOR UPDATE 行锁）
+- [x] **F08** open_compute_session / close_compute_session
+- [x] **F09** record_storage_allocation / record_storage_release
 
 ### Layer 2 — 配额检查
 
-- [ ] **F10** check_template_allowed
-- [ ] **F11** check_compute_quota + get_total_compute_remaining
-- [ ] **F12** check_concurrent_limit
-- [ ] **F13** check_storage_quota + get_total_storage_quota + get_current_storage_used
-- [ ] **F14** check_sandbox_duration
+- [x] **F10** check_template_allowed
+- [x] **F11** check_compute_quota + get_total_compute_remaining
+- [x] **F12** check_concurrent_limit
+- [x] **F13** check_storage_quota + get_total_storage_quota + get_current_storage_used
+- [x] **F14** check_sandbox_duration
 
 ### Layer 3 — 系统集成
 

--- a/tests/unit/test_metering_service.py
+++ b/tests/unit/test_metering_service.py
@@ -1,4 +1,4 @@
-"""Unit tests for MeteringService (Layer 1: F05–F09)."""
+"""Unit tests for MeteringService (Layer 1: F05–F09, Layer 2: F10–F14)."""
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -7,7 +7,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from treadstone.core.errors import NotFoundError, ValidationError
+from treadstone.core.errors import (
+    ComputeQuotaExceededError,
+    ConcurrentLimitError,
+    NotFoundError,
+    StorageQuotaExceededError,
+    TemplateNotAllowedError,
+    ValidationError,
+)
 from treadstone.models.metering import (
     ComputeSession,
     CreditGrant,
@@ -660,3 +667,381 @@ class TestRecordStorageRelease:
 
         assert result.storage_state == StorageState.DELETED
         assert result.gib_hours_consumed == Decimal("100.0000")
+
+
+# ═══════════════════════════════════════════════════════
+#  F10 — check_template_allowed
+# ═══════════════════════════════════════════════════════
+
+
+class TestCheckTemplateAllowed:
+    async def test_allowed_template_passes(self):
+        plan = _make_plan("user01", allowed_templates=["tiny", "small", "medium"])
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+
+        await svc.check_template_allowed(AsyncMock(), "user01", "small")
+
+    async def test_disallowed_template_raises(self):
+        plan = _make_plan("user01", tier="free", allowed_templates=["tiny", "small"])
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+
+        with pytest.raises(TemplateNotAllowedError) as exc_info:
+            await svc.check_template_allowed(AsyncMock(), "user01", "medium")
+        assert exc_info.value.status == 403
+        assert "medium" in exc_info.value.message
+        assert "free" in exc_info.value.message
+
+    async def test_empty_allowed_list_always_raises(self):
+        plan = _make_plan("user01", allowed_templates=[])
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+
+        with pytest.raises(TemplateNotAllowedError) as exc_info:
+            await svc.check_template_allowed(AsyncMock(), "user01", "tiny")
+        assert "Allowed templates: none" in exc_info.value.message
+
+    async def test_all_allowed_templates_pass(self):
+        templates = ["tiny", "small", "medium", "large"]
+        plan = _make_plan("user01", allowed_templates=templates)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+
+        for tmpl in templates:
+            await svc.check_template_allowed(AsyncMock(), "user01", tmpl)
+
+
+# ═══════════════════════════════════════════════════════
+#  F11 — check_compute_quota / get_total_compute_remaining
+# ═══════════════════════════════════════════════════════
+
+
+class TestCheckComputeQuota:
+    async def test_sufficient_monthly_passes(self):
+        plan = _make_plan(
+            "user01",
+            compute_credits_monthly_limit=Decimal("100"),
+            compute_credits_monthly_used=Decimal("50"),
+        )
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("0"))
+
+        await svc.check_compute_quota(AsyncMock(), "user01")
+
+    async def test_monthly_exhausted_but_extra_available(self):
+        plan = _make_plan(
+            "user01",
+            compute_credits_monthly_limit=Decimal("100"),
+            compute_credits_monthly_used=Decimal("100"),
+        )
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("50"))
+
+        await svc.check_compute_quota(AsyncMock(), "user01")
+
+    async def test_both_exhausted_raises(self):
+        plan = _make_plan(
+            "user01",
+            compute_credits_monthly_limit=Decimal("100"),
+            compute_credits_monthly_used=Decimal("100"),
+        )
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("0"))
+
+        with pytest.raises(ComputeQuotaExceededError) as exc_info:
+            await svc.check_compute_quota(AsyncMock(), "user01")
+        assert exc_info.value.status == 402
+        assert "100.0 / 100.0" in exc_info.value.message
+
+    async def test_exactly_zero_remaining_raises(self):
+        plan = _make_plan(
+            "user01",
+            compute_credits_monthly_limit=Decimal("10"),
+            compute_credits_monthly_used=Decimal("10"),
+        )
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("0"))
+
+        with pytest.raises(ComputeQuotaExceededError):
+            await svc.check_compute_quota(AsyncMock(), "user01")
+
+    async def test_negative_monthly_but_extra_covers(self):
+        """Grace period overage: monthly_used > limit, but extra credits compensate."""
+        plan = _make_plan(
+            "user01",
+            compute_credits_monthly_limit=Decimal("100"),
+            compute_credits_monthly_used=Decimal("105"),
+        )
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("10"))
+
+        await svc.check_compute_quota(AsyncMock(), "user01")
+
+    async def test_error_includes_extra_remaining(self):
+        plan = _make_plan(
+            "user01",
+            compute_credits_monthly_limit=Decimal("50"),
+            compute_credits_monthly_used=Decimal("50"),
+        )
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("0"))
+
+        with pytest.raises(ComputeQuotaExceededError) as exc_info:
+            await svc.check_compute_quota(AsyncMock(), "user01")
+        assert "extra remaining: 0.0" in exc_info.value.message
+
+
+class TestGetTotalComputeRemaining:
+    async def test_monthly_plus_extra(self):
+        plan = _make_plan(
+            "user01",
+            compute_credits_monthly_limit=Decimal("100"),
+            compute_credits_monthly_used=Decimal("60"),
+        )
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("50"))
+
+        result = await svc.get_total_compute_remaining(AsyncMock(), "user01")
+        assert result == Decimal("90")
+
+    async def test_overspent_returns_negative(self):
+        plan = _make_plan(
+            "user01",
+            compute_credits_monthly_limit=Decimal("100"),
+            compute_credits_monthly_used=Decimal("110"),
+        )
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("0"))
+
+        result = await svc.get_total_compute_remaining(AsyncMock(), "user01")
+        assert result == Decimal("-10")
+
+    async def test_no_extra_credits(self):
+        plan = _make_plan(
+            "user01",
+            compute_credits_monthly_limit=Decimal("100"),
+            compute_credits_monthly_used=Decimal("0"),
+        )
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("0"))
+
+        result = await svc.get_total_compute_remaining(AsyncMock(), "user01")
+        assert result == Decimal("100")
+
+    async def test_monthly_unused_plus_large_extra(self):
+        plan = _make_plan(
+            "user01",
+            compute_credits_monthly_limit=Decimal("100"),
+            compute_credits_monthly_used=Decimal("0"),
+        )
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("200"))
+
+        result = await svc.get_total_compute_remaining(AsyncMock(), "user01")
+        assert result == Decimal("300")
+
+
+# ═══════════════════════════════════════════════════════
+#  F12 — check_concurrent_limit
+# ═══════════════════════════════════════════════════════
+
+
+class TestCheckConcurrentLimit:
+    async def test_under_limit_passes(self):
+        plan = _make_plan("user01", max_concurrent_running=3)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc._count_running_sandboxes = AsyncMock(return_value=1)
+
+        await svc.check_concurrent_limit(AsyncMock(), "user01")
+
+    async def test_zero_running_passes(self):
+        plan = _make_plan("user01", max_concurrent_running=1)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc._count_running_sandboxes = AsyncMock(return_value=0)
+
+        await svc.check_concurrent_limit(AsyncMock(), "user01")
+
+    async def test_at_limit_raises(self):
+        plan = _make_plan("user01", max_concurrent_running=3)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc._count_running_sandboxes = AsyncMock(return_value=3)
+
+        with pytest.raises(ConcurrentLimitError) as exc_info:
+            await svc.check_concurrent_limit(AsyncMock(), "user01")
+        assert exc_info.value.status == 429
+        assert "3 / 3" in exc_info.value.message
+
+    async def test_over_limit_raises(self):
+        plan = _make_plan("user01", max_concurrent_running=3)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc._count_running_sandboxes = AsyncMock(return_value=5)
+
+        with pytest.raises(ConcurrentLimitError):
+            await svc.check_concurrent_limit(AsyncMock(), "user01")
+
+    async def test_single_slot_tier(self):
+        plan = _make_plan("user01", max_concurrent_running=1)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc._count_running_sandboxes = AsyncMock(return_value=1)
+
+        with pytest.raises(ConcurrentLimitError) as exc_info:
+            await svc.check_concurrent_limit(AsyncMock(), "user01")
+        assert "1 / 1" in exc_info.value.message
+
+
+class TestCountRunningSandboxes:
+    async def test_returns_count(self):
+        svc = MeteringService()
+        session = _mock_session(_MockResult(value=3))
+
+        result = await svc._count_running_sandboxes(session, "user01")
+        assert result == 3
+
+    async def test_zero_when_none_running(self):
+        svc = MeteringService()
+        session = _mock_session(_MockResult(value=0))
+
+        result = await svc._count_running_sandboxes(session, "user01")
+        assert result == 0
+
+
+# ═══════════════════════════════════════════════════════
+#  F13 — check_storage_quota / get_total_storage_quota / get_current_storage_used
+# ═══════════════════════════════════════════════════════
+
+
+class TestCheckStorageQuota:
+    async def test_sufficient_quota_passes(self):
+        svc = MeteringService()
+        svc.get_total_storage_quota = AsyncMock(return_value=10)
+        svc.get_current_storage_used = AsyncMock(return_value=3)
+
+        await svc.check_storage_quota(AsyncMock(), "user01", requested_gib=5)
+
+    async def test_exact_fit_passes(self):
+        svc = MeteringService()
+        svc.get_total_storage_quota = AsyncMock(return_value=10)
+        svc.get_current_storage_used = AsyncMock(return_value=5)
+
+        await svc.check_storage_quota(AsyncMock(), "user01", requested_gib=5)
+
+    async def test_insufficient_quota_raises(self):
+        svc = MeteringService()
+        svc.get_total_storage_quota = AsyncMock(return_value=10)
+        svc.get_current_storage_used = AsyncMock(return_value=8)
+
+        with pytest.raises(StorageQuotaExceededError) as exc_info:
+            await svc.check_storage_quota(AsyncMock(), "user01", requested_gib=5)
+        assert exc_info.value.status == 402
+        assert "8 GiB" in exc_info.value.message
+        assert "5 GiB" in exc_info.value.message
+        assert "10 GiB" in exc_info.value.message
+
+    async def test_zero_quota_raises(self):
+        svc = MeteringService()
+        svc.get_total_storage_quota = AsyncMock(return_value=0)
+        svc.get_current_storage_used = AsyncMock(return_value=0)
+
+        with pytest.raises(StorageQuotaExceededError):
+            await svc.check_storage_quota(AsyncMock(), "user01", requested_gib=5)
+
+    async def test_overcommitted_storage_raises(self):
+        """Post-downgrade scenario: current_used > total_quota."""
+        svc = MeteringService()
+        svc.get_total_storage_quota = AsyncMock(return_value=10)
+        svc.get_current_storage_used = AsyncMock(return_value=40)
+
+        with pytest.raises(StorageQuotaExceededError):
+            await svc.check_storage_quota(AsyncMock(), "user01", requested_gib=1)
+
+
+class TestGetTotalStorageQuota:
+    async def test_monthly_only(self):
+        plan = _make_plan("user01", storage_credits_monthly_limit=10)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("0"))
+
+        result = await svc.get_total_storage_quota(AsyncMock(), "user01")
+        assert result == 10
+
+    async def test_monthly_plus_extra(self):
+        plan = _make_plan("user01", storage_credits_monthly_limit=10)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("5"))
+
+        result = await svc.get_total_storage_quota(AsyncMock(), "user01")
+        assert result == 15
+
+    async def test_zero_monthly_with_extra(self):
+        plan = _make_plan("user01", storage_credits_monthly_limit=0)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+        svc.get_extra_credits_remaining = AsyncMock(return_value=Decimal("20"))
+
+        result = await svc.get_total_storage_quota(AsyncMock(), "user01")
+        assert result == 20
+
+
+class TestGetCurrentStorageUsed:
+    async def test_with_active_entries(self):
+        svc = MeteringService()
+        session = _mock_session(_MockResult(value=15))
+
+        result = await svc.get_current_storage_used(session, "user01")
+        assert result == 15
+
+    async def test_no_entries_returns_zero(self):
+        svc = MeteringService()
+        session = _mock_session(_MockResult(value=0))
+
+        result = await svc.get_current_storage_used(session, "user01")
+        assert result == 0
+
+
+# ═══════════════════════════════════════════════════════
+#  F14 — check_sandbox_duration
+# ═══════════════════════════════════════════════════════
+
+
+class TestCheckSandboxDuration:
+    async def test_returns_max_duration_for_free_tier(self):
+        plan = _make_plan("user01", max_sandbox_duration_seconds=1800)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+
+        result = await svc.check_sandbox_duration(AsyncMock(), "user01")
+        assert result == 1800
+
+    async def test_returns_max_duration_for_pro_tier(self):
+        plan = _make_plan("user01", tier="pro", max_sandbox_duration_seconds=7200)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+
+        result = await svc.check_sandbox_duration(AsyncMock(), "user01")
+        assert result == 7200
+
+    async def test_returns_overridden_duration(self):
+        plan = _make_plan("user01", max_sandbox_duration_seconds=14400)
+        svc = MeteringService()
+        svc.get_user_plan = AsyncMock(return_value=plan)
+
+        result = await svc.check_sandbox_duration(AsyncMock(), "user01")
+        assert result == 14400

--- a/treadstone/core/errors.py
+++ b/treadstone/core/errors.py
@@ -179,11 +179,12 @@ class ConcurrentLimitError(TreadstoneError):
 
 class TemplateNotAllowedError(TreadstoneError):
     def __init__(self, tier: str, template: str, allowed_templates: list[str]):
+        allowed_str = ", ".join(allowed_templates) if allowed_templates else "none"
         super().__init__(
             code="template_not_allowed",
             message=(
                 f"Template '{template}' is not available on the '{tier}' tier. "
-                f"Allowed templates: {', '.join(allowed_templates)}. "
+                f"Allowed templates: {allowed_str}. "
                 f"Upgrade your plan to access this template."
             ),
             status=403,

--- a/treadstone/services/metering_service.py
+++ b/treadstone/services/metering_service.py
@@ -1,11 +1,16 @@
 """MeteringService — core metering logic for the Treadstone billing system.
 
-Implements Layer 1 of the metering execution plan:
+Implements Layers 1–2 of the metering execution plan:
   F05: Plan management (ensure_user_plan, get_user_plan, update_user_tier)
   F06: Welcome bonus (auto-granted on free-tier registration)
   F07: Dual-pool credit consumption (consume_compute_credits)
   F08: Compute session lifecycle (open_compute_session, close_compute_session)
   F09: Storage ledger (record_storage_allocation, record_storage_release)
+  F10: Template permission check (check_template_allowed)
+  F11: Compute quota check (check_compute_quota, get_total_compute_remaining)
+  F12: Concurrent sandbox limit (check_concurrent_limit)
+  F13: Storage quota check (check_storage_quota, get_total_storage_quota, get_current_storage_used)
+  F14: Sandbox duration check (check_sandbox_duration)
 
 Transaction Policy
 ------------------
@@ -24,7 +29,14 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from treadstone.core.errors import NotFoundError, ValidationError
+from treadstone.core.errors import (
+    ComputeQuotaExceededError,
+    ConcurrentLimitError,
+    NotFoundError,
+    StorageQuotaExceededError,
+    TemplateNotAllowedError,
+    ValidationError,
+)
 from treadstone.models.metering import (
     ComputeSession,
     CreditGrant,
@@ -33,6 +45,7 @@ from treadstone.models.metering import (
     TierTemplate,
     UserPlan,
 )
+from treadstone.models.sandbox import Sandbox, SandboxStatus
 from treadstone.models.user import utc_now
 from treadstone.services.metering_helpers import (
     ConsumeResult,
@@ -408,8 +421,138 @@ class MeteringService:
         return ledger
 
     # ═══════════════════════════════════════════════════════
+    #  Quota Checks  (F10–F14)
+    # ═══════════════════════════════════════════════════════
+
+    async def check_template_allowed(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        template: str,
+    ) -> None:
+        """Verify that the user's tier permits the requested sandbox template.
+
+        Raises TemplateNotAllowedError (403) if the template is not in the
+        plan's ``allowed_templates`` list.
+        """
+        plan = await self.get_user_plan(session, user_id)
+        if template not in plan.allowed_templates:
+            raise TemplateNotAllowedError(plan.tier, template, plan.allowed_templates)
+
+    async def check_compute_quota(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> None:
+        """Verify that the user has remaining compute credits.
+
+        Checks monthly remaining + extra CreditGrants.
+        Raises ComputeQuotaExceededError (402) when total_remaining <= 0.
+        """
+        plan = await self.get_user_plan(session, user_id)
+        monthly_remaining = plan.compute_credits_monthly_limit - plan.compute_credits_monthly_used
+        extra_remaining = await self.get_extra_credits_remaining(session, user_id, "compute")
+        total_remaining = monthly_remaining + extra_remaining
+        if total_remaining <= Decimal("0"):
+            raise ComputeQuotaExceededError(
+                monthly_used=float(plan.compute_credits_monthly_used),
+                monthly_limit=float(plan.compute_credits_monthly_limit),
+                extra_remaining=float(extra_remaining),
+            )
+
+    async def check_concurrent_limit(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> None:
+        """Verify that the user has not reached the concurrent sandbox limit.
+
+        Counts sandboxes in ``creating`` or ``ready`` status.
+        Raises ConcurrentLimitError (429) when running >= max_concurrent_running.
+        """
+        plan = await self.get_user_plan(session, user_id)
+        running_count = await self._count_running_sandboxes(session, user_id)
+        if running_count >= plan.max_concurrent_running:
+            raise ConcurrentLimitError(running_count, plan.max_concurrent_running)
+
+    async def check_storage_quota(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        requested_gib: int,
+    ) -> None:
+        """Verify that the user has enough storage quota for the requested allocation.
+
+        total_quota = monthly_limit + extra_storage_grants
+        available  = total_quota - current_used
+        Raises StorageQuotaExceededError (402) when available < requested_gib.
+        """
+        total_quota = await self.get_total_storage_quota(session, user_id)
+        current_used = await self.get_current_storage_used(session, user_id)
+        available = total_quota - current_used
+        if available < requested_gib:
+            raise StorageQuotaExceededError(current_used, requested_gib, total_quota)
+
+    async def check_sandbox_duration(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> int:
+        """Return the maximum sandbox duration (seconds) allowed by the user's tier.
+
+        The caller is responsible for comparing the returned value against the
+        requested ``auto_stop_interval`` and raising ``SandboxDurationExceededError``
+        when the request exceeds the limit.  Duration-check semantics
+        (e.g. ``auto_stop_interval <= 0`` means unlimited) belong to the sandbox
+        domain, not the metering domain.
+        """
+        plan = await self.get_user_plan(session, user_id)
+        return plan.max_sandbox_duration_seconds
+
+    # ═══════════════════════════════════════════════════════
     #  Query Helpers
     # ═══════════════════════════════════════════════════════
+
+    async def get_total_compute_remaining(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> Decimal:
+        """Return total compute credits remaining (monthly + extra).
+
+        May be negative in grace-period overage scenarios.
+        """
+        plan = await self.get_user_plan(session, user_id)
+        monthly_remaining = plan.compute_credits_monthly_limit - plan.compute_credits_monthly_used
+        extra_remaining = await self.get_extra_credits_remaining(session, user_id, "compute")
+        return monthly_remaining + extra_remaining
+
+    async def get_total_storage_quota(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> int:
+        """Return total storage quota in GiB (monthly limit + extra storage grants)."""
+        plan = await self.get_user_plan(session, user_id)
+        extra_storage = await self.get_extra_credits_remaining(session, user_id, "storage")
+        return plan.storage_credits_monthly_limit + int(extra_storage)
+
+    async def get_current_storage_used(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> int:
+        """Return total active storage allocation in GiB.
+
+        Sums ``size_gib`` across all ``ACTIVE`` StorageLedger entries for the user.
+        """
+        result = await session.execute(
+            select(func.coalesce(func.sum(StorageLedger.size_gib), 0)).where(
+                StorageLedger.user_id == user_id,
+                StorageLedger.storage_state == StorageState.ACTIVE,
+            )
+        )
+        return int(result.scalar_one())
 
     async def get_extra_credits_remaining(
         self,
@@ -431,6 +574,22 @@ class MeteringService:
             )
         )
         return Decimal(str(result.scalar_one()))
+
+    async def _count_running_sandboxes(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> int:
+        """Count sandboxes in creating or ready status for the given user."""
+        result = await session.execute(
+            select(func.count())
+            .select_from(Sandbox)
+            .where(
+                Sandbox.owner_id == user_id,
+                Sandbox.status.in_([SandboxStatus.CREATING, SandboxStatus.READY]),
+            )
+        )
+        return result.scalar_one()
 
     async def _get_user_plan_for_update(self, session: AsyncSession, user_id: str) -> UserPlan:
         """Fetch and row-lock the user's plan for credit mutation.


### PR DESCRIPTION
## Summary

- Add 5 pre-flight quota check methods to `MeteringService`: `check_template_allowed`, `check_compute_quota`, `check_concurrent_limit`, `check_storage_quota`, `check_sandbox_duration`
- Add 3 public query helpers: `get_total_compute_remaining`, `get_total_storage_quota`, `get_current_storage_used`
- Add private helper `_count_running_sandboxes` (COUNT on Sandbox table)
- Fix `TemplateNotAllowedError` message when `allowed_templates` is empty (shows "none" instead of blank)
- Mark F05–F14 as complete in the metering execution plan checklist

## Design Notes

- `check_sandbox_duration` returns `int` rather than raising directly — `auto_stop_interval` semantics (0/-1 = unlimited) belong to the sandbox domain, not metering
- `get_current_storage_used` queries `StorageLedger` instead of the `Sandbox` table for cohesion within the metering bounded context
- `check_compute_quota` computes totals inline to avoid a redundant DB round-trip vs. delegating to `get_total_compute_remaining`
- All check methods are pure pre-flight validations — no locks, no commits, no side effects

## Test Plan

- [x] `make lint` — zero errors
- [x] `make test` — 401 passed (34 new tests for F10–F14)
- New tests cover: happy paths, boundary conditions (exactly zero, exact fit), error conditions (both pools exhausted, overcommitted storage, empty allowed list), grace period edge cases (negative monthly offset by extra), error message content assertions

Made with [Cursor](https://cursor.com)