### PR TITLE
[codex] refactor make task names for api and web

### DIFF
--- a/.agents/skills/dev-lifecycle/SKILL.md
+++ b/.agents/skills/dev-lifecycle/SKILL.md
@@ -93,7 +93,7 @@ If CI fails:
 ```bash
 gh run view <run-id> --log-failed   # inspect failure
 make test                           # reproduce locally
-make lint                           # check formatting
+make lint                           # run repo lint checks
 ```
 
 Fix, then `make ship MSG="fix: ..."` to push the fix.

--- a/.agents/skills/dev-setup/SKILL.md
+++ b/.agents/skills/dev-setup/SKILL.md
@@ -29,19 +29,19 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 brew install kind kubectl helm hurl
 ```
 
-## 2. Install Python Dependencies
+## 2. Install Repo Dependencies
 
 ```bash
 make install
 ```
 
-This runs `uv sync` (creates `.venv`, installs all deps) and configures git hooks.
+This installs Python dependencies with `uv`, installs web dependencies with `pnpm`, and configures git hooks.
 
 ## 3. Configure Database (Neon)
 
 The project uses [Neon](https://neon.tech) Serverless PostgreSQL — no local Postgres needed.
 
-For local API development (`make dev`), start from:
+For local API development (`make dev-api`), start from:
 
 ```bash
 cp .env.example .env
@@ -89,7 +89,7 @@ Expected: all tests pass (integration tests are excluded by default). If tests p
 Optional API sanity check:
 
 ```bash
-make dev
+make dev-api
 # In another terminal:
 curl http://localhost:8000/health
 ```
