### PR TITLE
chore: bump version to 0.5.7

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.5.6"
+version = "0.5.7"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.5.6"
+version = "0.5.7"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.5.6"
+version = "0.5.7"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1850,7 +1850,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "treadstone-web",
   "private": true,
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/app-version.ts
+++ b/web/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.6";
+export const APP_VERSION = "0.5.7";


### PR DESCRIPTION
## Summary

- Bump version to 0.5.7 in `pyproject.toml`, `cli/pyproject.toml`, `sdk/python/pyproject.toml`, `web/package.json`, `web/src/lib/app-version.ts`, and `uv.lock`

## Release Notes

**v0.5.7** — Unified Browser Auth

- All browser auth pages moved to the SPA; backend no longer renders HTML login forms
- CLI `browser_url` now points to the SPA page (`/auth/cli/login`) instead of the old server-rendered page
- New `POST /v1/auth/cli/flows/{flow_id}/approve` endpoint: one-click CLI approval for users already signed into the web app
- CLI OAuth callbacks redirect to the SPA with `result=approved|failed` query state instead of returning HTML
- Sandbox browser handoff (`/v1/browser/bootstrap`) redirects unauthenticated users to `/auth/sign-in?return_to=...` on the SPA
- `/auth/sign-in` now supports `return_to` for sandbox handoff and auto-redirects already-signed-in users

## Test Plan

- [x] Merge PR #119 (feat/unify-browser-auth) first
- [x] CI green on this bump PR

Made with [Cursor](https://cursor.com)