### PR TITLE
fix(test): update oauth callback tests to expect 303 redirect to /app

### DIFF
--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -139,9 +139,9 @@ async def test_google_callback_creates_user_and_sets_session_cookie(db_session, 
             follow_redirects=False,
         )
 
-    assert callback.status_code == 200
+    assert callback.status_code == 303
+    assert callback.headers["location"] == "/app"
     assert callback.cookies.get("session") is not None
-    assert "close this window" in callback.text.lower()
 
     async with _test_session_factory() as session:
         user = (await session.execute(select(User).where(User.email == "new@example.com"))).unique().scalar_one()
@@ -182,7 +182,8 @@ async def test_google_callback_auto_links_existing_user_by_email(db_session, mon
             follow_redirects=False,
         )
 
-    assert callback.status_code == 200
+    assert callback.status_code == 303
+    assert callback.headers["location"] == "/app"
     assert callback.cookies.get("session") is not None
 
     async with _test_session_factory() as session:


### PR DESCRIPTION
## Summary
- Fix two failing tests in `test_oauth_api.py` that expected 200 from the Google OAuth callback
- The callback behavior changed: without `return_to` or `cli_flow_id`, it now returns 303 redirect to `/app` and sets the session cookie
- Updated assertions to match current implementation

## Test Plan
- [x] Both previously failing tests now pass locally
- [x] `uv run pytest tests/api/test_oauth_api.py -v` all pass

Made with [Cursor](https://cursor.com)