### PR TITLE
chore: bump version to 0.6.4

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.6.3"
+version = "0.6.4"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.6.3"
+version = "0.6.4"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.6.3"
+version = "0.6.4"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1863,7 +1863,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "treadstone-web",
   "private": true,
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/app-version.ts
+++ b/web/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.3";
+export const APP_VERSION = "0.6.4";


### PR DESCRIPTION
## Summary
- Bump server, CLI, SDK, and web app versions to 0.6.4
- Update `uv.lock` for the new treadstone package version

## Test Plan
- [x] `make bump` completes successfully (version script + `uv lock`)
- [x] Pre-commit passed on bump commit

Made with [Cursor](https://cursor.com)