### PR TITLE
fix: repair broken method call and add storage-ledger API

### DIFF
--- a/tests/api/test_usage_api.py
+++ b/tests/api/test_usage_api.py
@@ -228,3 +228,39 @@ async def test_list_grants_shows_correct_status(user_client):
         assert item["status"] in ("active", "exhausted", "expired")
     for item in body["storage_quota_grants"]:
         assert item["status"] in ("active", "expired")
+
+
+# ── GET /v1/usage/storage-ledger ──────────────────────────────────────────
+
+
+async def test_list_storage_ledger_empty(user_client):
+    resp = await user_client.get("/v1/usage/storage-ledger")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+    assert data["limit"] == 20
+    assert data["offset"] == 0
+
+
+async def test_list_storage_ledger_with_status_filter(user_client):
+    resp = await user_client.get("/v1/usage/storage-ledger", params={"status": "active"})
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+    resp = await user_client.get("/v1/usage/storage-ledger", params={"status": "released"})
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+
+async def test_list_storage_ledger_invalid_status_rejected(user_client):
+    resp = await user_client.get("/v1/usage/storage-ledger", params={"status": "invalid"})
+    assert resp.status_code == 422
+
+
+async def test_list_storage_ledger_pagination(user_client):
+    resp = await user_client.get("/v1/usage/storage-ledger", params={"limit": 5, "offset": 0})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["limit"] == 5
+    assert data["offset"] == 0

--- a/tests/unit/test_metering_tasks.py
+++ b/tests/unit/test_metering_tasks.py
@@ -358,7 +358,7 @@ class TestCheckWarningThresholds:
         with patch("treadstone.services.metering_tasks._metering") as mock_metering:
             mock_metering.get_user_plan = AsyncMock(return_value=plan)
             mock_metering.get_total_compute_remaining = AsyncMock(return_value=Decimal("15"))
-            mock_metering.get_extra_credits_remaining = AsyncMock(return_value=Decimal("0"))
+            mock_metering.get_extra_compute_remaining = AsyncMock(return_value=Decimal("0"))
             with patch("treadstone.services.metering_tasks.record_audit_event") as mock_audit:
                 mock_audit.return_value = MagicMock()
                 await check_warning_thresholds(session)
@@ -382,7 +382,7 @@ class TestCheckWarningThresholds:
         with patch("treadstone.services.metering_tasks._metering") as mock_metering:
             mock_metering.get_user_plan = AsyncMock(return_value=plan)
             mock_metering.get_total_compute_remaining = AsyncMock(return_value=Decimal("-5"))
-            mock_metering.get_extra_credits_remaining = AsyncMock(return_value=Decimal("0"))
+            mock_metering.get_extra_compute_remaining = AsyncMock(return_value=Decimal("0"))
             with patch("treadstone.services.metering_tasks.record_audit_event") as mock_audit:
                 mock_audit.return_value = MagicMock()
                 await check_warning_thresholds(session)
@@ -410,7 +410,7 @@ class TestCheckWarningThresholds:
         with patch("treadstone.services.metering_tasks._metering") as mock_metering:
             mock_metering.get_user_plan = AsyncMock(return_value=plan)
             mock_metering.get_total_compute_remaining = AsyncMock(return_value=Decimal("15"))
-            mock_metering.get_extra_credits_remaining = AsyncMock(return_value=Decimal("0"))
+            mock_metering.get_extra_compute_remaining = AsyncMock(return_value=Decimal("0"))
             with patch("treadstone.services.metering_tasks.record_audit_event") as mock_audit:
                 mock_audit.return_value = MagicMock()
                 await check_warning_thresholds(session)

--- a/treadstone/api/schemas.py
+++ b/treadstone/api/schemas.py
@@ -476,6 +476,24 @@ class ComputeSessionListResponse(BaseModel):
     offset: int = Field(..., examples=[0])
 
 
+class StorageLedgerItem(BaseModel):
+    id: str = Field(..., examples=["slabc123def456"])
+    sandbox_id: str | None = Field(default=None, examples=["sbabc123def456"])
+    size_gib: int = Field(..., examples=[10])
+    storage_state: str = Field(..., examples=["active"])
+    allocated_at: str = Field(..., examples=["2026-03-26T08:00:00+00:00"])
+    released_at: str | None = Field(default=None)
+    gib_hours_consumed: float = Field(..., examples=[120.0])
+    last_metered_at: str = Field(..., examples=["2026-03-26T09:00:00+00:00"])
+
+
+class StorageLedgerListResponse(BaseModel):
+    items: list[StorageLedgerItem]
+    total: int = Field(..., examples=[5])
+    limit: int = Field(..., examples=[20])
+    offset: int = Field(..., examples=[0])
+
+
 class ComputeGrantItem(BaseModel):
     id: str = Field(..., examples=["cgabc123def456"])
     grant_type: str = Field(..., examples=["admin_grant"])

