### PR TITLE
chore: rename make build to image, add image-web for frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-hooks dev test test-unit test-api test-integration test-all test-e2e test-cov lint format migrate migration downgrade gen-openapi build clean ship bump release up down deploy-storage deploy-infra deploy-runtime deploy-app deploy-web deploy-all undeploy-storage undeploy-app undeploy-web undeploy-runtime undeploy-all restart-app kind-create kind-delete port-forward dev-web lint-web build-web
+.PHONY: help install install-hooks dev test test-unit test-api test-integration test-all test-e2e test-cov lint format migrate migration downgrade gen-openapi image image-web clean ship bump release up down deploy-storage deploy-infra deploy-runtime deploy-app deploy-web deploy-all undeploy-storage undeploy-app undeploy-web undeploy-runtime undeploy-all restart-app kind-create kind-delete port-forward dev-web lint-web build-web
 
 # ── Development ──────────────────────────────────────────────────────────────
 
@@ -91,10 +91,13 @@ lint-web: ## Lint and type-check frontend
 build-web: ## Build frontend for production
 	cd web && pnpm build
 
-# ── Build ────────────────────────────────────────────────────────────────────
+# ── Docker Images ────────────────────────────────────────────────────────────
 
-build: ## Build Docker image
+image: ## Build backend Docker image
 	docker build -t treadstone:latest .
+
+image-web: ## Build frontend Docker image
+	docker build -t treadstone-web:latest web/
 
 clean: ## Remove build artifacts and caches
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ make lint             # Lint check
 make format           # Auto-format
 make migrate          # Run database migrations
 make migration MSG=x  # Generate a new migration
-make build            # Build Docker image
+make image            # Build backend Docker image
+make image-web        # Build frontend Docker image
 make up               # Spin up local Kind cluster + deploy
 make down             # Tear down local environment
 ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -81,11 +81,13 @@ make kind-create
 
 The cluster configuration is located at `deploy/kind/kind-config.yaml`: 1 control-plane + 2 workers, with automatic port mapping for 80/443 and ingress-nginx installed.
 
-### 2. Build and Load Image (local only)
+### 2. Build and Load Images (local only)
 
 ```bash
-make build
+make image
 kind load docker-image treadstone:latest --name treadstone
+make image-web
+kind load docker-image treadstone-web:latest --name treadstone
 ```
 
 ### 3. Deploy All Helm Charts
@@ -204,8 +206,10 @@ curl -s -X DELETE $BASE_URL/v1/sandboxes/{sandbox_id} \
 
 ```bash
 # local environment
-make build
+make image
 kind load docker-image treadstone:latest --name treadstone
+make image-web
+kind load docker-image treadstone-web:latest --name treadstone
 make restart-app
 
 # Or run make up to redo the full flow
@@ -270,7 +274,8 @@ with the ACM certificate ARN for `api.treadstone-ai.dev`.
 make help              # List all available commands
 make kind-create       # Create Kind cluster
 make kind-delete       # Delete Kind cluster
-make build             # Build Docker image
+make image             # Build backend Docker image
+make image-web         # Build frontend Docker image
 make deploy-all        # Deploy all layers (infra + runtime + app)
 make deploy-app        # Deploy app only
 make restart-app       # Rolling restart

--- a/docs/zh-CN/design/2026-03-17-phase0-scaffolding.md
+++ b/docs/zh-CN/design/2026-03-17-phase0-scaffolding.md
@@ -449,7 +449,8 @@ docs/                # 设计文档和计划
   make format          # 自动格式化
   make migrate         # 运行数据库迁移
   make migration MSG=x # 生成新迁移
-  make build           # 构建 Docker 镜像
+  make image           # 构建后端 Docker 镜像
+  make image-web       # 构建前端 Docker 镜像
 
 ## Code Conventions
 

--- a/docs/zh-CN/design/2026-03-18-testing-ci-and-make-ship.md
+++ b/docs/zh-CN/design/2026-03-18-testing-ci-and-make-ship.md
@@ -409,7 +409,8 @@ make lint            # 代码检查
 make format          # 自动格式化
 make migrate         # 运行数据库迁移
 make migration MSG=x # 生成新迁移
-make build           # 构建 Docker 镜像
+make image           # 构建后端 Docker 镜像
+make image-web       # 构建前端 Docker 镜像
 make ship MSG=x      # AI 专用：add + commit + push（MSG 必填）
 ```
 ```

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -13,13 +13,13 @@ if [ "$ENV" = "local" ]; then
     bash "$SCRIPT_DIR/kind-setup.sh"
     echo ""
     echo "Building backend Docker image ..."
-    docker build -t treadstone:latest .
+    make image
     echo ""
     echo "Loading backend image into Kind cluster ..."
     kind load docker-image treadstone:latest --name "$CLUSTER_NAME"
     echo ""
     echo "Building frontend Docker image ..."
-    docker build -t treadstone-web:latest web/
+    make image-web
     echo ""
     echo "Loading frontend image into Kind cluster ..."
     kind load docker-image treadstone-web:latest --name "$CLUSTER_NAME"


### PR DESCRIPTION
## Summary

- Rename `make build` → `make image` (build backend Docker image)
- Add `make image-web` (build frontend Docker image, was missing)
- Keep `make build-web` as-is (compiles frontend static assets via `pnpm build`)

This fixes a naming inconsistency where `build` and `build-web` referred to completely different operations (Docker build vs pnpm build). The new naming follows the same pattern as other paired commands (`dev`/`dev-web`, `lint`/`lint-web`).

## Files Changed

- `Makefile` — rename target, add new target, update `.PHONY`
- `README.md` — update command reference table
- `deploy/README.md` — update build + load image instructions
- `docs/zh-CN/design/*.md` — update quick reference sections
- `scripts/up.sh` — use `make image` / `make image-web` instead of raw `docker build`

## Test Plan

- [x] `make lint` passes
- [x] `make test` passes

Made with [Cursor](https://cursor.com)