### PR TITLE
fix: mark unverified user as verified when linking via OAuth

### DIFF
--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -284,6 +284,48 @@ async def test_github_callback_rejects_unverified_email_and_does_not_link_existi
 
 
 @pytest.mark.asyncio
+async def test_oauth_link_marks_unverified_email_user_as_verified(db_session, monkeypatch):
+    """An unverified email-registered user becomes verified upon linking via OAuth.
+
+    OAuth providers (Google, GitHub) have already confirmed email ownership, so
+    there is no reason to keep is_verified=False after a successful OAuth link.
+    """
+    monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
+    client = FakeOAuthClient("google", account_id="acct-verify-link", account_email="unverified@example.com")
+    monkeypatch.setattr(auth_api, "get_google_oauth_client", lambda: client, raising=False)
+
+    async with _test_session_factory() as session:
+        user = User(
+            email="unverified@example.com",
+            hashed_password="hashed",
+            has_local_password=True,
+            is_active=True,
+            is_verified=False,
+            role="rw",
+        )
+        session.add(user)
+        await session.commit()
+        existing_user_id = user.id
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
+        authorize = await http_client.get("/v1/auth/google/authorize", follow_redirects=False)
+        state = _extract_state(authorize.headers["location"])
+        callback = await http_client.get(
+            "/v1/auth/google/callback",
+            params={"code": "oauth-code", "state": state},
+            follow_redirects=False,
+        )
+
+    assert callback.status_code == 303
+
+    async with _test_session_factory() as session:
+        user = (await session.execute(select(User).where(User.id == existing_user_id))).unique().scalar_one()
+
+    assert user.is_verified is True
+    assert user.id == existing_user_id
+
+
+@pytest.mark.asyncio
 async def test_oauth_only_user_can_set_local_password_and_login_with_it(db_session, monkeypatch):
     monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
     client = FakeOAuthClient("google", account_id="acct-set-password", account_email="setpass@example.com")

--- a/treadstone/api/auth.py
+++ b/treadstone/api/auth.py
@@ -701,6 +701,17 @@ async def _oauth_callback(
     except fastapi_users_exceptions.UserAlreadyExists as exc:
         raise ConflictError("Email already registered") from exc
 
+    # fastapi-users only applies is_verified_by_default when creating a brand-new user.
+    # When an existing unverified user links via OAuth the flag is ignored, leaving
+    # is_verified=False even though the OAuth provider has already confirmed ownership
+    # of the email address. Fix that here.
+    if outcome == "link" and not user.is_verified:
+        db_user = await session.get(User, user.id)
+        if db_user and not db_user.is_verified:
+            db_user.is_verified = True
+            session.add(db_user)
+            user = db_user
+
     surface = "cli" if cli_flow_id_from_state else surface
 
     set_request_context(request, actor_user_id=user.id, credential_type="cookie")


### PR DESCRIPTION
## Summary

- Fix a bug where an email-registered user with `is_verified=False` remained unverified after successfully linking their account via Google or GitHub OAuth.
- `fastapi-users` only applies `is_verified_by_default=True` when **creating** a brand-new user; it is silently ignored for the `associate_by_email` (link) path.
- After a successful OAuth link, the fix explicitly sets `is_verified=True` because the OAuth provider has already confirmed email ownership.

## Test Plan

- [x] Added `test_oauth_link_marks_unverified_email_user_as_verified` to `tests/api/test_oauth_api.py` — the test was red before the fix and green after.
- [x] `make test` — 551 passed, 0 failed.
- [x] `make lint` — all checks passed (enforced by pre-commit hook).

Made with [Cursor](https://cursor.com)