### PR TITLE
refactor: rename api_base_url to app_base_url to fix cross-domain OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,10 @@ TREADSTONE_DATABASE_URL=postgresql+asyncpg://user:password@ep-xxx.region.aws.neo
 
 # === App ===
 TREADSTONE_DEBUG=false
+# Public web-app origin used for browser auth (OAuth callbacks, sandbox bootstrap, CLI browser login).
 # Local ingress default. If you run `make dev` directly without ingress, use http://localhost:8000 instead.
-TREADSTONE_API_BASE_URL=http://localhost
+# Prod: https://app.treadstone-ai.dev (frontend nginx proxies /v1/ to the backend)
+TREADSTONE_APP_BASE_URL=http://localhost
 TREADSTONE_AUTH_TYPE=cookie
 TREADSTONE_SESSION_TTL_SECONDS=604800
 
@@ -13,11 +15,11 @@ TREADSTONE_SESSION_TTL_SECONDS=604800
 TREADSTONE_JWT_SECRET=CHANGE_ME_IN_PROD
 
 # === OAuth Social (leave empty to disable) ===
-# Register these callback URLs with each provider:
+# Register these callback URLs with each provider (must match TREADSTONE_APP_BASE_URL):
 #   Local ingress: http://localhost/v1/auth/google/callback and http://localhost/v1/auth/github/callback
 #   Local `make dev`: http://localhost:8000/v1/auth/google/callback and http://localhost:8000/v1/auth/github/callback
-#   Demo: https://demo.treadstone-ai.dev/v1/auth/google/callback and https://demo.treadstone-ai.dev/v1/auth/github/callback
-#   Prod: https://api.treadstone-ai.dev/v1/auth/google/callback and https://api.treadstone-ai.dev/v1/auth/github/callback
+#   Demo: https://app-demo.treadstone-ai.dev/v1/auth/google/callback and https://app-demo.treadstone-ai.dev/v1/auth/github/callback
+#   Prod: https://app.treadstone-ai.dev/v1/auth/google/callback and https://app.treadstone-ai.dev/v1/auth/github/callback
 TREADSTONE_GOOGLE_OAUTH_CLIENT_ID=
 TREADSTONE_GOOGLE_OAUTH_CLIENT_SECRET=
 TREADSTONE_GITHUB_OAUTH_CLIENT_ID=
@@ -43,8 +45,8 @@ TREADSTONE_CORS_ALLOWED_ORIGINS=["http://localhost:5173"]
 # Prod: "sandbox.example.com"  ->  {sandbox_id}.sandbox.example.com
 # Empty string disables subdomain routing.
 TREADSTONE_SANDBOX_DOMAIN=
-# Required when TREADSTONE_SANDBOX_DOMAIN is public/non-local.
-# Set this to the public API origin for the current environment.
+# Required when TREADSTONE_SANDBOX_DOMAIN is public/non-local:
+# TREADSTONE_APP_BASE_URL must be set to the public app origin.
 # Must match the K8s namespace for this environment (treadstone-local / treadstone-demo / treadstone-prod)
 TREADSTONE_SANDBOX_NAMESPACE=treadstone-local
 TREADSTONE_SANDBOX_PORT=8080

--- a/docs/zh-CN/modules/03-browser-handoff-and-data-plane.md
+++ b/docs/zh-CN/modules/03-browser-handoff-and-data-plane.md
@@ -118,9 +118,9 @@
 
 当 `sandbox_domain` 是公网域名而不是 `localhost` 变体时，代码会强制要求：
 
-- `TREADSTONE_API_BASE_URL` 必须是可公开访问的 API 根地址
+- `TREADSTONE_APP_BASE_URL` 必须是可公开访问的 Web App 地址（如 `https://app.treadstone-ai.dev`）
 
-这是为了让浏览器跳转和 OAuth callback 都能返回正确地址。
+这是为了让浏览器跳转和 OAuth callback 都能返回正确地址，且 cookie 保持在同一个域名上。
 
 ## 6. 当前实现现状
 

