### PR TITLE
fix: resolve frontend TypeScript errors for new compute usage model

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.6.4"
+version = "0.6.5"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.6.4"
+version = "0.6.5"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.6.4"
+version = "0.6.5"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1863,7 +1863,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "treadstone-web",
   "private": true,
-  "version": "0.6.4",
+  "version": "0.6.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/app-version.ts
+++ b/web/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.4";
+export const APP_VERSION = "0.6.5";

--- a/web/src/pages/app/create-sandbox.tsx
+++ b/web/src/pages/app/create-sandbox.tsx
@@ -407,12 +407,12 @@ export function CreateSandboxPage() {
               <ul className="mt-6 space-y-5">
                 <li>
                   <p className="text-[10px] uppercase tracking-[2px] text-muted-foreground">
-                    Monthly credit
+                    Compute usage
                   </p>
                   <p className="mt-1 text-lg font-bold text-foreground">
-                    {usage.compute.monthly_limit}{" "}
+                    {usage.compute.vcpu_hours.toFixed(2)}{" "}
                     <span className="text-xs font-normal text-muted-foreground">
-                      {usage.compute.unit}/mo
+                      vCPU-h
                     </span>
                   </p>
                 </li>

--- a/web/src/pages/app/dashboard.tsx
+++ b/web/src/pages/app/dashboard.tsx
@@ -50,9 +50,7 @@ function InlineMetrics() {
   const { data: usage } = useUsageOverview()
   const { data: grants } = useGrants()
 
-  const computeRemaining = usage
-    ? (usage.compute.monthly_limit - usage.compute.monthly_used).toFixed(1)
-    : "—"
+  const computeVcpuHours = usage ? usage.compute.vcpu_hours.toFixed(2) : "—"
   const tier = usage?.tier ?? "—"
 
   const welcomeBonus = useMemo(() => {
@@ -66,10 +64,10 @@ function InlineMetrics() {
     <div className="grid grid-cols-3 border border-border/15">
       <div className="border-r border-border/15 bg-card px-6 py-6">
         <p className="text-[10px] uppercase tracking-[2px] text-muted-foreground">
-          Compute Remaining
+          Compute Usage
         </p>
         <div className="mt-2 flex items-baseline gap-2">
-          <span className="text-2xl font-bold text-foreground">{computeRemaining}</span>
+          <span className="text-2xl font-bold text-foreground">{computeVcpuHours}</span>
           <span className="text-xs text-muted-foreground">vCPU-hours</span>
         </div>
       </div>

--- a/web/src/pages/internal/admin-metering.tsx
+++ b/web/src/pages/internal/admin-metering.tsx
@@ -399,10 +399,8 @@ function UserPlanSection() {
   }
 
   const tier = usage?.tier ?? "—"
-  const computeUsed = usage?.compute.monthly_used
-  const computeLimit = usage?.compute.monthly_limit
-  const creditsRemaining =
-    computeUsed != null && computeLimit != null ? (computeLimit - computeUsed).toFixed(1) : "—"
+  const vcpuHours = usage?.compute.vcpu_hours ?? 0
+  const memGibHours = usage?.compute.memory_gib_hours ?? 0
   const maxConcurrent = usage?.limits.max_concurrent_running ?? "—"
   const runningNow = usage?.limits.current_running ?? 0
 
@@ -477,9 +475,15 @@ function UserPlanSection() {
                 </div>
                 <div>
                   <p className="text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
-                    CREDITS REMAINING
+                    VCPU-HOURS
                   </p>
-                  <p className="mt-1 text-base font-semibold text-foreground">{creditsRemaining}</p>
+                  <p className="mt-1 text-base font-semibold text-foreground">{vcpuHours.toFixed(2)}</p>
+                </div>
+                <div>
+                  <p className="text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
+                    MEM GIB-HOURS
+                  </p>
+                  <p className="mt-1 text-base font-semibold text-foreground">{memGibHours.toFixed(2)}</p>
                 </div>
                 <div>
                   <p className="text-[9px] font-medium uppercase tracking-wide text-muted-foreground">


### PR DESCRIPTION
## Summary
- Fix TS build errors in create-sandbox, dashboard, and admin-metering pages
- Pages were still referencing removed `monthly_limit`/`monthly_used`/`unit` fields from the old ComputeUsage schema
- Updated to use new `vcpu_hours`/`memory_gib_hours` fields

## Test Plan
- [x] `make test` — 550 passed
- [x] `make lint` — all clean (includes ESLint)

Made with [Cursor](https://cursor.com)