--- a/treadstone/api/usage.py
+++ b/treadstone/api/usage.py
@@ -1,10 +1,11 @@
 """Usage API — read-only endpoints for users to view their metering data.
 
 Endpoints:
-  GET /v1/usage          — aggregate usage overview
-  GET /v1/usage/plan     — full UserPlan details
-  GET /v1/usage/sessions — paginated ComputeSession list
-  GET /v1/usage/grants   — ComputeGrant and StorageQuotaGrant lists
+  GET /v1/usage                — aggregate usage overview
+  GET /v1/usage/plan           — full UserPlan details
+  GET /v1/usage/sessions       — paginated ComputeSession list
+  GET /v1/usage/storage-ledger — paginated StorageLedger list
+  GET /v1/usage/grants         — ComputeGrant and StorageQuotaGrant lists
 
 Note: All endpoints call ``session.commit()`` because ``get_user_plan``
 (called internally by ``get_usage_summary``, etc.) may lazily create a
@@ -27,11 +28,12 @@ from treadstone.api.metering_serializers import (
 from treadstone.api.schemas import (
     ComputeSessionListResponse,
     GrantsResponse,
+    StorageLedgerListResponse,
     UsageSummaryResponse,
     UserPlanResponse,
 )
 from treadstone.core.database import get_session
-from treadstone.models.metering import ComputeSession
+from treadstone.models.metering import ComputeSession, StorageLedger
 from treadstone.models.user import User, utc_now
 from treadstone.services.metering_service import MeteringService
 
@@ -92,6 +94,38 @@ async def list_compute_sessions(
     await session.commit()
     return {
         "items": [_serialize_session(cs) for cs in items],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+def _serialize_storage_ledger(entry: StorageLedger) -> dict:
+    return {
+        "id": entry.id,
+        "sandbox_id": entry.sandbox_id,
+        "size_gib": entry.size_gib,
+        "storage_state": entry.storage_state,
+        "allocated_at": iso(entry.allocated_at),
+        "released_at": iso(entry.released_at),
+        "gib_hours_consumed": float(entry.gib_hours_consumed),
+        "last_metered_at": iso(entry.last_metered_at),
+    }
+
+
+@router.get("/storage-ledger", response_model=StorageLedgerListResponse)
+async def list_storage_ledger(
+    user: User = Depends(get_current_control_plane_user),
+    session: AsyncSession = Depends(get_session),
+    status: str = Query(default="all", pattern="^(active|released|all)$"),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+):
+    await _metering.ensure_user_plan(session, user.id)
+    items, total = await _metering.list_storage_ledger(session, user.id, status=status, limit=limit, offset=offset)
+    await session.commit()
+    return {
+        "items": [_serialize_storage_ledger(entry) for entry in items],
         "total": total,
         "limit": limit,
         "offset": offset,

--- a/treadstone/services/metering_service.py
+++ b/treadstone/services/metering_service.py
@@ -770,6 +770,31 @@ class MeteringService:
         )
         return list(items_result.scalars().all()), total
 
+    async def list_storage_ledger(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        *,
+        status: str = "all",
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[StorageLedger], int]:
+        """Return paginated StorageLedger entries for a user."""
+        base = select(StorageLedger).where(StorageLedger.user_id == user_id)
+        count_base = select(func.count()).select_from(StorageLedger).where(StorageLedger.user_id == user_id)
+        if status == "active":
+            base = base.where(StorageLedger.storage_state == StorageState.ACTIVE)
+            count_base = count_base.where(StorageLedger.storage_state == StorageState.ACTIVE)
+        elif status == "released":
+            base = base.where(StorageLedger.storage_state == StorageState.DELETED)
+            count_base = count_base.where(StorageLedger.storage_state == StorageState.DELETED)
+
+        total = (await session.execute(count_base)).scalar_one()
+        items_result = await session.execute(
+            base.order_by(StorageLedger.allocated_at.desc()).limit(limit).offset(offset)
+        )
+        return list(items_result.scalars().all()), total
+
     async def list_compute_grants(self, session: AsyncSession, user_id: str) -> list[ComputeGrant]:
         """Return all ComputeGrants for a user, newest first."""
         result = await session.execute(

--- a/treadstone/services/metering_tasks.py
+++ b/treadstone/services/metering_tasks.py
@@ -159,7 +159,7 @@ async def check_warning_thresholds(session: AsyncSession) -> None:
 
         monthly_limit = plan.compute_credits_monthly_limit
         monthly_used = plan.compute_credits_monthly_used
-        extra_remaining = await _metering.get_extra_credits_remaining(session, user_id, "compute")
+        extra_remaining = await _metering.get_extra_compute_remaining(session, user_id)
 
         # 100% warning: monthly + extra fully exhausted
         if total_remaining <= Decimal("0") and plan.warning_100_notified_at is None:


### PR DESCRIPTION
## Summary
- Fix `check_warning_thresholds` calling deleted `get_extra_credits_remaining` method (runtime AttributeError)
- Add `GET /v1/usage/storage-ledger` endpoint with pagination and status filter
- Add `StorageLedgerItem` / `StorageLedgerListResponse` schemas
- Add `MeteringService.list_storage_ledger()` method

## Test Plan
- [x] `make test` — 550 passed
- [x] `make lint` — all clean

Made with [Cursor](https://cursor.com)