### PR TITLE
chore: bump version to 0.5.5

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.5.4"
+version = "0.5.5"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.5.4"
+version = "0.5.5"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.5.4"
+version = "0.5.5"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1850,7 +1850,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "treadstone-web",
   "private": true,
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/app-version.ts
+++ b/web/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.4";
+export const APP_VERSION = "0.5.5";


### PR DESCRIPTION
## Summary

- Bump version to 0.5.5 across server, CLI, SDK, and web

## Release Notes

This release renames the `TREADSTONE_API_BASE_URL` environment variable to `TREADSTONE_APP_BASE_URL` to fix cross-domain OAuth login failures in production. See PR #114 for details.

## Test Plan

- [x] `make bump V=0.5.5` succeeded
- CI will validate build and tests

Made with [Cursor](https://cursor.com)