### PR TITLE
fix: remove stale computeUsed/computeLimit in admin-metering

### DIFF
--- a/web/src/pages/internal/admin-metering.tsx
+++ b/web/src/pages/internal/admin-metering.tsx
@@ -465,13 +465,9 @@ function UserPlanSection() {
                 </div>
                 <div>
                   <p className="text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
-                    COMPUTE USED
+                    TIER
                   </p>
-                  <p className="mt-1 text-base font-semibold text-foreground">
-                    {computeUsed != null && computeLimit != null
-                      ? `${computeUsed.toFixed(1)} / ${computeLimit.toFixed(1)} vCPU-h`
-                      : "—"}
-                  </p>
+                  <p className="mt-1 text-base font-semibold text-foreground">{tier}</p>
                 </div>
                 <div>
                   <p className="text-[9px] font-medium uppercase tracking-wide text-muted-foreground">


### PR DESCRIPTION
Fix remaining TS build errors that caused v0.6.5 release to fail.

Made with [Cursor](https://cursor.com)