### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.5.1"
+version = "0.5.2"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.5.1"
+version = "0.5.2"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.5.1"
+version = "0.5.2"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1850,7 +1850,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Bump version to 0.5.2 across `pyproject.toml`, `cli/pyproject.toml`, `sdk/python/pyproject.toml`, and `uv.lock`

## Changes in this release
- feat(web): implement Admin Metering and Audit Events pages (Figma-based)
- fix: resolve frontend-backend API mismatches and UX issues

Made with [Cursor](https://cursor.com)