### PR TITLE
fix: update web frontend image tag in prod values on release

### DIFF
--- a/.github/workflows/update-prod-image.yml
+++ b/.github/workflows/update-prod-image.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add deploy/treadstone/values-prod.yaml
+          git add deploy/treadstone/values-prod.yaml deploy/treadstone-web/values-prod.yaml
           git diff --cached --quiet \
             || git commit -m "chore: update prod image to ${{ steps.tag.outputs.version }}"
           git push

--- a/scripts/update_prod_image.py
+++ b/scripts/update_prod_image.py
@@ -1,4 +1,4 @@
-"""Update the image.tag in deploy/treadstone/values-prod.yaml to the given version."""
+"""Update the image.tag in prod Helm values files to the given version."""
 
 from __future__ import annotations
 
@@ -7,33 +7,42 @@ import re
 import sys
 from pathlib import Path
 
-HELM_VALUES_PATH = "deploy/treadstone/values-prod.yaml"
+HELM_VALUES_PATHS = [
+    "deploy/treadstone/values-prod.yaml",
+    "deploy/treadstone-web/values-prod.yaml",
+]
 
 
-def update_prod_image(root: Path, version: str) -> Path:
+def update_prod_image(root: Path, version: str) -> list[Path]:
     normalized = version.lstrip("v")
-    path = root / HELM_VALUES_PATH
-    if not path.exists():
-        raise FileNotFoundError(HELM_VALUES_PATH)
+    updated_paths: list[Path] = []
 
-    content = path.read_text(encoding="utf-8")
-    updated, count = re.subn(r"(?m)^(\s+tag:\s*)\S+$", rf"\g<1>{normalized}", content, count=1)
-    if count != 1:
-        raise ValueError(f"{HELM_VALUES_PATH}: missing image.tag entry")
+    for rel_path in HELM_VALUES_PATHS:
+        path = root / rel_path
+        if not path.exists():
+            raise FileNotFoundError(rel_path)
 
-    path.write_text(updated, encoding="utf-8")
-    return path
+        content = path.read_text(encoding="utf-8")
+        updated, count = re.subn(r"(?m)^(\s+tag:\s*)\S+$", rf"\g<1>{normalized}", content, count=1)
+        if count != 1:
+            raise ValueError(f"{rel_path}: missing image.tag entry")
+
+        path.write_text(updated, encoding="utf-8")
+        updated_paths.append(path)
+
+    return updated_paths
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Update prod Helm values image tag.")
+    parser = argparse.ArgumentParser(description="Update prod Helm values image tags.")
     parser.add_argument("version", help="Release version, e.g. v0.4.2 or 0.4.2")
     parser.add_argument("--root", default=".", help="Repository root.")
     args = parser.parse_args()
 
     try:
-        path = update_prod_image(Path(args.root).resolve(), args.version)
-        print(path)
+        paths = update_prod_image(Path(args.root).resolve(), args.version)
+        for p in paths:
+            print(p)
     except (FileNotFoundError, ValueError) as exc:
         print(exc, file=sys.stderr)
         return 1

--- a/tests/unit/test_update_prod_image.py
+++ b/tests/unit/test_update_prod_image.py
@@ -7,7 +7,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "update_prod_image.py"
 
-SAMPLE_VALUES = """\
+SAMPLE_VALUES_BACKEND = """\
 replicaCount: 1
 
 image:
@@ -18,16 +18,36 @@ image:
 envSecretRef: treadstone-secrets
 """
 
+SAMPLE_VALUES_WEB = """\
+replicaCount: 2
 
-def _write_values(tmp_path: Path, content: str = SAMPLE_VALUES) -> Path:
+image:
+  repository: ghcr.io/earayu/treadstone-web
+  tag: 0.4.0
+  pullPolicy: Always
+"""
+
+
+def _write_backend_values(tmp_path: Path, content: str = SAMPLE_VALUES_BACKEND) -> Path:
     values_path = tmp_path / "deploy" / "treadstone" / "values-prod.yaml"
     values_path.parent.mkdir(parents=True, exist_ok=True)
     values_path.write_text(content, encoding="utf-8")
     return values_path
 
 
+def _write_web_values(tmp_path: Path, content: str = SAMPLE_VALUES_WEB) -> Path:
+    values_path = tmp_path / "deploy" / "treadstone-web" / "values-prod.yaml"
+    values_path.parent.mkdir(parents=True, exist_ok=True)
+    values_path.write_text(content, encoding="utf-8")
+    return values_path
+
+
+def _write_all_values(tmp_path: Path) -> tuple[Path, Path]:
+    return _write_backend_values(tmp_path), _write_web_values(tmp_path)
+
+
 def test_update_prod_image_replaces_tag(tmp_path: Path) -> None:
-    values_path = _write_values(tmp_path)
+    backend_path, _ = _write_all_values(tmp_path)
 
     result = subprocess.run(
         [sys.executable, str(SCRIPT_PATH), "v0.5.0", "--root", str(tmp_path)],
@@ -37,13 +57,13 @@ def test_update_prod_image_replaces_tag(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    content = values_path.read_text(encoding="utf-8")
+    content = backend_path.read_text(encoding="utf-8")
     assert "tag: 0.5.0" in content
     assert "tag: 0.4.0" not in content
 
 
 def test_update_prod_image_strips_v_prefix(tmp_path: Path) -> None:
-    values_path = _write_values(tmp_path)
+    backend_path, _ = _write_all_values(tmp_path)
 
     subprocess.run(
         [sys.executable, str(SCRIPT_PATH), "v1.2.3", "--root", str(tmp_path)],
@@ -52,7 +72,24 @@ def test_update_prod_image_strips_v_prefix(tmp_path: Path) -> None:
         check=True,
     )
 
-    assert "tag: 1.2.3" in values_path.read_text(encoding="utf-8")
+    assert "tag: 1.2.3" in backend_path.read_text(encoding="utf-8")
+
+
+def test_update_prod_image_also_updates_web(tmp_path: Path) -> None:
+    """Ensure the web frontend values-prod.yaml is updated alongside the backend."""
+    _, web_path = _write_all_values(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "v0.5.0", "--root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    content = web_path.read_text(encoding="utf-8")
+    assert "tag: 0.5.0" in content
+    assert "tag: 0.4.0" not in content
 
 
 def test_update_prod_image_fails_when_file_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- `update_prod_image.py` previously only updated `deploy/treadstone/values-prod.yaml` (backend), leaving `deploy/treadstone-web/values-prod.yaml` (frontend) stale after every release.
- Both the backend (`ghcr.io/earayu/treadstone`) and frontend (`ghcr.io/earayu/treadstone-web`) images are published with the same semver tag in `release.yml`, so both `values-prod.yaml` files must be bumped together.
- The `update-prod-image.yml` workflow `git add` step was also missing the web values file.

## Changes
- `scripts/update_prod_image.py`: refactored to iterate over a list of `HELM_VALUES_PATHS`, updating both `deploy/treadstone/values-prod.yaml` and `deploy/treadstone-web/values-prod.yaml` in one run.
- `.github/workflows/update-prod-image.yml`: added `deploy/treadstone-web/values-prod.yaml` to the `git add` step.
- `tests/unit/test_update_prod_image.py`: added `test_update_prod_image_also_updates_web` to cover the previously missing frontend case.

## Test Plan
- [x] `make test` — 501 passed
- [x] `make lint` — all checks passed

Made with [Cursor](https://cursor.com)