### PR TITLE
feat: implement Layer 3 metering integration (F15, F16, F17)

### DIFF
--- a/docs/zh-CN/design/2026-03-26-metering-compute.md
+++ b/docs/zh-CN/design/2026-03-26-metering-compute.md
@@ -927,28 +927,34 @@ async def handle_period_rollover(
 
 ```python
 class ComputeQuotaExceededError(TreadstoneError):
-    def __init__(self, user_id: str):
+    def __init__(self, monthly_used: float, monthly_limit: float, extra_remaining: float):
         super().__init__(
             code="compute_quota_exceeded",
-            message="Compute credit quota exceeded. Please upgrade your plan or purchase additional credits.",
+            message=(
+                f"Compute credits exhausted. "
+                f"Monthly used: {monthly_used:.1f} / {monthly_limit:.1f} vCPU-hours, "
+                f"extra remaining: {extra_remaining:.1f} vCPU-hours. "
+                f"Please wait for the next billing cycle or purchase additional credits."
+            ),
             status=402,
         )
 
 
-class ConcurrentLimitExceededError(TreadstoneError):
-    def __init__(self, user_id: str, limit: int):
+class ConcurrentLimitError(TreadstoneError):
+    def __init__(self, current_running: int, max_concurrent: int):
         super().__init__(
             code="concurrent_limit_exceeded",
-            message=f"Maximum concurrent sandbox limit ({limit}) reached.",
+            message=f"Concurrent sandbox limit reached. Running: {current_running} / {max_concurrent}. Stop an existing sandbox before creating a new one.",
             status=429,
         )
 
 
-class TemplateForbiddenError(TreadstoneError):
-    def __init__(self, template: str, plan_name: str):
+class TemplateNotAllowedError(TreadstoneError):
+    def __init__(self, tier: str, template: str, allowed_templates: list[str]):
+        allowed_str = ", ".join(allowed_templates) if allowed_templates else "none"
         super().__init__(
-            code="template_forbidden",
-            message=f"Template '{template}' is not available on the {plan_name} plan.",
+            code="template_not_allowed",
+            message=f"Template '{template}' is not available on the '{tier}' tier. Allowed templates: {allowed_str}. Upgrade your plan to access this template.",
             status=403,
         )
 ```
@@ -979,16 +985,16 @@ class SandboxService:
         # ... (后续不变)
 
     async def _check_quotas(self, user_id: str, template: str) -> None:
-        plan = await get_user_plan(self.session, user_id)
+        plan = await self._metering.get_user_plan(self.session, user_id)
 
         # 1. 模板权限
         if template not in plan.allowed_templates:
-            raise TemplateForbiddenError(template, plan.plan_name)
+            raise TemplateNotAllowedError(plan.tier, template, plan.allowed_templates)
 
         # 2. 并发 sandbox 数
         active_count = await self._count_active_sandboxes(user_id)
-        if active_count >= plan.max_concurrent_sandboxes:
-            raise ConcurrentLimitExceededError(user_id, plan.max_concurrent_sandboxes)
+        if active_count >= plan.max_concurrent_running:
+            raise ConcurrentLimitError(active_count, plan.max_concurrent_running)
 
         # 3. Compute 额度余量
         monthly_remaining = (

--- a/docs/zh-CN/design/2026-03-26-metering-enforcement.md
+++ b/docs/zh-CN/design/2026-03-26-metering-enforcement.md
@@ -55,10 +55,13 @@ flowchart TD
     H --> I{创建成功?}
     I -->|是| J{persist?}
     J -->|是| K[record_storage_allocation]
-    J -->|否| L[open_compute_session]
-    K --> L
-    L --> M[返回Sandbox]
+    K --> M[返回Sandbox<br/>status=creating]
+    J -->|否| M
     I -->|否| N[原有错误处理]
+
+    style M fill:#e8f5e9
+    note1["注意: open_compute_session 不在此流程中。
+    它由 K8s Sync 在 sandbox 进入 READY 状态时触发。"]
 ```
 
 ### 1.5 检查顺序设计原则
@@ -1838,14 +1841,14 @@ def upgrade() -> None:
 
     # Seed TierTemplate
     op.execute("""
-    INSERT INTO tier_template (tier, compute_credits_monthly, storage_credits_monthly,
+    INSERT INTO tier_template (tier_name, compute_credits_monthly, storage_credits_monthly,
         max_concurrent_running, max_sandbox_duration_seconds, allowed_templates,
-        grace_period_seconds, gmt_created, gmt_updated)
+        grace_period_seconds, is_active, gmt_created, gmt_updated)
     VALUES
-        ('free',       10,    1,  1,  3600,  '["tiny"]',                                600,  NOW(), NOW()),
-        ('pro',        100,   10, 3,  7200,  '["tiny","small","medium"]',                1800, NOW(), NOW()),
-        ('ultra',      500,   50, 10, 14400, '["tiny","small","medium","large"]',        3600, NOW(), NOW()),
-        ('enterprise', 5000,  500,50, 86400, '["tiny","small","medium","large","gpu"]',  7200, NOW(), NOW())
+        ('free',       10,   0,   1,  1800,  '["tiny","small"]',                          600,  TRUE, NOW(), NOW()),
+        ('pro',        100,  10,  3,  7200,  '["tiny","small","medium"]',                  1800, TRUE, NOW(), NOW()),
+        ('ultra',      300,  20,  5,  28800, '["tiny","small","medium","large"]',          3600, TRUE, NOW(), NOW()),
+        ('enterprise', 5000, 500, 50, 86400, '["tiny","small","medium","large","xlarge"]', 7200, TRUE, NOW(), NOW())
     """)
 ```
 

--- a/docs/zh-CN/design/2026-03-26-metering-storage.md
+++ b/docs/zh-CN/design/2026-03-26-metering-storage.md
@@ -282,16 +282,17 @@ stateDiagram-v2
 
 ```python
 class StorageQuotaExceededError(TreadstoneError):
-    def __init__(self, used: int, requested: int, quota: int):
+    def __init__(self, current_used_gib: int, requested_gib: int, total_quota_gib: int):
         super().__init__(
             code="storage_quota_exceeded",
             message=(
                 f"Storage quota exceeded. "
-                f"Used: {used} GiB, Requested: {requested} GiB, "
-                f"Quota: {quota} GiB. "
-                f"Delete unused persistent sandboxes or upgrade your plan."
+                f"Current used: {current_used_gib} GiB, requested: {requested_gib} GiB, "
+                f"total quota: {total_quota_gib} GiB "
+                f"(available: {total_quota_gib - current_used_gib} GiB). "
+                f"Delete existing persistent sandboxes to free space, or upgrade your plan."
             ),
-            status=403,
+            status=402,
         )
 
 
@@ -353,13 +354,13 @@ async def check_storage_quota(
 ```mermaid
 flowchart TD
     A[用户请求创建sandbox<br/>persist=true] --> B{Free tier?}
-    B -->|是| Z1[返回403<br/>StorageQuotaExceededError]
+    B -->|是| Z1[返回402<br/>StorageQuotaExceededError]
     B -->|否| C[解析storage_size<br/>转换为GiB整数]
     C --> D[查询用户Plan<br/>获取monthly配额]
     D --> E[查询未过期的<br/>extra storage grants]
     E --> F[查询active状态的<br/>StorageLedger总和]
     F --> G{used+requested<br/><=quota?}
-    G -->|否| Z2[返回403<br/>StorageQuotaExceededError]
+    G -->|否| Z2[返回402<br/>StorageQuotaExceededError]
     G -->|是| H[检查StorageClass<br/>是否存在]
     H --> I[创建Sandbox记录<br/>status=creating]
     I --> J[创建K8s<br/>SandboxCR+PVC]
@@ -841,8 +842,8 @@ SANDBOX_STORAGE_SIZE_VALUES = ("1Gi", "2Gi", "5Gi", "10Gi", "20Gi", "50Gi")
 ```
 Given: Free tier 用户 (monthly_storage = 0, extra_storage = 0)
 When:  请求创建 sandbox (persist=true, storage_size="5Gi")
-Then:  返回 403 StorageQuotaExceededError
-       消息: "Storage quota exceeded. Used: 0 GiB, Requested: 5 GiB, Quota: 0 GiB."
+Then:  返回 402 StorageQuotaExceededError
+       消息: "Storage quota exceeded. Current used: 0 GiB, requested: 5 GiB, total quota: 0 GiB (available: 0 GiB). ..."
        不创建 K8s 资源
        不创建 StorageLedger 记录
 ```
@@ -853,8 +854,8 @@ Then:  返回 403 StorageQuotaExceededError
 Given: Pro tier 用户 (monthly_storage = 10)
        已有 2 个持久 sandbox: 5Gi + 3Gi = 8 GiB 已用
 When:  请求创建 sandbox (persist=true, storage_size="5Gi")
-Then:  返回 403 StorageQuotaExceededError
-       消息: "Storage quota exceeded. Used: 8 GiB, Requested: 5 GiB, Quota: 10 GiB."
+Then:  返回 402 StorageQuotaExceededError
+       消息: "Storage quota exceeded. Current used: 8 GiB, requested: 5 GiB, total quota: 10 GiB (available: 2 GiB). ..."
 ```
 
 ### 场景 3：Extra Credits 扩展配额
@@ -1055,12 +1056,12 @@ Response (201):
 POST /api/v1/sandboxes
 Request: { "persist": true, "storage_size": "10Gi", ... }
 
-Response (403):
+Response (402):
 {
     "error": {
         "code": "storage_quota_exceeded",
-        "message": "Storage quota exceeded. Used: 8 GiB, Requested: 10 GiB, Quota: 10 GiB. Delete unused persistent sandboxes or upgrade your plan.",
-        "status": 403
+        "message": "Storage quota exceeded. Current used: 8 GiB, requested: 10 GiB, total quota: 10 GiB (available: 2 GiB). Delete existing persistent sandboxes to free space, or upgrade your plan.",
+        "status": 402
     }
 }
 ```

--- a/tests/unit/test_metering_integration.py
+++ b/tests/unit/test_metering_integration.py
@@ -1,0 +1,711 @@
+"""Unit tests for metering integration in SandboxService (F15), K8s Sync (F16), and reconcile_metering (F17)."""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from treadstone.core.errors import (
+    ComputeQuotaExceededError,
+    ConcurrentLimitError,
+    SandboxDurationExceededError,
+    StorageQuotaExceededError,
+    TemplateNotAllowedError,
+)
+from treadstone.models.metering import ComputeSession, UserPlan
+from treadstone.models.sandbox import Sandbox, SandboxStatus
+from treadstone.services.metering_service import MeteringService
+
+FIXED_NOW = datetime(2026, 3, 15, 10, 0, 0, tzinfo=UTC)
+
+
+# ── Helpers ──────────────────────────────────────────────
+
+
+def _make_sandbox(**overrides) -> Sandbox:
+    defaults = {
+        "id": "sb1234567890abcdef",
+        "name": "test-sandbox",
+        "owner_id": "user1234567890abcd",
+        "template": "small",
+        "labels": {},
+        "auto_stop_interval": 15,
+        "auto_delete_interval": -1,
+        "status": SandboxStatus.CREATING,
+        "version": 1,
+        "endpoints": {},
+        "k8s_sandbox_claim_name": "sb1234567890abcdef",
+        "k8s_sandbox_name": "sb1234567890abcdef",
+        "k8s_namespace": "treadstone-local",
+        "persist": False,
+        "storage_size": None,
+        "provision_mode": "claim",
+    }
+    defaults.update(overrides)
+    sb = Sandbox()
+    for k, v in defaults.items():
+        setattr(sb, k, v)
+    return sb
+
+
+def _make_plan(tier: str = "pro", **kwargs) -> UserPlan:
+    defaults = {
+        "user_id": "user1234567890abcd",
+        "tier": tier,
+        "compute_credits_monthly_limit": Decimal("100"),
+        "compute_credits_monthly_used": Decimal("0"),
+        "storage_credits_monthly_limit": 10,
+        "max_concurrent_running": 3,
+        "max_sandbox_duration_seconds": 7200,
+        "allowed_templates": ["tiny", "small", "medium"],
+        "grace_period_seconds": 1800,
+        "period_start": datetime(2026, 3, 1, 0, 0, 0, tzinfo=UTC),
+        "period_end": datetime(2026, 4, 1, 0, 0, 0, tzinfo=UTC),
+    }
+    defaults.update(kwargs)
+    return UserPlan(**defaults)
+
+
+def _mock_session(sandbox: Sandbox | None = None, *extra_scalars):
+    session = AsyncMock()
+    execute_results = [sandbox, *extra_scalars, None]
+
+    def _make_result(value):
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = value
+        return mock_result
+
+    session.execute.side_effect = [_make_result(value) for value in execute_results] or [_make_result(None)]
+    session.get.return_value = sandbox
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.rollback = AsyncMock()
+    session.delete = AsyncMock()
+    return session
+
+
+def _mock_k8s_client():
+    k8s = AsyncMock()
+    k8s.create_sandbox_claim = AsyncMock(return_value={"metadata": {"name": "test-sb"}})
+    k8s.delete_sandbox_claim = AsyncMock(return_value=True)
+    k8s.create_sandbox = AsyncMock(return_value={"metadata": {"name": "test-sb"}})
+    k8s.delete_sandbox = AsyncMock(return_value=True)
+    k8s.scale_sandbox = AsyncMock(return_value=True)
+    k8s.get_storage_class = AsyncMock(return_value={"metadata": {"name": "treadstone-workspace"}})
+    k8s.list_sandbox_templates = AsyncMock(
+        return_value=[
+            {
+                "name": "small",
+                "image": "ghcr.io/agent-infra/sandbox:latest",
+                "resource_spec": {"cpu": "500m", "memory": "1Gi"},
+            },
+        ]
+    )
+    return k8s
+
+
+def _mock_metering() -> MeteringService:
+    m = MagicMock(spec=MeteringService)
+    m.check_template_allowed = AsyncMock()
+    m.check_compute_quota = AsyncMock()
+    m.check_concurrent_limit = AsyncMock()
+    m.check_storage_quota = AsyncMock()
+    m.check_sandbox_duration = AsyncMock(return_value=7200)
+    m.get_user_plan = AsyncMock(return_value=_make_plan())
+    m.record_storage_allocation = AsyncMock()
+    m.record_storage_release = AsyncMock()
+    m.open_compute_session = AsyncMock()
+    m.close_compute_session = AsyncMock()
+    return m
+
+
+# ═══════════════════════════════════════════════════════════
+#  F15 — SandboxService metering integration
+# ═══════════════════════════════════════════════════════════
+
+
+class TestSandboxServiceCreateWithMetering:
+    async def test_create_runs_all_quota_checks(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        await service.create(owner_id="user1234567890abcd", template="small")
+
+        metering.check_template_allowed.assert_awaited_once()
+        metering.check_compute_quota.assert_awaited_once()
+        metering.check_concurrent_limit.assert_awaited_once()
+        metering.check_sandbox_duration.assert_awaited_once()
+
+    async def test_create_persist_checks_storage_quota(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        await service.create(owner_id="user1234567890abcd", template="small", persist=True, storage_size="5Gi")
+
+        metering.check_storage_quota.assert_awaited_once_with(session, "user1234567890abcd", 5)
+
+    async def test_create_non_persist_skips_storage_check(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        await service.create(owner_id="user1234567890abcd", template="small", persist=False)
+
+        metering.check_storage_quota.assert_not_awaited()
+
+    async def test_create_persist_records_storage_allocation(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        result = await service.create(
+            owner_id="user1234567890abcd", template="small", persist=True, storage_size="10Gi"
+        )
+
+        metering.record_storage_allocation.assert_awaited_once_with(session, "user1234567890abcd", result.id, 10)
+
+    async def test_create_template_not_allowed_aborts_early(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        metering.check_template_allowed = AsyncMock(
+            side_effect=TemplateNotAllowedError("free", "large", ["tiny", "small"])
+        )
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        with pytest.raises(TemplateNotAllowedError):
+            await service.create(owner_id="user1234567890abcd", template="large")
+
+        session.add.assert_not_called()
+        k8s.create_sandbox_claim.assert_not_called()
+
+    async def test_create_compute_quota_exceeded_aborts_early(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        metering.check_compute_quota = AsyncMock(side_effect=ComputeQuotaExceededError(100.0, 100.0, 0.0))
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        with pytest.raises(ComputeQuotaExceededError):
+            await service.create(owner_id="user1234567890abcd", template="small")
+
+        session.add.assert_not_called()
+
+    async def test_create_concurrent_limit_exceeded_aborts_early(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        metering.check_concurrent_limit = AsyncMock(side_effect=ConcurrentLimitError(3, 3))
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        with pytest.raises(ConcurrentLimitError):
+            await service.create(owner_id="user1234567890abcd", template="small")
+
+        session.add.assert_not_called()
+
+    async def test_create_storage_quota_exceeded_aborts_early(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        metering.check_storage_quota = AsyncMock(side_effect=StorageQuotaExceededError(8, 5, 10))
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        with pytest.raises(StorageQuotaExceededError):
+            await service.create(owner_id="user1234567890abcd", template="small", persist=True, storage_size="5Gi")
+
+        session.add.assert_not_called()
+
+    async def test_create_duration_exceeded_raises(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        metering.check_sandbox_duration = AsyncMock(return_value=1800)
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        with pytest.raises(SandboxDurationExceededError):
+            await service.create(
+                owner_id="user1234567890abcd",
+                template="small",
+                auto_stop_interval=60,
+            )
+
+    async def test_create_auto_stop_disabled_skips_duration_check(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        metering.check_sandbox_duration = AsyncMock(return_value=1800)
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        result = await service.create(
+            owner_id="user1234567890abcd",
+            template="small",
+            auto_stop_interval=-1,
+        )
+        assert result.status == SandboxStatus.CREATING
+
+    async def test_create_without_metering_skips_all_checks(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        service = SandboxService(session=session, k8s_client=k8s, metering=None)
+
+        result = await service.create(owner_id="user1234567890abcd", template="small")
+
+        assert result.status == SandboxStatus.CREATING
+
+
+class TestSandboxServiceStartWithMetering:
+    async def test_start_runs_quota_checks(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        sb = _make_sandbox(status=SandboxStatus.STOPPED)
+        session = _mock_session(sb)
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        await service.start(sandbox_id=sb.id, owner_id=sb.owner_id)
+
+        metering.check_compute_quota.assert_awaited_once()
+        metering.check_concurrent_limit.assert_awaited_once()
+
+    async def test_start_compute_quota_exceeded_aborts(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        sb = _make_sandbox(status=SandboxStatus.STOPPED)
+        session = _mock_session(sb)
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        metering.check_compute_quota = AsyncMock(side_effect=ComputeQuotaExceededError(100.0, 100.0, 0.0))
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        with pytest.raises(ComputeQuotaExceededError):
+            await service.start(sandbox_id=sb.id, owner_id=sb.owner_id)
+
+        k8s.scale_sandbox.assert_not_called()
+
+    async def test_start_without_metering_skips_checks(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        sb = _make_sandbox(status=SandboxStatus.STOPPED)
+        session = _mock_session(sb)
+        k8s = _mock_k8s_client()
+        service = SandboxService(session=session, k8s_client=k8s, metering=None)
+
+        result = await service.start(sandbox_id=sb.id, owner_id=sb.owner_id)
+        assert result.status == SandboxStatus.CREATING
+        k8s.scale_sandbox.assert_called_once()
+
+
+class TestSandboxServiceDeleteWithMetering:
+    async def test_delete_persist_releases_storage(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        sb = _make_sandbox(status=SandboxStatus.READY, persist=True, provision_mode="direct")
+        session = _mock_session(sb)
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        await service.delete(sandbox_id=sb.id, owner_id=sb.owner_id)
+
+        metering.record_storage_release.assert_awaited_once_with(session, sb.id)
+
+    async def test_delete_non_persist_skips_storage_release(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        sb = _make_sandbox(status=SandboxStatus.READY, persist=False)
+        session = _mock_session(sb)
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        await service.delete(sandbox_id=sb.id, owner_id=sb.owner_id)
+
+        metering.record_storage_release.assert_not_awaited()
+
+    async def test_delete_without_metering_succeeds(self):
+        from treadstone.services.sandbox_service import SandboxService
+
+        sb = _make_sandbox(status=SandboxStatus.READY, persist=True, provision_mode="direct")
+        session = _mock_session(sb)
+        k8s = _mock_k8s_client()
+        service = SandboxService(session=session, k8s_client=k8s, metering=None)
+
+        await service.delete(sandbox_id=sb.id, owner_id=sb.owner_id)
+        assert sb.status == SandboxStatus.DELETING
+
+    async def test_delete_persist_metering_failure_still_deletes(self):
+        """Metering release failure should not block sandbox deletion."""
+        from treadstone.services.sandbox_service import SandboxService
+
+        sb = _make_sandbox(status=SandboxStatus.READY, persist=True, provision_mode="direct")
+        session = _mock_session(sb)
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        metering.record_storage_release = AsyncMock(side_effect=RuntimeError("DB error"))
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        await service.delete(sandbox_id=sb.id, owner_id=sb.owner_id)
+
+        assert sb.status == SandboxStatus.DELETING
+        k8s.delete_sandbox.assert_called_once()
+
+    async def test_create_persist_metering_allocation_failure_still_returns(self):
+        """Storage allocation metering failure should not block sandbox creation."""
+        from treadstone.services.sandbox_service import SandboxService
+
+        session = _mock_session()
+        k8s = _mock_k8s_client()
+        metering = _mock_metering()
+        metering.record_storage_allocation = AsyncMock(side_effect=RuntimeError("DB error"))
+        service = SandboxService(session=session, k8s_client=k8s, metering=metering)
+
+        result = await service.create(owner_id="user1234567890abcd", template="small", persist=True, storage_size="5Gi")
+
+        assert result.status == SandboxStatus.CREATING
+        assert result.persist is True
+
+
+# ═══════════════════════════════════════════════════════════
+#  F16 — K8s Sync metering integration
+# ═══════════════════════════════════════════════════════════
+
+
+class TestApplyMeteringOnTransition:
+    async def test_creating_to_ready_opens_session(self):
+        from treadstone.services.k8s_sync import _apply_metering_on_transition
+
+        session = AsyncMock()
+        sandbox = _make_sandbox(status=SandboxStatus.CREATING)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.open_compute_session = AsyncMock()
+            mock_metering.close_compute_session = AsyncMock()
+
+            await _apply_metering_on_transition(session, sandbox, SandboxStatus.CREATING, SandboxStatus.READY)
+
+            mock_metering.open_compute_session.assert_awaited_once_with(
+                session, sandbox.id, sandbox.owner_id, sandbox.template
+            )
+            mock_metering.close_compute_session.assert_not_awaited()
+
+    async def test_ready_to_stopped_closes_session(self):
+        from treadstone.services.k8s_sync import _apply_metering_on_transition
+
+        session = AsyncMock()
+        sandbox = _make_sandbox(status=SandboxStatus.READY)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.open_compute_session = AsyncMock()
+            mock_metering.close_compute_session = AsyncMock()
+
+            await _apply_metering_on_transition(session, sandbox, SandboxStatus.READY, SandboxStatus.STOPPED)
+
+            mock_metering.close_compute_session.assert_awaited_once_with(session, sandbox.id)
+            mock_metering.open_compute_session.assert_not_awaited()
+
+    async def test_ready_to_error_closes_session(self):
+        from treadstone.services.k8s_sync import _apply_metering_on_transition
+
+        session = AsyncMock()
+        sandbox = _make_sandbox(status=SandboxStatus.READY)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.close_compute_session = AsyncMock()
+
+            await _apply_metering_on_transition(session, sandbox, SandboxStatus.READY, SandboxStatus.ERROR)
+
+            mock_metering.close_compute_session.assert_awaited_once()
+
+    async def test_ready_to_deleting_closes_session(self):
+        from treadstone.services.k8s_sync import _apply_metering_on_transition
+
+        session = AsyncMock()
+        sandbox = _make_sandbox(status=SandboxStatus.READY)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.close_compute_session = AsyncMock()
+
+            await _apply_metering_on_transition(session, sandbox, SandboxStatus.READY, SandboxStatus.DELETING)
+
+            mock_metering.close_compute_session.assert_awaited_once()
+
+    async def test_creating_to_error_is_noop(self):
+        from treadstone.services.k8s_sync import _apply_metering_on_transition
+
+        session = AsyncMock()
+        sandbox = _make_sandbox(status=SandboxStatus.CREATING)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.open_compute_session = AsyncMock()
+            mock_metering.close_compute_session = AsyncMock()
+
+            await _apply_metering_on_transition(session, sandbox, SandboxStatus.CREATING, SandboxStatus.ERROR)
+
+            mock_metering.open_compute_session.assert_not_awaited()
+            mock_metering.close_compute_session.assert_not_awaited()
+
+    async def test_metering_failure_does_not_raise(self):
+        from treadstone.services.k8s_sync import _apply_metering_on_transition
+
+        session = AsyncMock()
+        sandbox = _make_sandbox(status=SandboxStatus.CREATING)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.open_compute_session = AsyncMock(side_effect=RuntimeError("DB failure"))
+
+            await _apply_metering_on_transition(session, sandbox, SandboxStatus.CREATING, SandboxStatus.READY)
+
+
+class TestTryCloseComputeSession:
+    async def test_delegates_to_metering(self):
+        from treadstone.services.k8s_sync import _try_close_compute_session
+
+        session = AsyncMock()
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.close_compute_session = AsyncMock()
+
+            await _try_close_compute_session(session, "sb_test")
+
+            mock_metering.close_compute_session.assert_awaited_once_with(session, "sb_test")
+
+    async def test_failure_does_not_raise(self):
+        from treadstone.services.k8s_sync import _try_close_compute_session
+
+        session = AsyncMock()
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.close_compute_session = AsyncMock(side_effect=RuntimeError("oops"))
+
+            await _try_close_compute_session(session, "sb_test")
+
+
+# ═══════════════════════════════════════════════════════════
+#  F17 — reconcile_metering
+# ═══════════════════════════════════════════════════════════
+
+
+class _MockScalarsResult:
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return self
+
+    def scalar_one_or_none(self):
+        return self._items[0] if self._items else None
+
+    def __iter__(self):
+        return iter(self._items)
+
+
+class TestReconcileMetering:
+    async def test_opens_session_for_ready_sandbox_without_one(self):
+        from treadstone.services.k8s_sync import reconcile_metering
+
+        sandbox = _make_sandbox(status=SandboxStatus.READY)
+
+        session = AsyncMock()
+        call_count = 0
+
+        async def mock_execute(stmt):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _MockScalarsResult([sandbox])
+            elif call_count == 2:
+                return _MockScalarsResult([])
+            else:
+                return _MockScalarsResult([])
+
+        session.execute = AsyncMock(side_effect=mock_execute)
+        session.get = AsyncMock(return_value=sandbox)
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.__aenter__ = AsyncMock(return_value=session)
+        factory.__aexit__ = AsyncMock(return_value=False)
+        session_factory = MagicMock(return_value=factory)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.open_compute_session = AsyncMock()
+            mock_metering.close_compute_session = AsyncMock()
+
+            await reconcile_metering(session_factory)
+
+            mock_metering.open_compute_session.assert_awaited_once_with(
+                session, sandbox.id, sandbox.owner_id, sandbox.template
+            )
+
+    async def test_closes_session_for_stopped_sandbox_with_open_session(self):
+        from treadstone.services.k8s_sync import reconcile_metering
+
+        stopped_sandbox = _make_sandbox(status=SandboxStatus.STOPPED)
+        open_cs = ComputeSession(
+            id="cs_test",
+            sandbox_id=stopped_sandbox.id,
+            user_id=stopped_sandbox.owner_id,
+            template="small",
+            credit_rate_per_hour=Decimal("0.5"),
+            started_at=FIXED_NOW,
+            last_metered_at=FIXED_NOW,
+        )
+
+        session = AsyncMock()
+        call_count = 0
+
+        async def mock_execute(stmt):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _MockScalarsResult([])
+            elif call_count == 2:
+                return _MockScalarsResult([open_cs])
+            else:
+                return _MockScalarsResult([])
+
+        session.execute = AsyncMock(side_effect=mock_execute)
+        session.get = AsyncMock(return_value=stopped_sandbox)
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.__aenter__ = AsyncMock(return_value=session)
+        factory.__aexit__ = AsyncMock(return_value=False)
+        session_factory = MagicMock(return_value=factory)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.open_compute_session = AsyncMock()
+            mock_metering.close_compute_session = AsyncMock()
+
+            await reconcile_metering(session_factory)
+
+            mock_metering.close_compute_session.assert_awaited_once_with(session, stopped_sandbox.id)
+
+    async def test_closes_session_for_deleted_sandbox(self):
+        from treadstone.services.k8s_sync import reconcile_metering
+
+        open_cs = ComputeSession(
+            id="cs_orphan",
+            sandbox_id="sb_deleted",
+            user_id="user01",
+            template="small",
+            credit_rate_per_hour=Decimal("0.5"),
+            started_at=FIXED_NOW,
+            last_metered_at=FIXED_NOW,
+        )
+
+        session = AsyncMock()
+        call_count = 0
+
+        async def mock_execute(stmt):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _MockScalarsResult([])
+            elif call_count == 2:
+                return _MockScalarsResult([open_cs])
+            else:
+                return _MockScalarsResult([])
+
+        session.execute = AsyncMock(side_effect=mock_execute)
+        session.get = AsyncMock(return_value=None)
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.__aenter__ = AsyncMock(return_value=session)
+        factory.__aexit__ = AsyncMock(return_value=False)
+        session_factory = MagicMock(return_value=factory)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.close_compute_session = AsyncMock()
+
+            await reconcile_metering(session_factory)
+
+            mock_metering.close_compute_session.assert_awaited_once_with(session, "sb_deleted")
+
+    async def test_no_mismatches_is_noop(self):
+        from treadstone.services.k8s_sync import reconcile_metering
+
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=_MockScalarsResult([]))
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.__aenter__ = AsyncMock(return_value=session)
+        factory.__aexit__ = AsyncMock(return_value=False)
+        session_factory = MagicMock(return_value=factory)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.open_compute_session = AsyncMock()
+            mock_metering.close_compute_session = AsyncMock()
+
+            await reconcile_metering(session_factory)
+
+            mock_metering.open_compute_session.assert_not_awaited()
+            mock_metering.close_compute_session.assert_not_awaited()
+
+    async def test_metering_failure_does_not_halt_reconciliation(self):
+        from treadstone.services.k8s_sync import reconcile_metering
+
+        sb1 = _make_sandbox(id="sb_a", status=SandboxStatus.READY)
+        sb2 = _make_sandbox(id="sb_b", status=SandboxStatus.READY)
+
+        session = AsyncMock()
+        call_count = 0
+
+        async def mock_execute(stmt):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _MockScalarsResult([sb1, sb2])
+            elif call_count in (2, 3):
+                return _MockScalarsResult([])
+            elif call_count == 4:
+                return _MockScalarsResult([])
+            else:
+                return _MockScalarsResult([])
+
+        session.execute = AsyncMock(side_effect=mock_execute)
+        session.get = AsyncMock(return_value=None)
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.__aenter__ = AsyncMock(return_value=session)
+        factory.__aexit__ = AsyncMock(return_value=False)
+        session_factory = MagicMock(return_value=factory)
+
+        with patch("treadstone.services.k8s_sync._metering") as mock_metering:
+            mock_metering.open_compute_session = AsyncMock(side_effect=[RuntimeError("fail on sb_a"), None])
+
+            await reconcile_metering(session_factory)
+
+            assert mock_metering.open_compute_session.await_count == 2

--- a/treadstone/services/k8s_sync.py
+++ b/treadstone/services/k8s_sync.py
@@ -24,8 +24,11 @@ from treadstone.models.audit_event import AuditActorType
 from treadstone.models.sandbox import Sandbox, SandboxStatus, is_valid_transition
 from treadstone.services.audit import record_audit_event
 from treadstone.services.k8s_client import K8sClientProtocol, WatchExpiredError
+from treadstone.services.metering_service import MeteringService
 
 logger = logging.getLogger(__name__)
+
+_metering = MeteringService()
 
 RECONCILE_INTERVAL = 300  # 5 minutes
 WATCH_RESTART_BACKOFF = 5  # seconds to wait before restarting Watch after unexpected failure
@@ -98,6 +101,7 @@ async def handle_watch_event(
             return
 
         if event_type == "DELETED":
+            await _try_close_compute_session(session, sandbox.id)
             if sandbox.status == SandboxStatus.DELETING:
                 await _record_status_change(
                     session,
@@ -156,6 +160,7 @@ async def handle_watch_event(
                 )
                 return
 
+            old_status = sandbox.status
             rows = await _optimistic_update(
                 session, sandbox.id, sandbox.version, new_status, resource_version=cr_rv, message=message
             )
@@ -165,11 +170,12 @@ async def handle_watch_event(
                 await _record_status_change(
                     session,
                     sandbox_id=sandbox.id,
-                    from_status=sandbox.status,
+                    from_status=old_status,
                     to_status=new_status,
                     source="k8s_watch",
                     message=message,
                 )
+                await _apply_metering_on_transition(session, sandbox, old_status, new_status)
                 await session.commit()
 
 
@@ -204,6 +210,7 @@ async def reconcile(
 
             if cr is None:
                 if sandbox.status == SandboxStatus.DELETING:
+                    await _try_close_compute_session(session, sandbox.id)
                     await _record_status_change(
                         session,
                         sandbox_id=sandbox.id,
@@ -214,14 +221,16 @@ async def reconcile(
                     await _delete_sandbox_row(session, sandbox.id)
                 elif sandbox.status != SandboxStatus.CREATING:
                     logger.warning("CR missing for %s (status=%s), marking error", sandbox.id, sandbox.status)
+                    old_status = sandbox.status
                     await _optimistic_update(session, sandbox.id, sandbox.version, SandboxStatus.ERROR)
                     await _record_status_change(
                         session,
                         sandbox_id=sandbox.id,
-                        from_status=sandbox.status,
+                        from_status=old_status,
                         to_status=SandboxStatus.ERROR,
                         source="k8s_reconcile",
                     )
+                    await _apply_metering_on_transition(session, sandbox, old_status, SandboxStatus.ERROR)
                     await session.commit()
                 continue
 
@@ -232,20 +241,28 @@ async def reconcile(
             new_status, message = derive_status_from_sandbox_cr(cr)
 
             if new_status != sandbox.status and is_valid_transition(sandbox.status, new_status):
+                old_status = sandbox.status
                 await _optimistic_update(
                     session, sandbox.id, sandbox.version, new_status, resource_version=cr_rv, message=message
                 )
                 await _record_status_change(
                     session,
                     sandbox_id=sandbox.id,
-                    from_status=sandbox.status,
+                    from_status=old_status,
                     to_status=new_status,
                     source="k8s_reconcile",
                     message=message,
                 )
+                await _apply_metering_on_transition(session, sandbox, old_status, new_status)
                 await session.commit()
             elif cr_rv != sandbox.k8s_resource_version:
                 await _update_sync_metadata(session, sandbox.id, cr_rv, message)
+
+    # ── Metering reconciliation: fix mismatches between sessions and sandbox state ──
+    try:
+        await reconcile_metering(session_factory)
+    except Exception:
+        logger.exception("Metering reconciliation failed")
 
     logger.info("Reconciliation complete. %d unmanaged CRs in K8s. list_rv=%s", len(cr_map), list_rv)
     return list_rv
@@ -370,6 +387,90 @@ async def _delete_sandbox_row(session: AsyncSession, sandbox_id: str) -> None:
         return
     await session.delete(sandbox)
     await session.commit()
+
+
+async def _apply_metering_on_transition(
+    session: AsyncSession,
+    sandbox: Sandbox,
+    old_status: str,
+    new_status: str,
+) -> None:
+    """Open or close a ComputeSession based on sandbox state transition.
+
+    Best-effort: failures are logged but never block the sync pipeline.
+    reconcile_metering() will repair any missed operations.
+    """
+    try:
+        if old_status != SandboxStatus.READY and new_status == SandboxStatus.READY:
+            await _metering.open_compute_session(session, sandbox.id, sandbox.owner_id, sandbox.template)
+
+        elif old_status == SandboxStatus.READY and new_status in (
+            SandboxStatus.STOPPED,
+            SandboxStatus.ERROR,
+            SandboxStatus.DELETING,
+        ):
+            await _metering.close_compute_session(session, sandbox.id)
+    except Exception:
+        logger.exception("Metering transition failed for sandbox %s (%s→%s)", sandbox.id, old_status, new_status)
+
+
+async def _try_close_compute_session(session: AsyncSession, sandbox_id: str) -> None:
+    """Best-effort close of any open ComputeSession for the given sandbox."""
+    try:
+        await _metering.close_compute_session(session, sandbox_id)
+    except Exception:
+        logger.exception("Failed to close compute session for sandbox %s", sandbox_id)
+
+
+async def reconcile_metering(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Check and repair mismatches between ComputeSession state and sandbox state.
+
+    Two repair cases:
+      1. sandbox is READY but has no open ComputeSession → open one
+      2. sandbox is NOT READY (or missing) but has an open ComputeSession → close it
+    """
+    async with session_factory() as session:
+        from treadstone.models.metering import ComputeSession
+
+        # Case 1: READY sandboxes missing an open session
+        ready_result = await session.execute(select(Sandbox).where(Sandbox.status == SandboxStatus.READY))
+        for sandbox in ready_result.scalars():
+            open_result = await session.execute(
+                select(ComputeSession).where(
+                    ComputeSession.sandbox_id == sandbox.id,
+                    ComputeSession.ended_at.is_(None),
+                )
+            )
+            if open_result.scalar_one_or_none() is None:
+                logger.warning("Ready sandbox %s has no open ComputeSession, opening one", sandbox.id)
+                try:
+                    await _metering.open_compute_session(session, sandbox.id, sandbox.owner_id, sandbox.template)
+                except Exception:
+                    logger.exception("Failed to open compute session for sandbox %s during reconciliation", sandbox.id)
+
+        # Case 2: open sessions for non-READY (or deleted) sandboxes
+        open_sessions_result = await session.execute(select(ComputeSession).where(ComputeSession.ended_at.is_(None)))
+        for cs in open_sessions_result.scalars():
+            sandbox = await session.get(Sandbox, cs.sandbox_id)
+            if sandbox is None or sandbox.status != SandboxStatus.READY:
+                status_desc = sandbox.status if sandbox else "deleted"
+                logger.warning(
+                    "ComputeSession %s for sandbox %s is open but sandbox is %s, closing",
+                    cs.id,
+                    cs.sandbox_id,
+                    status_desc,
+                )
+                try:
+                    await _metering.close_compute_session(session, cs.sandbox_id)
+                except Exception:
+                    logger.exception(
+                        "Failed to close compute session %s during reconciliation",
+                        cs.id,
+                    )
+
+        await session.commit()
 
 
 async def _record_status_change(

--- a/treadstone/services/metering_service.py
+++ b/treadstone/services/metering_service.py
@@ -16,9 +16,14 @@ Transaction Policy
 ------------------
 Methods modify ORM objects but do NOT commit the session.
 Callers are responsible for committing or rolling back.  This keeps
-transaction boundaries explicit and composable — e.g. k8s_sync can
-update sandbox state and open a compute session in the same atomic
-transaction.
+transaction boundaries explicit and composable.
+
+Note: in k8s_sync, ``_optimistic_update`` commits the sandbox status
+change in its own transaction, so the subsequent metering call runs
+in a separate implicit transaction.  If the metering call fails, the
+sandbox status is already committed but the ComputeSession may be
+missing.  ``reconcile_metering()`` repairs such mismatches, providing
+eventual consistency.
 """
 
 import logging

--- a/treadstone/services/sandbox_service.py
+++ b/treadstone/services/sandbox_service.py
@@ -7,7 +7,10 @@ Dual-path provisioning:
 start/stop use scale_sandbox on the Sandbox CR regardless of path.
 """
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -16,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from treadstone.config import settings
 from treadstone.core.errors import (
     InvalidTransitionError,
+    SandboxDurationExceededError,
     SandboxNameConflictError,
     SandboxNotFoundError,
     StorageBackendNotReadyError,
@@ -25,6 +29,10 @@ from treadstone.models.sandbox import Sandbox, SandboxStatus, is_valid_transitio
 from treadstone.models.sandbox_web_link import SandboxWebLink
 from treadstone.models.user import random_id, utc_now
 from treadstone.services.k8s_client import K8sClientProtocol, get_k8s_client
+from treadstone.services.metering_helpers import parse_storage_size_gib
+
+if TYPE_CHECKING:
+    from treadstone.services.metering_service import MeteringService
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +57,15 @@ def _build_resource_limits(requests: dict[str, str]) -> dict[str, str]:
 
 
 class SandboxService:
-    def __init__(self, session: AsyncSession, k8s_client: K8sClientProtocol | None = None):
+    def __init__(
+        self,
+        session: AsyncSession,
+        k8s_client: K8sClientProtocol | None = None,
+        metering: MeteringService | None = None,
+    ):
         self.session = session
         self.k8s = k8s_client or get_k8s_client()
+        self._metering = metering
 
     async def create(
         self,
@@ -64,9 +78,26 @@ class SandboxService:
         persist: bool = False,
         storage_size: str | None = None,
     ) -> Sandbox:
+        effective_storage_size = storage_size or settings.sandbox_default_storage_size
+
+        # ── Metering: quota checks (must run before any resource creation) ──
+        if self._metering is not None:
+            await self._metering.check_template_allowed(self.session, owner_id, template)
+            await self._metering.check_compute_quota(self.session, owner_id)
+            await self._metering.check_concurrent_limit(self.session, owner_id)
+
+            if persist:
+                size_gib = parse_storage_size_gib(effective_storage_size)
+                await self._metering.check_storage_quota(self.session, owner_id, size_gib)
+
+            max_duration = await self._metering.check_sandbox_duration(self.session, owner_id)
+            if auto_stop_interval > 0 and (auto_stop_interval * 60) > max_duration:
+                plan = await self._metering.get_user_plan(self.session, owner_id)
+                raise SandboxDurationExceededError(plan.tier, max_duration)
+
+        # ── Create sandbox record ──
         sandbox_id = "sb" + random_id()
         sandbox_name = name or f"sb-{random_id(8)}"
-        effective_storage_size = storage_size or settings.sandbox_default_storage_size
 
         if persist:
             await self._ensure_persistent_storage_backend_ready()
@@ -118,6 +149,15 @@ class SandboxService:
             sandbox.version += 1
             self.session.add(sandbox)
             await self.session.commit()
+
+        # ── Metering: record storage allocation for persistent sandboxes (best-effort) ──
+        if self._metering is not None and persist and sandbox.status != SandboxStatus.ERROR:
+            try:
+                size_gib = parse_storage_size_gib(effective_storage_size)
+                await self._metering.record_storage_allocation(self.session, owner_id, sandbox.id, size_gib)
+                await self.session.commit()
+            except Exception:
+                logger.exception("Failed to record storage allocation for sandbox %s", sandbox_id)
 
         return sandbox
 
@@ -205,6 +245,13 @@ class SandboxService:
         if not is_valid_transition(sandbox.status, SandboxStatus.DELETING):
             raise InvalidTransitionError(sandbox_id, sandbox.status, "deleting")
 
+        # ── Metering: release storage before K8s deletion (best-effort) ──
+        if self._metering is not None and sandbox.persist:
+            try:
+                await self._metering.record_storage_release(self.session, sandbox.id)
+            except Exception:
+                logger.exception("Failed to release storage metering for sandbox %s", sandbox_id)
+
         sandbox.status = SandboxStatus.DELETING
         sandbox.version += 1
         self.session.add(sandbox)
@@ -246,6 +293,11 @@ class SandboxService:
 
         if sandbox.status != SandboxStatus.STOPPED:
             raise InvalidTransitionError(sandbox_id, sandbox.status, "ready")
+
+        # ── Metering: quota checks before resuming ──
+        if self._metering is not None:
+            await self._metering.check_compute_quota(self.session, owner_id)
+            await self._metering.check_concurrent_limit(self.session, owner_id)
 
         sandbox.status = SandboxStatus.CREATING
         sandbox.gmt_started = utc_now()


### PR DESCRIPTION
## Summary
Implement Layer 3 of the metering system integration:
- **F15**: Integrate `MeteringService` into `SandboxService` (`create`, `start`, `delete`)
- **F16**: Integrate `MeteringService` into `K8s Sync` (open/close `ComputeSession` on state transitions)
- **F17**: Implement `reconcile_metering` for eventual consistency between sandbox state and metering records

## Changes
### Code
- Modified `treadstone/services/sandbox_service.py`: Added quota checks before resource creation and best-effort storage allocation/release
- Modified `treadstone/services/k8s_sync.py`: Added hooks to open/close `ComputeSession` based on Kubernetes events, implemented `reconcile_metering` function
- Updated `treadstone/services/metering_service.py` docstring: Clarified transaction boundaries with k8s_sync
- Added `tests/unit/test_metering_integration.py`: 32 comprehensive unit tests

### Documentation
- Fixed `metering-enforcement.md`: Corrected TierTemplate seed data, removed `open_compute_session` from Create Sandbox flowchart
- Fixed `metering-compute.md`: Updated error class names and field references
- Fixed `metering-storage.md`: Standardized HTTP status code to 402 for `StorageQuotaExceededError`

## Test Plan
- [x] make test — all 433 tests pass
- [x] make lint — no linting errors
- [x] Documentation consistency verified
- [x] Code review fixes applied
- [x] Best-effort error handling for metering operations in critical paths

## Design Decisions
1. **Placement of `open_compute_session`**: Implemented in K8s Sync on READY transition (not in `SandboxService.create`) per sequence diagram
2. **Best-Effort Metering in k8s_sync**: Metering failures don't block system sync; eventual consistency via `reconcile_metering`
3. **Module-level MeteringService**: Singleton in k8s_sync acceptable due to stateless nature

Made with [Cursor](https://cursor.com)