@@ -105,7 +105,7 @@ make up   # One-command: Kind cluster + build + deploy
 make test-e2e
 ```
 
-Pure API development (`make dev`) does not require a K8s cluster.
+Pure API development (`make dev-api`) does not require a K8s cluster.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: uv sync --frozen
       - name: Lint check
-        run: make lint
+        run: make lint-py
 
   test:
     runs-on: ubuntu-latest
@@ -65,9 +65,6 @@ jobs:
 
   web-check:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -78,8 +75,8 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
+      - run: make install-web
       - name: Lint
-        run: pnpm lint
+        run: make lint-web
       - name: Type-check and build
-        run: pnpm build
+        run: make build-web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
       - run: uv sync --frozen
-      - run: make lint
+      - run: make lint-py
 
   test:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ Skills live under `.agents/skills/*/SKILL.md`. AGENTS.md defines repo facts and 
 
 - Python 3.12+, FastAPI, Uvicorn, SQLAlchemy (async), asyncpg
 - Database: Neon (Serverless PostgreSQL)
-- Package manager: uv
-- Linter/formatter: ruff
+- Package managers: uv (Python), pnpm (web)
+- Lint/format: ruff (Python), ESLint (web)
 - Testing: pytest + pytest-asyncio + httpx; Hurl for E2E
 - Containerization: Docker
 - Orchestration: Kubernetes (Kind for dev, GKE/EKS/AKS for prod)
@@ -97,7 +97,7 @@ Rules:
 - SQLAlchemy async engine + asyncpg driver.
 - Alembic migrations (Alembic uses a sync URL — `env.py` strips `+asyncpg` automatically).
 - All connection strings must include `?sslmode=require`.
-- For local `make dev`, use `.env`. For Kubernetes deployment, use `.env.<ENV>` such as `.env.local`.
+- For local `make dev-api`, use `.env`. For Kubernetes deployment, use `.env.<ENV>` such as `.env.local`.
 - For model design conventions and the migration workflow, see the `database-migration` skill.
 
 ## Testing
@@ -155,14 +155,17 @@ Run `make help` for the full list. Key commands:
 
 | Command | Purpose |
 |---------|---------|
-| `make dev` | Start dev server (localhost:8000, hot reload) |
+| `make install` | Install Python/web dependencies and git hooks |
+| `make dev-api` | Start API dev server (localhost:8000, hot reload) |
+| `make dev-web` | Start web dev server (localhost:5173, hot reload) |
 | `make test` | Run tests (excludes integration) |
 | `make test-all` | Run all tests including integration |
 | `make test-e2e` | Run E2E tests against deployed cluster |
-| `make lint` / `make format` | Lint check / auto-format |
+| `make lint` / `make format-py` | Repo lint checks / Python auto-format |
 | `make migrate` | Apply database migrations |
 | `make migration MSG=x` | Generate a new Alembic migration |
 | `make gen-openapi` | Export `openapi.json` from the FastAPI app |
+| `make gen-web-types` / `make gen-sdk-python` | Generate client artifacts from OpenAPI |
 | `make up` / `make down` | Full K8s environment up/down (see `deploy/README.md`) |
 | `make ship MSG=x` | git add + commit + push (feature branches only) |
 | `make bump V=x.y.z` | Bump version files, commit + push (feature branches only) |

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,52 @@
-.PHONY: help install install-hooks dev test test-unit test-api test-integration test-all test-e2e test-cov lint format migrate migration downgrade gen-openapi image image-web clean ship bump release up down deploy-storage deploy-infra deploy-runtime deploy-app deploy-web deploy-all undeploy-storage undeploy-app undeploy-web undeploy-runtime undeploy-all restart-app kind-create kind-delete port-forward dev-web lint-web build-web
+.PHONY: \
+	help \
+	install install-py install-web install-hooks \
+	dev-api dev-web \
+	test test-unit test-api test-integration test-all test-e2e test-cov \
+	lint lint-py lint-web format-py \
+	migrate migration downgrade \
+	gen-openapi gen-web-types gen-sdk-python gen-clients \
+	build-web \
+	image-api image-web \
+	clean clean-py clean-web \
+	deploy-storage deploy-infra deploy-runtime deploy-api deploy-web deploy-all \
+	undeploy-storage undeploy-infra undeploy-runtime undeploy-api undeploy-web undeploy-env \
+	restart-api port-forward-api \
+	up down kind-create kind-delete \
+	ship bump release
 
 # ── Development ──────────────────────────────────────────────────────────────
 
 help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-install: install-hooks ## Install dependencies (first time setup)
+install: install-py install-web install-hooks ## Install repo dependencies and hooks (first time setup)
+
+install-py: ## Install Python dependencies
 	uv sync
 	@echo "✓ Dependencies installed. Copy .env.example to .env and fill in your Neon connection string."
+
+install-web: ## Install web dependencies
+	cd web && pnpm install --frozen-lockfile
 
 install-hooks: ## Install git hooks (auto-called by install)
 	git config core.hooksPath .githooks
 	@echo "✓ Git hooks installed (.githooks/)"
 
-dev: ## Start local dev server with hot reload
+dev-api: ## Start local API dev server with hot reload
 	uv run uvicorn treadstone.main:app --reload --host 0.0.0.0 --port 8000
 
 # ── Code Quality ─────────────────────────────────────────────────────────────
 
-lint: ## Run linter and formatter check
+lint: lint-py lint-web ## Run all lint checks
+
+lint-py: ## Run Python lint and format checks
 	uv run ruff check treadstone/ tests/
 	uv run ruff format --check treadstone/ tests/
 	uv run ruff check --config cli/pyproject.toml cli/treadstone_cli/
 	uv run ruff format --check --config cli/pyproject.toml cli/treadstone_cli/
 
-format: ## Auto-format code
+format-py: ## Auto-format Python code
 	uv run ruff check --fix treadstone/ tests/
 	uv run ruff format treadstone/ tests/
 	uv run ruff check --fix --config cli/pyproject.toml cli/treadstone_cli/
@@ -70,22 +92,24 @@ downgrade: ## Rollback last migration
 gen-openapi: ## Export openapi.json from FastAPI app (no server needed)
 	uv run python scripts/export_openapi.py
 
-gen-ts-types: gen-openapi ## Generate TypeScript types from OpenAPI spec
+gen-web-types: gen-openapi ## Generate web TypeScript types from OpenAPI spec
 	cd web && npx openapi-typescript ../openapi.json -o src/api/schema.d.ts
 
-gen-sdk: gen-openapi ## Generate Python SDK from OpenAPI spec
+gen-sdk-python: gen-openapi ## Generate Python SDK from OpenAPI spec
 	openapi-python-client generate \
 		--path openapi.json \
 		--config openapi-client-config.yaml \
 		--output-path sdk/python \
 		--overwrite
 
+gen-clients: gen-web-types gen-sdk-python ## Generate all client artifacts
+
 # ── Web Frontend ─────────────────────────────────────────────────────────────
 
 dev-web: ## Start Vite dev server (localhost:5173, hot reload)
 	cd web && pnpm dev
 
-lint-web: ## Lint and type-check frontend
+lint-web: ## Run frontend lint checks
 	cd web && pnpm lint
 
 build-web: ## Build frontend for production
@@ -93,17 +117,22 @@ build-web: ## Build frontend for production
 
 # ── Docker Images ────────────────────────────────────────────────────────────
 
-image: ## Build backend Docker image
+image-api: ## Build API Docker image
 	docker build -t treadstone:latest .
 
 image-web: ## Build frontend Docker image
 	docker build -t treadstone-web:latest web/
 
-clean: ## Remove build artifacts and caches
+clean: clean-py clean-web ## Remove build artifacts and caches
+
+clean-py: ## Remove Python build artifacts and caches
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name .ruff_cache -exec rm -rf {} + 2>/dev/null || true
 	rm -rf dist/ build/ *.egg-info/ htmlcov/
+
+clean-web: ## Remove web build artifacts
+	rm -rf web/dist web/.vite
 
 # ── Deploy (Helm) ────────────────────────────────────────────────────────────
 
@@ -115,7 +144,7 @@ CLUSTER_PROFILE ?= $(if $(filter local,$(ENV)),local,ack)
 # Every environment gets its own namespace and Helm release name:
 # local → treadstone-local, demo → treadstone-demo, prod → treadstone-prod
 NS              := treadstone-$(ENV)
-APP_RELEASE     := treadstone-$(ENV)
+API_RELEASE     := treadstone-$(ENV)
 WEB_RELEASE     := treadstone-web-$(ENV)
 RT_RELEASE      := sandbox-runtime-$(ENV)
 STORAGE_NS      := cluster-storage-system
@@ -136,7 +165,7 @@ deploy-runtime: ## Deploy sandbox templates + warmpool
 		-n $(NS) -f deploy/sandbox-runtime/values-$(ENV).yaml \
 		--create-namespace
 
-deploy-app: ## Deploy Treadstone application (creates K8s secret from .env.<ENV>)
+deploy-api: ## Deploy Treadstone API service (creates K8s secret from .env.<ENV>)
 	@ENV_FILE=".env.$(ENV)"; \
 	if [ ! -f "$$ENV_FILE" ]; then \
 		echo "Error: $$ENV_FILE not found. Run: cp .env.example .env.$(ENV)"; \
@@ -147,7 +176,7 @@ deploy-app: ## Deploy Treadstone application (creates K8s secret from .env.<ENV>
 		-n $(NS) \
 		--from-env-file="$$ENV_FILE" \
 		--dry-run=client -o yaml | kubectl apply -f -
-	helm upgrade --install $(APP_RELEASE) deploy/treadstone \
+	helm upgrade --install $(API_RELEASE) deploy/treadstone \
 		-n $(NS) -f deploy/treadstone/values-$(ENV).yaml \
 		--create-namespace
 
@@ -156,19 +185,22 @@ deploy-web: ## Deploy Treadstone Web UI frontend
 		-n $(NS) -f deploy/treadstone-web/values-$(ENV).yaml \
 		--create-namespace
 
-deploy-all: deploy-storage deploy-infra deploy-runtime deploy-app deploy-web ## Deploy everything (storage → infra → runtime → app → web)
+deploy-all: deploy-storage deploy-infra deploy-runtime deploy-api deploy-web ## Deploy all layers (storage → infra → runtime → api → web)
 
-restart-app: ## Rolling restart to pick up new env vars
-	kubectl rollout restart deployment/$(APP_RELEASE)-treadstone -n $(NS)
+restart-api: ## Rolling restart for the API deployment
+	kubectl rollout restart deployment/$(API_RELEASE)-treadstone -n $(NS)
 
-port-forward: ## Port-forward treadstone service to localhost:8000
-	kubectl -n $(NS) port-forward svc/$(APP_RELEASE)-treadstone 8000:8000
+port-forward-api: ## Port-forward the API service to localhost:8000
+	kubectl -n $(NS) port-forward svc/$(API_RELEASE)-treadstone 8000:8000
 
 undeploy-storage: ## Undeploy cluster-scoped storage aliases (use with care on shared clusters)
 	helm uninstall $(STORAGE_RELEASE) -n $(STORAGE_NS) 2>/dev/null || true
 
-undeploy-app: ## Undeploy Treadstone application
-	helm uninstall $(APP_RELEASE) -n $(NS) 2>/dev/null || true
+undeploy-infra: ## Undeploy agent-sandbox controller
+	helm uninstall agent-sandbox 2>/dev/null || true
+
+undeploy-api: ## Undeploy Treadstone API service
+	helm uninstall $(API_RELEASE) -n $(NS) 2>/dev/null || true
 
 undeploy-web: ## Undeploy Treadstone Web UI frontend
 	helm uninstall $(WEB_RELEASE) -n $(NS) 2>/dev/null || true
@@ -176,7 +208,7 @@ undeploy-web: ## Undeploy Treadstone Web UI frontend
 undeploy-runtime: ## Undeploy sandbox runtime
 	helm uninstall $(RT_RELEASE) -n $(NS) 2>/dev/null || true
 
-undeploy-all: undeploy-app undeploy-web undeploy-runtime ## Undeploy app + web + runtime (keeps shared infra + storage)
+undeploy-env: undeploy-api undeploy-web undeploy-runtime ## Undeploy namespace-scoped layers (keeps shared infra + storage)
 	@echo "Note: agent-sandbox controller and cluster-storage are left in place."
 	@echo "Remove manually only if the cluster is dedicated to Treadstone."
 

--- a/README.md
+++ b/README.md
@@ -185,13 +185,15 @@ Current Chinese module documentation is available in [docs/zh-CN/README.md](docs
 
 ```bash
 make help             # Show all available commands
-make dev              # Start local dev server (hot reload)
+make install          # Install Python/web dependencies and git hooks
+make dev-api          # Start local API dev server (hot reload)
+make dev-web          # Start local web dev server
 make test             # Run tests
-make lint             # Lint check
-make format           # Auto-format
+make lint             # Run Python + web lint checks
+make format-py        # Auto-format Python code
 make migrate          # Run database migrations
 make migration MSG=x  # Generate a new migration
-make image            # Build backend Docker image
+make image-api        # Build API Docker image
 make image-web        # Build frontend Docker image
 make up               # Spin up local Kind cluster + deploy
 make down             # Tear down local environment

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,16 +4,17 @@ This document describes how to deploy Treadstone to Kubernetes and perform basic
 
 ## Architecture Overview
 
-The deployment consists of four layers of Helm charts, ordered by dependency from bottom to top:
+The deployment consists of five layers of Helm charts, ordered by dependency from bottom to top:
 
 | Layer | Chart | Description |
 |-------|-------|-------------|
 | Storage | `deploy/cluster-storage` | Cluster-scoped StorageClass aliases for persistent sandbox workspaces |
 | Infra | `deploy/agent-sandbox` | Sandbox CRD + controller (cluster-scoped, deploy once) |
 | Runtime | `deploy/sandbox-runtime` | SandboxTemplate + WarmPool (namespace-scoped) |
-| App | `deploy/treadstone` | FastAPI application + Ingress + RBAC + Migration Job |
+| API | `deploy/treadstone` | FastAPI API service + Ingress + RBAC + Migration Job |
+| Web | `deploy/treadstone-web` | React web frontend + Service + Ingress |
 
-The app/runtime layers use the `ENV` variable (`local`, `demo`, `prod`). Cluster storage uses `CLUSTER_PROFILE`
+The API/web/runtime layers use the `ENV` variable (`local`, `demo`, `prod`). Cluster storage uses `CLUSTER_PROFILE`
 (`local`, `ack`, `aws`) because `StorageClass` resources are cluster-scoped rather than namespace-scoped.
 
 ## Prerequisites
@@ -49,7 +50,7 @@ For OAuth provider setup, register callback URLs that match the current environm
 
 ### Local Environment
 
-`make up` automatically handles: creating the Kind cluster → installing ingress-nginx → building the image → loading the image into the cluster → deploying all Helm charts.
+`make up` automatically handles: creating the Kind cluster → installing ingress-nginx → building the API and web images → loading them into the cluster → deploying all Helm charts.
 
 ```bash
 make up              # Equivalent to make up ENV=local
@@ -84,7 +85,7 @@ The cluster configuration is located at `deploy/kind/kind-config.yaml`: 1 contro
 ### 2. Build and Load Images (local only)
 
 ```bash
-make image
+make image-api
 kind load docker-image treadstone:latest --name treadstone
 make image-web
 kind load docker-image treadstone-web:latest --name treadstone
@@ -102,10 +103,11 @@ This is equivalent to running in sequence:
 make deploy-storage CLUSTER_PROFILE=local  # StorageClass aliases (cluster-scoped)
 make deploy-infra ENV=local     # Sandbox CRD + controller
 make deploy-runtime ENV=local   # SandboxTemplate + WarmPool
-make deploy-app ENV=local       # App + Secret + Migration
+make deploy-api ENV=local       # API + Secret + Migration
+make deploy-web ENV=local       # Web frontend
 ```
 
-`deploy-app` automatically creates a K8s Secret (`treadstone-secrets`) from `.env.local`, and runs the database migration in a Helm pre-install/pre-upgrade hook.
+`deploy-api` automatically creates a K8s Secret (`treadstone-secrets`) from `.env.local`, and runs the database migration in a Helm pre-install/pre-upgrade hook.
 Persistent sandboxes use `TREADSTONE_SANDBOX_STORAGE_CLASS` from the environment file and default to a 5 GiB workspace.
 
 ### 4. Verify Deployment
@@ -129,7 +131,7 @@ curl http://localhost/health
 ### Via port-forward (alternative)
 
 ```bash
-make port-forward
+make port-forward-api
 # Access http://localhost:8000 in another terminal
 curl http://localhost:8000/health
 ```
@@ -206,11 +208,11 @@ curl -s -X DELETE $BASE_URL/v1/sandboxes/{sandbox_id} \
 
 ```bash
 # local environment
-make image
+make image-api
 kind load docker-image treadstone:latest --name treadstone
 make image-web
 kind load docker-image treadstone-web:latest --name treadstone
-make restart-app
+make restart-api
 
 # Or run make up to redo the full flow
 ```
@@ -218,8 +220,8 @@ make restart-app
 ### Uninstall
 
 ```bash
-make undeploy-app                  # Uninstall app only
-make undeploy-all                  # Uninstall app + runtime (keep shared infra + storage)
+make undeploy-api                  # Uninstall API only
+make undeploy-env                  # Uninstall API + web + runtime (keep shared infra + storage)
 make down                          # Tear down everything (including Kind cluster in local)
 ```
 
@@ -234,7 +236,8 @@ make kind-delete
 | Config | local | demo | prod |
 |--------|-------|------|------|
 | K8s Namespace | `treadstone-local` | `treadstone-demo` | `treadstone-prod` |
-| Helm release (app) | `treadstone-local` | `treadstone-demo` | `treadstone-prod` |
+| Helm release (api) | `treadstone-local` | `treadstone-demo` | `treadstone-prod` |
+| Helm release (web) | `treadstone-web-local` | `treadstone-web-demo` | `treadstone-web-prod` |
 | Helm release (runtime) | `sandbox-runtime-local` | `sandbox-runtime-demo` | `sandbox-runtime-prod` |
 | Image source | Local build | `ghcr.io/earayu/treadstone` | Specified by CI/CD |
 | Replicas | 1 | 1 | 2 |
@@ -264,7 +267,7 @@ with the ACM certificate ARN for `api.treadstone-ai.dev`.
 | Templates API returns `python-dev` / `nodejs-dev` | `TREADSTONE_DEBUG=true` in `.env` | Set to `false` and recreate the Secret |
 | API returns 500 + `column "xxx" does not exist` | Database is missing new columns | Migration Job should run automatically; manual fix: `kubectl -n treadstone-<ENV> exec deploy/treadstone-<ENV>-treadstone -- uv run alembic upgrade head` |
 | Pod stuck not Ready | Image pull failure | For local: run `kind load docker-image` first; for remote: check image registry permissions |
-| `curl localhost` connection refused | ingress-nginx not ready or port conflict | Rebuild cluster with `make kind-delete && make kind-create`, or use `make port-forward` |
+| `curl localhost` connection refused | ingress-nginx not ready or port conflict | Rebuild cluster with `make kind-delete && make kind-create`, or use `make port-forward-api` |
 | 403 Forbidden in pod logs | Insufficient RBAC permissions | Confirm the Helm chart deployed ClusterRole + ClusterRoleBinding |
 | Sandbox Pod in CrashLoopBackOff | Kind cannot pull sandbox image | `docker pull <image> && kind load docker-image <image> --name treadstone` |
 
@@ -274,13 +277,14 @@ with the ACM certificate ARN for `api.treadstone-ai.dev`.
 make help              # List all available commands
 make kind-create       # Create Kind cluster
 make kind-delete       # Delete Kind cluster
-make image             # Build backend Docker image
+make image-api         # Build API Docker image
 make image-web         # Build frontend Docker image
-make deploy-all        # Deploy all layers (infra + runtime + app)
-make deploy-app        # Deploy app only
-make restart-app       # Rolling restart
-make port-forward      # Forward port to localhost:8000
-make undeploy-all      # Uninstall app + runtime
+make deploy-all        # Deploy all layers (storage + infra + runtime + api + web)
+make deploy-api        # Deploy API only
+make deploy-web        # Deploy web only
+make restart-api       # Rolling restart for the API
+make port-forward-api  # Forward the API to localhost:8000
+make undeploy-env      # Uninstall namespace-scoped layers
 make test-e2e          # Run E2E tests against deployed service
 make up                # One-command deploy (includes cluster creation for local)
 make down              # One-command teardown

--- a/docs/zh-CN/modules/06-control-plane-runtime-and-deployment.md
+++ b/docs/zh-CN/modules/06-control-plane-runtime-and-deployment.md
@@ -128,7 +128,8 @@
 
 本地开发常用入口：
 
-- `make dev`
+- `make dev-api`
+- `make dev-web`
 - `make test`
 - `make lint`
 - `make migrate`
@@ -156,4 +157,3 @@
 - 支付与账单系统
 
 这些主题在历史文档里存在，但不再属于当前控制面运行时文档的范围。
-

--- a/scripts/down.sh
+++ b/scripts/down.sh
@@ -6,7 +6,7 @@ ENV="${1:-local}"
 echo "=== Treadstone Down (ENV=$ENV) ==="
 echo ""
 
-make undeploy-all ENV="$ENV"
+make undeploy-env ENV="$ENV"
 
 if [ "$ENV" = "local" ]; then
     echo ""

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -12,16 +12,16 @@ echo ""
 if [ "$ENV" = "local" ]; then
     bash "$SCRIPT_DIR/kind-setup.sh"
     echo ""
-    echo "Building backend Docker image ..."
-    make image
+    echo "Building API Docker image ..."
+    make image-api
     echo ""
-    echo "Loading backend image into Kind cluster ..."
+    echo "Loading API image into Kind cluster ..."
     kind load docker-image treadstone:latest --name "$CLUSTER_NAME"
     echo ""
-    echo "Building frontend Docker image ..."
+    echo "Building web Docker image ..."
     make image-web
     echo ""
-    echo "Loading frontend image into Kind cluster ..."
+    echo "Loading web image into Kind cluster ..."
     kind load docker-image treadstone-web:latest --name "$CLUSTER_NAME"
 fi
 


### PR DESCRIPTION
## Summary
- rename top-level Make targets so API and web commands use explicit names instead of backend-default aliases
- split aggregate vs module-specific tasks for install, lint, clean, deploy, and client generation
- update scripts, workflows, README/AGENTS/deploy docs, and root skills to match the new Make command surface

## Why
The repository is now an API + web codebase, but the old Makefile still treated backend commands as the implicit default. That made deploy/build/dev task names misleading and left docs and skills inconsistent.

## Validation
- [x] `make help`
- [x] `make lint-py`
- [x] `make install-web`
- [x] `make lint-web`
- [x] `make build-web`
- [x] `make test`
- [x] `git diff --check`
