### PR TITLE
chore: bump version to 0.5.8

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.5.7"
+version = "0.5.8"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.5.7"
+version = "0.5.8"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.5.7"
+version = "0.5.8"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1850,7 +1850,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.5.7"
+version = "0.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "treadstone-web",
   "private": true,
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/app-version.ts
+++ b/web/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.7";
+export const APP_VERSION = "0.5.8";


### PR DESCRIPTION
## Summary
- Bump version to 0.5.8 across server, CLI, SDK, and web

## Included in this release
- fix: normalize sandbox template names to full K8s names (aio-sandbox-*) (#122)
  - Fixes Create Sandbox page showing "No templates available for your plan"
  - Fixes Create button being permanently disabled
  - Adds Alembic data migration to update existing DB rows

## Test Plan
- [x] CI passing on #122
- [x] make bump V=0.5.8

Made with [Cursor](https://cursor.com)