--- a/tests/api/test_cli_auth_api.py
+++ b/tests/api/test_cli_auth_api.py
@@ -72,7 +72,7 @@ async def _create_flow(http_client: AsyncClient) -> dict:
 
 @pytest.mark.asyncio
 async def test_create_flow_returns_flow_data(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         data = await _create_flow(http_client)
 
@@ -83,7 +83,7 @@ async def test_create_flow_returns_flow_data(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_poll_flow_pending(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         flow = await _create_flow(http_client)
         resp = await http_client.get(
@@ -97,7 +97,7 @@ async def test_poll_flow_pending(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_poll_flow_wrong_secret_returns_401(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         flow = await _create_flow(http_client)
         resp = await http_client.get(
@@ -110,7 +110,7 @@ async def test_poll_flow_wrong_secret_returns_401(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_poll_flow_missing_secret_returns_401(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         flow = await _create_flow(http_client)
         resp = await http_client.get(f"/v1/auth/cli/flows/{flow['flow_id']}/status")
@@ -120,7 +120,7 @@ async def test_poll_flow_missing_secret_returns_401(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_email_login_approves_flow_and_exchange_returns_session(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         await _register_user(http_client)
         flow = await _create_flow(http_client)
@@ -148,7 +148,7 @@ async def test_email_login_approves_flow_and_exchange_returns_session(db_session
 
 @pytest.mark.asyncio
 async def test_exchange_marks_flow_as_used(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         await _register_user(http_client)
         flow = await _create_flow(http_client)
@@ -167,7 +167,7 @@ async def test_exchange_marks_flow_as_used(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_exchange_pending_flow_returns_error(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         flow = await _create_flow(http_client)
 
@@ -181,7 +181,7 @@ async def test_exchange_pending_flow_returns_error(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_expired_flow_returns_expired_status(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         flow = await _create_flow(http_client)
 
@@ -201,7 +201,7 @@ async def test_expired_flow_returns_expired_status(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cli_login_page_renders(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         flow = await _create_flow(http_client)
         resp = await http_client.get(f"/v1/auth/cli/login?flow_id={flow['flow_id']}")
@@ -213,7 +213,7 @@ async def test_cli_login_page_renders(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cli_login_page_with_oauth_buttons(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     monkeypatch.setattr(login_page_service, "get_google_oauth_client", lambda: SimpleNamespace(name="google"))
     monkeypatch.setattr(login_page_service, "get_github_oauth_client", lambda: SimpleNamespace(name="github"))
 
@@ -229,7 +229,7 @@ async def test_cli_login_page_with_oauth_buttons(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_email_login_wrong_password_re_renders_page(db_session, monkeypatch):
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         await _register_user(http_client)
         flow = await _create_flow(http_client)
@@ -246,8 +246,8 @@ async def test_email_login_wrong_password_re_renders_page(db_session, monkeypatc
 @pytest.mark.asyncio
 async def test_oauth_callback_approves_cli_flow(db_session, monkeypatch):
     """Google OAuth callback with cli_flow_id approves the flow and renders CLI success page."""
-    monkeypatch.setattr(auth_api.settings, "api_base_url", "http://test")
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
 
     from tests.api.test_oauth_api import FakeOAuthClient
 
@@ -292,7 +292,7 @@ async def test_oauth_callback_approves_cli_flow(db_session, monkeypatch):
 @pytest.mark.asyncio
 async def test_session_token_from_exchange_is_valid(db_session, monkeypatch):
     """Session token from CLI flow exchange can be used to call authenticated endpoints."""
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
         await _register_user(http_client)
         flow = await _create_flow(http_client)
@@ -319,8 +319,8 @@ async def test_session_token_from_exchange_is_valid(db_session, monkeypatch):
 @pytest.mark.asyncio
 async def test_oauth_callback_with_expired_flow_does_not_create_user(db_session, monkeypatch):
     """P1 regression: expired CLI flow must reject BEFORE creating user/OAuthAccount."""
-    monkeypatch.setattr(auth_api.settings, "api_base_url", "http://test")
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
 
     from tests.api.test_oauth_api import FakeOAuthClient
 
@@ -360,8 +360,8 @@ async def test_oauth_callback_with_expired_flow_does_not_create_user(db_session,
 @pytest.mark.asyncio
 async def test_oauth_access_denied_marks_cli_flow_as_failed(db_session, monkeypatch):
     """P2 regression: provider deny must mark CLI flow as failed so CLI stops polling."""
-    monkeypatch.setattr(auth_api.settings, "api_base_url", "http://test")
-    monkeypatch.setattr(cli_auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
+    monkeypatch.setattr(cli_auth_api.settings, "app_base_url", "http://test")
 
     from tests.api.test_oauth_api import FakeOAuthClient
 

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -96,7 +96,7 @@ def _extract_state(location: str) -> str:
 
 
 def _enable_browser_flow(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
     monkeypatch.setattr(auth_api.settings, "sandbox_domain", "sandbox.localhost")
     monkeypatch.setattr(browser_login_service.settings, "sandbox_domain", "sandbox.localhost")
 
@@ -126,7 +126,7 @@ async def test_google_authorize_redirects_to_provider_and_sets_flow_cookies(db_s
 
 @pytest.mark.asyncio
 async def test_google_callback_creates_user_and_sets_session_cookie(db_session, monkeypatch):
-    monkeypatch.setattr(auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
     client = FakeOAuthClient("google", account_id="acct-new", account_email="new@example.com")
     monkeypatch.setattr(auth_api, "get_google_oauth_client", lambda: client, raising=False)
 
@@ -156,7 +156,7 @@ async def test_google_callback_creates_user_and_sets_session_cookie(db_session, 
 
 @pytest.mark.asyncio
 async def test_google_callback_auto_links_existing_user_by_email(db_session, monkeypatch):
-    monkeypatch.setattr(auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
     client = FakeOAuthClient("google", account_id="acct-link", account_email="existing@example.com")
     monkeypatch.setattr(auth_api, "get_google_oauth_client", lambda: client, raising=False)
 
@@ -223,7 +223,7 @@ async def test_google_callback_provider_denied_redirects_back_to_browser_login(d
 
 @pytest.mark.asyncio
 async def test_google_callback_invalid_state_returns_treadstone_error(db_session, monkeypatch):
-    monkeypatch.setattr(auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
     client = FakeOAuthClient("google")
     monkeypatch.setattr(auth_api, "get_google_oauth_client", lambda: client, raising=False)
 
@@ -239,7 +239,7 @@ async def test_google_callback_invalid_state_returns_treadstone_error(db_session
 
 @pytest.mark.asyncio
 async def test_github_callback_rejects_unverified_email_and_does_not_link_existing_user(db_session, monkeypatch):
-    monkeypatch.setattr(auth_api.settings, "api_base_url", "http://test")
+    monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
     client = FakeGitHubOAuthClient(
         account_id="gh-unverified",
         account_email="existing@example.com",

--- a/tests/api/test_sandbox_subdomain_api.py
+++ b/tests/api/test_sandbox_subdomain_api.py
@@ -60,7 +60,7 @@ async def db_session():
 
 @pytest.fixture
 async def auth_client(db_session):
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="https://api.localhost") as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="https://app.localhost") as client:
         await client.post("/v1/auth/register", json={"email": "sandbox@test.com", "password": "Pass123!"})
         await client.post("/v1/auth/login", json={"email": "sandbox@test.com", "password": "Pass123!"})
         yield client
@@ -91,12 +91,12 @@ def _capture_mock():
     return mock_client, captured
 
 
-def _enable_subdomain(monkeypatch, domain: str = "sandbox.localhost", api_base_url: str = "https://api.localhost"):
+def _enable_subdomain(monkeypatch, domain: str = "sandbox.localhost", app_base_url: str = "https://app.localhost"):
     monkeypatch.setenv("TREADSTONE_SANDBOX_DOMAIN", domain)
     monkeypatch.setenv("TREADSTONE_SANDBOX_SUBDOMAIN_PREFIX", "sandbox-")
     monkeypatch.setenv("TREADSTONE_SANDBOX_NAMESPACE", "default")
     monkeypatch.setenv("TREADSTONE_SANDBOX_PORT", "8080")
-    monkeypatch.setenv("TREADSTONE_API_BASE_URL", api_base_url)
+    monkeypatch.setenv("TREADSTONE_APP_BASE_URL", app_base_url)
     monkeypatch.setenv("TREADSTONE_JWT_SECRET", "test-jwt-secret-should-be-32-bytes!")
     from treadstone.config import Settings
 
@@ -155,7 +155,7 @@ class TestSubdomainRouting:
         assert resp.status_code == 303
         location = resp.headers["location"]
         parsed = urlparse(location)
-        assert parsed.netloc == "api.localhost"
+        assert parsed.netloc == "app.localhost"
         assert parsed.path == "/v1/browser/bootstrap"
         assert parse_qs(parsed.query)["return_to"] == [f"https://sandbox-{sandbox_id}.sandbox.localhost/"]
 
@@ -203,7 +203,7 @@ class TestSubdomainRouting:
         mock_client, _ = _capture_mock()
         with patch("treadstone.services.sandbox_proxy._http_client", mock_client):
             with patch("treadstone.middleware.sandbox_subdomain.get_http_client", return_value=mock_client):
-                async with AsyncClient(transport=ASGITransport(app=app), base_url="https://api.localhost") as client:
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="https://app.localhost") as client:
                     resp = await client.get(open_link, follow_redirects=True)
                     followup = await client.get(
                         f"https://sandbox-{sandbox_id}.sandbox.localhost/",
@@ -237,7 +237,7 @@ class TestSubdomainRouting:
 
         assert first == second
 
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="https://api.localhost") as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="https://app.localhost") as client:
             first_resp = await client.get(first, follow_redirects=False)
             second_resp = await client.get(second, follow_redirects=False)
 
@@ -252,7 +252,7 @@ class TestSubdomainRouting:
         delete_resp = await auth_client.delete(f"/v1/sandboxes/{sandbox_id}/web-link")
         status_resp = await auth_client.get(f"/v1/sandboxes/{sandbox_id}/web-link")
 
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="https://api.localhost") as browser:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="https://app.localhost") as browser:
             open_resp = await browser.get(open_link, follow_redirects=False)
 
         assert delete_resp.status_code == 204
@@ -279,7 +279,7 @@ class TestSubdomainRouting:
         second_resp = await auth_client.post(f"/v1/sandboxes/{sandbox_id}/web-link")
         second_link = second_resp.json()["open_link"]
 
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="https://api.localhost") as browser:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="https://app.localhost") as browser:
             first_open = await browser.get(first_link, follow_redirects=False)
             second_open = await browser.get(second_link, follow_redirects=False)
 
@@ -294,7 +294,7 @@ class TestSubdomainRouting:
         sandbox_id = await _create_ready_sandbox(auth_client)
         first_link = (await auth_client.post(f"/v1/sandboxes/{sandbox_id}/web-link")).json()["open_link"]
 
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="https://api.localhost") as browser:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="https://app.localhost") as browser:
             await browser.get(first_link, follow_redirects=False)
 
         first_status = await auth_client.get(f"/v1/sandboxes/{sandbox_id}/web-link")
@@ -312,7 +312,7 @@ class TestSubdomainRouting:
         sandbox_id = await _create_ready_sandbox(auth_client)
         mock_client, _ = _capture_mock()
 
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="https://api.localhost") as browser:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="https://app.localhost") as browser:
             first = await browser.get(f"https://sandbox-{sandbox_id}.sandbox.localhost/", follow_redirects=False)
             bootstrap_url = first.headers["location"]
             bootstrap = await browser.get(bootstrap_url, follow_redirects=False)
@@ -323,7 +323,7 @@ class TestSubdomainRouting:
             with patch("treadstone.services.sandbox_proxy._http_client", mock_client):
                 with patch("treadstone.middleware.sandbox_subdomain.get_http_client", return_value=mock_client):
                     final = await browser.post(
-                        "https://api.localhost/v1/browser/login",
+                        "https://app.localhost/v1/browser/login",
                         data={
                             "email": "sandbox@test.com",
                             "password": "Pass123!",

--- a/tests/api/test_sandboxes_api.py
+++ b/tests/api/test_sandboxes_api.py
@@ -66,12 +66,12 @@ async def second_auth_client(db_session):
         yield client
 
 
-def _enable_subdomain(monkeypatch, domain: str = "sandbox.localhost", api_base_url: str = "http://test"):
+def _enable_subdomain(monkeypatch, domain: str = "sandbox.localhost", app_base_url: str = "http://test"):
     monkeypatch.setenv("TREADSTONE_SANDBOX_DOMAIN", domain)
     monkeypatch.setenv("TREADSTONE_SANDBOX_SUBDOMAIN_PREFIX", "sandbox-")
     monkeypatch.setenv("TREADSTONE_SANDBOX_NAMESPACE", "default")
     monkeypatch.setenv("TREADSTONE_SANDBOX_PORT", "8080")
-    monkeypatch.setenv("TREADSTONE_API_BASE_URL", api_base_url)
+    monkeypatch.setenv("TREADSTONE_APP_BASE_URL", app_base_url)
     monkeypatch.setenv("TREADSTONE_JWT_SECRET", "test-jwt-secret-should-be-32-bytes!")
     from treadstone.config import Settings
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,9 +17,9 @@ def test_settings_override():
     assert s.debug is True
 
 
-def test_settings_api_base_url_default():
+def test_settings_app_base_url_default():
     s = Settings(_env_file=None, database_url=DB_URL)
-    assert s.api_base_url == "http://localhost"
+    assert s.app_base_url == "http://localhost"
 
 
 def test_auth_defaults():
@@ -85,20 +85,20 @@ def test_validate_runtime_settings_allows_public_sandbox_domain():
         database_url=DB_URL,
         jwt_secret="x" * 32,
         sandbox_domain="treadstone-ai.dev",
-        api_base_url="https://api.treadstone-ai.dev",
+        app_base_url="https://app.treadstone-ai.dev",
     )
     validate_runtime_settings(s)
 
 
-def test_validate_runtime_settings_rejects_public_sandbox_domain_with_local_api_base_url():
+def test_validate_runtime_settings_rejects_public_sandbox_domain_with_local_app_base_url():
     s = Settings(
         _env_file=None,
         database_url=DB_URL,
         jwt_secret="x" * 32,
         sandbox_domain="treadstone-ai.dev",
-        api_base_url="http://localhost:8000",
+        app_base_url="http://localhost:8000",
     )
-    with pytest.raises(RuntimeError, match="TREADSTONE_API_BASE_URL"):
+    with pytest.raises(RuntimeError, match="TREADSTONE_APP_BASE_URL"):
         validate_runtime_settings(s)
 
 

--- a/treadstone/api/auth.py
+++ b/treadstone/api/auth.py
@@ -73,7 +73,7 @@ def _oauth_return_to_cookie_name(provider: str) -> str:
 
 
 def _oauth_callback_url(provider: str) -> str:
-    return f"{settings.api_base_url.rstrip('/')}/v1/auth/{provider}/callback"
+    return f"{settings.app_base_url.rstrip('/')}/v1/auth/{provider}/callback"
 
 
 def _oauth_state_payload(provider: str, csrf_token: str, return_to: str | None, cli_flow_id: str | None = None) -> str:

--- a/treadstone/api/cli_auth.py
+++ b/treadstone/api/cli_auth.py
@@ -83,7 +83,7 @@ async def create_cli_flow(session: AsyncSession = Depends(get_session)):
     await session.commit()
     await session.refresh(flow)
 
-    browser_url = f"{settings.api_base_url.rstrip('/')}/v1/auth/cli/login?flow_id={flow.id}"
+    browser_url = f"{settings.app_base_url.rstrip('/')}/v1/auth/cli/login?flow_id={flow.id}"
     return {
         "flow_id": flow.id,
         "flow_secret": raw_secret,

--- a/treadstone/config.py
+++ b/treadstone/config.py
@@ -13,8 +13,11 @@ class Settings(BaseSettings):
     app_name: str = "treadstone"
     debug: bool = False
     database_url: str = "postgresql+asyncpg://user:pass@ep-xxx.us-east-2.aws.neon.tech/treadstone?sslmode=require"
-    # Public API origin used in browser bootstrap redirects and public sandbox Web UI flows.
-    api_base_url: str = "http://localhost"
+    # Public web-app origin used for browser auth flows (OAuth callbacks, sandbox
+    # bootstrap redirects, CLI browser login).  In production this should point to
+    # the frontend domain (e.g. https://app.treadstone-ai.dev) whose nginx reverse-
+    # proxies /v1/ to the backend, so that cookies stay on a single host.
+    app_base_url: str = "http://localhost"
 
     # Auth
     auth_type: str = "cookie"  # cookie | auth0 | authing | logto | none
@@ -103,9 +106,9 @@ def validate_runtime_settings(cfg: Settings) -> None:
         )
 
     if cfg.sandbox_domain and not is_local_sandbox_domain(cfg.sandbox_domain):
-        parsed = urlparse(cfg.api_base_url)
+        parsed = urlparse(cfg.app_base_url)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc or is_local_hostname(parsed.hostname):
             raise RuntimeError(
-                "TREADSTONE_API_BASE_URL must be set to the public API origin "
-                "when sandbox Web UI subdomains are enabled."
+                "TREADSTONE_APP_BASE_URL must be set to the public app origin "
+                "(e.g. https://app.treadstone-ai.dev) when sandbox Web UI subdomains are enabled."
             )

--- a/treadstone/core/users.py
+++ b/treadstone/core/users.py
@@ -18,7 +18,7 @@ COOKIE_MAX_AGE = settings.session_ttl_seconds
 
 
 def should_use_secure_cookies() -> bool:
-    return not settings.debug and urlparse(settings.api_base_url).scheme == "https"
+    return not settings.debug and urlparse(settings.app_base_url).scheme == "https"
 
 
 def get_google_oauth_client() -> GoogleOAuth2 | None:

--- a/treadstone/middleware/sandbox_subdomain.py
+++ b/treadstone/middleware/sandbox_subdomain.py
@@ -152,7 +152,7 @@ class SandboxSubdomainMiddleware:
 
     def _build_bootstrap_redirect(self, scope: Scope, host: str) -> str:
         return_to = self._build_return_to(scope, host)
-        return f"{settings.api_base_url.rstrip('/')}/v1/browser/bootstrap?{urlencode({'return_to': return_to})}"
+        return f"{settings.app_base_url.rstrip('/')}/v1/browser/bootstrap?{urlencode({'return_to': return_to})}"
 
     @staticmethod
     def _set_sandbox_cookie(response: Response, sandbox_id: str, issued_via: str) -> None:


### PR DESCRIPTION
## Summary

- Rename config field `api_base_url` → `app_base_url` (env var `TREADSTONE_API_BASE_URL` → `TREADSTONE_APP_BASE_URL`)
- Fix cross-domain cookie loss that broke OAuth login, sandbox bootstrap, and CLI browser login in production

## Root Cause

`TREADSTONE_API_BASE_URL` was set to `https://api.treadstone-ai.dev`, but all browser auth flows originate from `https://app.treadstone-ai.dev`. Since cookies are host-only (no `Domain` attribute), CSRF cookies set during OAuth authorize on `app.` were absent when Google's callback arrived at `api.` — causing `"Invalid OAuth state."`.

The same cross-domain issue broke sandbox bootstrap (redirect to `api.` where `session` cookie is absent) and CLI browser login URL generation.

## Fix

Point `app_base_url` at the frontend domain (`https://app.treadstone-ai.dev`). The frontend nginx already proxies all `/v1/` requests to the backend, so OAuth callbacks, bootstrap redirects, and login pages all land on the correct host where cookies exist.

## Deployment Steps (after merge)

1. Update K8s secret: rename `TREADSTONE_API_BASE_URL` → `TREADSTONE_APP_BASE_URL=https://app.treadstone-ai.dev`
2. Google OAuth Console: update redirect URI to `https://app.treadstone-ai.dev/v1/auth/google/callback`
3. GitHub OAuth App: update callback URL to `https://app.treadstone-ai.dev/v1/auth/github/callback`

## Test Plan

- [x] `make test` — 506 passed, 0 failed
- [x] `make lint` — all checks passed
- [x] Code review passed (no critical/important issues)

Made with [Cursor](https://cursor.com)