### PR TITLE
feat: rename credits to compute_units across metering system

### DIFF
--- a/alembic/versions/e1a2b3c4d5f6_rename_credits_to_compute_units.py
+++ b/alembic/versions/e1a2b3c4d5f6_rename_credits_to_compute_units.py
@@ -1,0 +1,35 @@
+"""rename credits to compute units
+
+Rename user-facing "credits" terminology to "Compute Units" (CU) to align
+with Neon-style CU = max(vCPU, memory_GiB / 2) semantics.
+
+Affected columns:
+- tier_template.compute_credits_monthly  -> compute_units_monthly
+- user_plan.compute_credits_monthly_limit -> compute_units_monthly_limit
+- user_plan.compute_credits_monthly_used  -> compute_units_monthly_used
+
+Values are unchanged — they already represented CU-hours via calculate_credit_rate.
+
+Revision ID: e1a2b3c4d5f6
+Revises: 351062994638
+Create Date: 2026-03-29
+"""
+
+from alembic import op
+
+revision = "e1a2b3c4d5f6"
+down_revision = "351062994638"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("tier_template", "compute_credits_monthly", new_column_name="compute_units_monthly")
+    op.alter_column("user_plan", "compute_credits_monthly_limit", new_column_name="compute_units_monthly_limit")
+    op.alter_column("user_plan", "compute_credits_monthly_used", new_column_name="compute_units_monthly_used")
+
+
+def downgrade() -> None:
+    op.alter_column("tier_template", "compute_units_monthly", new_column_name="compute_credits_monthly")
+    op.alter_column("user_plan", "compute_units_monthly_limit", new_column_name="compute_credits_monthly_limit")
+    op.alter_column("user_plan", "compute_units_monthly_used", new_column_name="compute_credits_monthly_used")

--- a/tests/api/test_admin_api.py
+++ b/tests/api/test_admin_api.py
@@ -25,7 +25,7 @@ async def _seed_tier_templates(session: AsyncSession) -> None:
     defaults = [
         TierTemplate(
             tier_name="free",
-            compute_credits_monthly=Decimal("10"),
+            compute_units_monthly=Decimal("10"),
             storage_capacity_gib=0,
             max_concurrent_running=1,
             max_sandbox_duration_seconds=1800,
@@ -34,7 +34,7 @@ async def _seed_tier_templates(session: AsyncSession) -> None:
         ),
         TierTemplate(
             tier_name="pro",
-            compute_credits_monthly=Decimal("100"),
+            compute_units_monthly=Decimal("100"),
             storage_capacity_gib=10,
             max_concurrent_running=3,
             max_sandbox_duration_seconds=7200,
@@ -43,7 +43,7 @@ async def _seed_tier_templates(session: AsyncSession) -> None:
         ),
         TierTemplate(
             tier_name="ultra",
-            compute_credits_monthly=Decimal("300"),
+            compute_units_monthly=Decimal("300"),
             storage_capacity_gib=20,
             max_concurrent_running=5,
             max_sandbox_duration_seconds=28800,
@@ -142,18 +142,18 @@ async def test_list_tier_templates_requires_admin(member_client):
 async def test_update_tier_template(admin_client):
     resp = await admin_client.patch(
         "/v1/admin/tier-templates/pro",
-        json={"compute_credits_monthly": 150, "apply_to_existing": False},
+        json={"compute_units_monthly": 150, "apply_to_existing": False},
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["compute_credits_monthly"] == 150.0
+    assert data["compute_units_monthly"] == 150.0
     assert data["users_affected"] == 0
 
 
 async def test_update_tier_template_not_found(admin_client):
     resp = await admin_client.patch(
         "/v1/admin/tier-templates/nonexistent",
-        json={"compute_credits_monthly": 150},
+        json={"compute_units_monthly": 150},
     )
     assert resp.status_code == 404
 
@@ -165,15 +165,15 @@ async def test_update_tier_template_apply_to_existing(admin_client):
 
     resp = await admin_client.patch(
         "/v1/admin/tier-templates/pro",
-        json={"compute_credits_monthly": 200, "apply_to_existing": True},
+        json={"compute_units_monthly": 200, "apply_to_existing": True},
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["compute_credits_monthly"] == 200.0
+    assert data["compute_units_monthly"] == 200.0
     assert data["users_affected"] >= 1
 
     plan_resp = await admin_client.get("/v1/usage/plan")
-    assert plan_resp.json()["compute_credits_monthly_limit"] == 200.0
+    assert plan_resp.json()["compute_units_monthly_limit"] == 200.0
 
 
 async def test_update_tier_template_apply_to_existing_skips_overridden(admin_client):
@@ -181,18 +181,18 @@ async def test_update_tier_template_apply_to_existing_skips_overridden(admin_cli
 
     await admin_client.patch(
         f"/v1/admin/users/{user_id}/plan",
-        json={"tier": "pro", "overrides": {"compute_credits_monthly_limit": 999}},
+        json={"tier": "pro", "overrides": {"compute_units_monthly_limit": 999}},
     )
 
     resp = await admin_client.patch(
         "/v1/admin/tier-templates/pro",
-        json={"compute_credits_monthly": 200, "apply_to_existing": True},
+        json={"compute_units_monthly": 200, "apply_to_existing": True},
     )
     assert resp.status_code == 200
     assert resp.json()["users_affected"] == 0
 
     plan_resp = await admin_client.get("/v1/usage/plan")
-    assert plan_resp.json()["compute_credits_monthly_limit"] == 999.0
+    assert plan_resp.json()["compute_units_monthly_limit"] == 999.0
 
 
 async def test_update_tier_template_requires_at_least_one_field(admin_client):
@@ -238,7 +238,7 @@ async def test_admin_update_user_plan_change_tier(admin_client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["tier"] == "pro"
-    assert data["compute_credits_monthly_limit"] == 100.0
+    assert data["compute_units_monthly_limit"] == 100.0
     assert data["max_concurrent_running"] == 3
 
 
@@ -246,13 +246,13 @@ async def test_admin_update_user_plan_with_overrides(admin_client):
     user_id = _get_user_id(admin_client)
     resp = await admin_client.patch(
         f"/v1/admin/users/{user_id}/plan",
-        json={"tier": "pro", "overrides": {"compute_credits_monthly_limit": 200}},
+        json={"tier": "pro", "overrides": {"compute_units_monthly_limit": 200}},
     )
     assert resp.status_code == 200
     data = resp.json()
     assert data["tier"] == "pro"
-    assert data["compute_credits_monthly_limit"] == 200.0
-    assert data["overrides"]["compute_credits_monthly_limit"] == 200
+    assert data["compute_units_monthly_limit"] == 200.0
+    assert data["overrides"]["compute_units_monthly_limit"] == 200
 
 
 async def test_admin_update_user_plan_overrides_only(admin_client):

--- a/tests/api/test_usage_api.py
+++ b/tests/api/test_usage_api.py
@@ -26,7 +26,7 @@ async def _seed_tier_templates(session: AsyncSession) -> None:
     defaults = [
         TierTemplate(
             tier_name="free",
-            compute_credits_monthly=Decimal("10"),
+            compute_units_monthly=Decimal("10"),
             storage_capacity_gib=0,
             max_concurrent_running=1,
             max_sandbox_duration_seconds=1800,
@@ -35,7 +35,7 @@ async def _seed_tier_templates(session: AsyncSession) -> None:
         ),
         TierTemplate(
             tier_name="pro",
-            compute_credits_monthly=Decimal("100"),
+            compute_units_monthly=Decimal("100"),
             storage_capacity_gib=10,
             max_concurrent_running=3,
             max_sandbox_duration_seconds=7200,
@@ -104,14 +104,13 @@ async def test_get_usage_returns_summary(user_client):
     assert data["billing_period"]["start"] is not None
     assert data["billing_period"]["end"] is not None
 
-    assert data["compute"]["vcpu_hours"] == 0.0
-    assert data["compute"]["memory_gib_hours"] == 0.0
+    assert data["compute"]["compute_unit_hours"] == 0.0
     assert data["compute"]["monthly_limit"] == 10.0
     assert data["compute"]["monthly_used"] == 0.0
     assert data["compute"]["monthly_remaining"] == 10.0
     assert data["compute"]["extra_remaining"] == 50.0
     assert data["compute"]["total_remaining"] == 60.0
-    assert data["compute"]["unit"] == "credits"
+    assert data["compute"]["unit"] == "CU-hours"
 
     assert data["storage"]["gib_hours"] == 0.0
     assert data["storage"]["current_used_gib"] == 0
@@ -131,8 +130,7 @@ async def test_get_usage_includes_credit_pool_and_grants(user_client):
     usage = await user_client.get("/v1/usage")
     assert usage.status_code == 200
     u = usage.json()
-    assert u["compute"]["vcpu_hours"] == 0.0
-    assert u["compute"]["memory_gib_hours"] == 0.0
+    assert u["compute"]["compute_unit_hours"] == 0.0
     assert u["compute"]["monthly_limit"] == 10.0
     assert u["compute"]["monthly_used"] == 0.0
     assert u["compute"]["extra_remaining"] == 50.0
@@ -147,8 +145,8 @@ async def test_get_usage_includes_credit_pool_and_grants(user_client):
 
     plan = await user_client.get("/v1/usage/plan")
     assert plan.status_code == 200
-    assert plan.json()["compute_credits_monthly_limit"] == 10.0
-    assert plan.json()["compute_credits_monthly_used"] == 0.0
+    assert plan.json()["compute_units_monthly_limit"] == 10.0
+    assert plan.json()["compute_units_monthly_used"] == 0.0
 
 
 async def test_get_usage_unauthenticated(db_session):
@@ -166,8 +164,8 @@ async def test_get_plan_returns_full_details(user_client):
     data = resp.json()
 
     assert data["tier"] == "free"
-    assert data["compute_credits_monthly_limit"] == 10.0
-    assert data["compute_credits_monthly_used"] == 0.0
+    assert data["compute_units_monthly_limit"] == 10.0
+    assert data["compute_units_monthly_used"] == 0.0
     assert data["storage_capacity_limit_gib"] == 0
     assert data["max_concurrent_running"] == 1
     assert data["max_sandbox_duration_seconds"] == 1800

--- a/tests/e2e/07-metering-usage.hurl
+++ b/tests/e2e/07-metering-usage.hurl
@@ -38,14 +38,13 @@ HTTP 200
 jsonpath "$.tier" == "free"
 jsonpath "$.billing_period.start" isString
 jsonpath "$.billing_period.end" isString
-jsonpath "$.compute.vcpu_hours" >= 0.0
-jsonpath "$.compute.memory_gib_hours" >= 0.0
+jsonpath "$.compute.compute_unit_hours" >= 0.0
 jsonpath "$.compute.monthly_limit" == 10.0
 jsonpath "$.compute.monthly_used" >= 0.0
 jsonpath "$.compute.monthly_remaining" >= 0.0
 jsonpath "$.compute.extra_remaining" == 50.0
 jsonpath "$.compute.total_remaining" >= 0.0
-jsonpath "$.compute.unit" == "credits"
+jsonpath "$.compute.unit" == "CU-hours"
 jsonpath "$.storage.current_used_gib" == 0
 jsonpath "$.storage.total_quota_gib" == 0
 jsonpath "$.storage.available_gib" == 0
@@ -66,8 +65,8 @@ HTTP 200
 jsonpath "$.id" isString
 jsonpath "$.user_id" isString
 jsonpath "$.tier" == "free"
-jsonpath "$.compute_credits_monthly_limit" == 10.0
-jsonpath "$.compute_credits_monthly_used" >= 0.0
+jsonpath "$.compute_units_monthly_limit" == 10.0
+jsonpath "$.compute_units_monthly_used" >= 0.0
 jsonpath "$.storage_capacity_limit_gib" == 0
 jsonpath "$.max_concurrent_running" == 1
 jsonpath "$.max_sandbox_duration_seconds" == 1800

--- a/tests/e2e/08-metering-admin.hurl
+++ b/tests/e2e/08-metering-admin.hurl
@@ -81,7 +81,7 @@ jsonpath "$.tier" == "free"
 jsonpath "$.compute.monthly_limit" == 10.0
 jsonpath "$.compute.monthly_used" >= 0.0
 jsonpath "$.compute.extra_remaining" == 50.0
-jsonpath "$.compute.unit" == "credits"
+jsonpath "$.compute.unit" == "CU-hours"
 jsonpath "$.storage.total_quota_gib" == 0
 jsonpath "$.storage.unit" == "GiB"
 jsonpath "$.limits.max_concurrent_running" == 1
@@ -107,7 +107,7 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.tier" == "pro"
-jsonpath "$.compute_credits_monthly_limit" == 100.0
+jsonpath "$.compute_units_monthly_limit" == 100.0
 jsonpath "$.storage_capacity_limit_gib" == 10
 jsonpath "$.max_concurrent_running" == 3
 jsonpath "$.max_sandbox_duration_seconds" == 7200

--- a/tests/unit/test_metering_integration.py
+++ b/tests/unit/test_metering_integration.py
@@ -53,8 +53,8 @@ def _make_plan(tier: str = "pro", **kwargs) -> UserPlan:
     defaults = {
         "user_id": "user1234567890abcd",
         "tier": tier,
-        "compute_credits_monthly_limit": Decimal("100"),
-        "compute_credits_monthly_used": Decimal("0"),
+        "compute_units_monthly_limit": Decimal("100"),
+        "compute_units_monthly_used": Decimal("0"),
         "storage_capacity_limit_gib": 10,
         "max_concurrent_running": 3,
         "max_sandbox_duration_seconds": 7200,

--- a/tests/unit/test_metering_models.py
+++ b/tests/unit/test_metering_models.py
@@ -18,7 +18,7 @@ from treadstone.models.metering import (
 from treadstone.services.metering_helpers import (
     TEMPLATE_SPECS,
     ConsumeResult,
-    calculate_credit_rate,
+    calculate_cu_rate,
     compute_period_bounds,
     parse_storage_size_gib,
     validate_template_specs,
@@ -45,7 +45,7 @@ def test_tier_template_fields_exist():
     for field in [
         "id",
         "tier_name",
-        "compute_credits_monthly",
+        "compute_units_monthly",
         "storage_capacity_gib",
         "max_concurrent_running",
         "max_sandbox_duration_seconds",
@@ -81,7 +81,7 @@ def test_user_plan_fields_exist():
         "id",
         "user_id",
         "tier",
-        "compute_credits_monthly_limit",
+        "compute_units_monthly_limit",
         "storage_capacity_limit_gib",
         "max_concurrent_running",
         "max_sandbox_duration_seconds",
@@ -89,7 +89,7 @@ def test_user_plan_fields_exist():
         "grace_period_seconds",
         "period_start",
         "period_end",
-        "compute_credits_monthly_used",
+        "compute_units_monthly_used",
         "overrides",
         "grace_period_started_at",
         "warning_80_notified_at",
@@ -259,25 +259,25 @@ def test_storage_ledger_indexes():
 # ── Metering Helpers (F04) ──
 
 
-class TestCalculateCreditRate:
+class TestCalculateCuRate:
     def test_tiny(self):
-        assert calculate_credit_rate("aio-sandbox-tiny") == Decimal("0.25")
+        assert calculate_cu_rate("aio-sandbox-tiny") == Decimal("0.25")
 
     def test_small(self):
-        assert calculate_credit_rate("aio-sandbox-small") == Decimal("0.5")
+        assert calculate_cu_rate("aio-sandbox-small") == Decimal("0.5")
 
     def test_medium(self):
-        assert calculate_credit_rate("aio-sandbox-medium") == Decimal("1")
+        assert calculate_cu_rate("aio-sandbox-medium") == Decimal("1")
 
     def test_large(self):
-        assert calculate_credit_rate("aio-sandbox-large") == Decimal("2")
+        assert calculate_cu_rate("aio-sandbox-large") == Decimal("2")
 
     def test_xlarge(self):
-        assert calculate_credit_rate("aio-sandbox-xlarge") == Decimal("4")
+        assert calculate_cu_rate("aio-sandbox-xlarge") == Decimal("4")
 
     def test_unknown_template_raises(self):
         with pytest.raises(BadRequestError, match="Unknown sandbox template"):
-            calculate_credit_rate("nonexistent")
+            calculate_cu_rate("nonexistent")
 
 
 class TestTemplateSpecs:

--- a/tests/unit/test_metering_service.py
+++ b/tests/unit/test_metering_service.py
@@ -40,7 +40,7 @@ FIXED_NOW = datetime(2026, 3, 15, 10, 0, 0, tzinfo=UTC)
 def _make_template(tier_name: str = "free", **kwargs) -> TierTemplate:
     defaults = {
         "free": {
-            "compute_credits_monthly": Decimal("10"),
+            "compute_units_monthly": Decimal("10"),
             "storage_capacity_gib": 0,
             "max_concurrent_running": 1,
             "max_sandbox_duration_seconds": 1800,
@@ -48,7 +48,7 @@ def _make_template(tier_name: str = "free", **kwargs) -> TierTemplate:
             "grace_period_seconds": 600,
         },
         "pro": {
-            "compute_credits_monthly": Decimal("100"),
+            "compute_units_monthly": Decimal("100"),
             "storage_capacity_gib": 10,
             "max_concurrent_running": 3,
             "max_sandbox_duration_seconds": 7200,
@@ -63,8 +63,8 @@ def _make_template(tier_name: str = "free", **kwargs) -> TierTemplate:
 def _make_plan(user_id: str = "user01", tier: str = "free", **kwargs) -> UserPlan:
     defaults = {
         "tier": tier,
-        "compute_credits_monthly_limit": Decimal("10"),
-        "compute_credits_monthly_used": Decimal("0"),
+        "compute_units_monthly_limit": Decimal("10"),
+        "compute_units_monthly_used": Decimal("0"),
         "storage_capacity_limit_gib": 0,
         "max_concurrent_running": 1,
         "max_sandbox_duration_seconds": 1800,
@@ -153,7 +153,7 @@ class TestEnsureUserPlan:
 
         assert plan.user_id == "user01"
         assert plan.tier == "free"
-        assert plan.compute_credits_monthly_limit == Decimal("10")
+        assert plan.compute_units_monthly_limit == Decimal("10")
         assert plan.period_start == datetime(2026, 3, 1, tzinfo=UTC)
         assert plan.period_end == datetime(2026, 4, 1, tzinfo=UTC)
 
@@ -175,7 +175,7 @@ class TestEnsureUserPlan:
         plan = await svc.ensure_user_plan(session, "user01", tier="pro")
 
         assert plan.tier == "pro"
-        assert plan.compute_credits_monthly_limit == Decimal("100")
+        assert plan.compute_units_monthly_limit == Decimal("100")
         grants = _added_objects(session, ComputeGrant)
         assert len(grants) == 0
 
@@ -241,7 +241,7 @@ class TestUpdateUserTier:
         plan = await svc.update_user_tier(session, "user01", "pro")
 
         assert plan.tier == "pro"
-        assert plan.compute_credits_monthly_limit == Decimal("100")
+        assert plan.compute_units_monthly_limit == Decimal("100")
         assert plan.max_concurrent_running == 3
         assert plan.gmt_updated == FIXED_NOW
 
@@ -255,10 +255,10 @@ class TestUpdateUserTier:
             _MockResult(value=old_plan),  # existing plan lookup
         )
 
-        overrides = {"compute_credits_monthly_limit": Decimal("500"), "max_concurrent_running": 10}
+        overrides = {"compute_units_monthly_limit": Decimal("500"), "max_concurrent_running": 10}
         plan = await svc.update_user_tier(session, "user01", "pro", overrides=overrides)
 
-        assert plan.compute_credits_monthly_limit == Decimal("500")
+        assert plan.compute_units_monthly_limit == Decimal("500")
         assert plan.max_concurrent_running == 10
         assert plan.overrides == overrides
 
@@ -269,7 +269,7 @@ class TestUpdateUserTier:
         svc = MeteringService()
         svc._get_tier_template = AsyncMock(return_value=pro_template)
 
-        created_plan = _make_plan("user01", tier="pro", compute_credits_monthly_limit=Decimal("100"))
+        created_plan = _make_plan("user01", tier="pro", compute_units_monthly_limit=Decimal("100"))
         svc.ensure_user_plan = AsyncMock(return_value=created_plan)
 
         session = _mock_session(
@@ -297,7 +297,7 @@ class TestUpdateUserTier:
         plan = await svc.update_user_tier(session, "user01", "pro")
 
         assert plan.tier == "pro"
-        assert plan.compute_credits_monthly_limit == Decimal("100")
+        assert plan.compute_units_monthly_limit == Decimal("100")
         assert plan.max_concurrent_running == 3
 
 
@@ -315,7 +315,7 @@ class TestApplyOverrides:
     def test_all_allowed_keys_accepted(self):
         plan = _make_plan()
         overrides = {
-            "compute_credits_monthly_limit": Decimal("999"),
+            "compute_units_monthly_limit": Decimal("999"),
             "storage_capacity_limit_gib": 999,
             "max_concurrent_running": 99,
             "max_sandbox_duration_seconds": 99999,
@@ -366,8 +366,8 @@ class TestConsumeComputeCredits:
         monkeypatch.setattr("treadstone.services.metering_service.utc_now", lambda: FIXED_NOW)
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("100"),
-            compute_credits_monthly_used=Decimal("50"),
+            compute_units_monthly_limit=Decimal("100"),
+            compute_units_monthly_used=Decimal("50"),
         )
         svc = MeteringService()
         svc._get_user_plan_for_update = AsyncMock(return_value=plan)
@@ -378,14 +378,14 @@ class TestConsumeComputeCredits:
         assert result.monthly == Decimal("10")
         assert result.extra == Decimal("0")
         assert result.shortfall == Decimal("0")
-        assert plan.compute_credits_monthly_used == Decimal("60")
+        assert plan.compute_units_monthly_used == Decimal("60")
 
     async def test_monthly_plus_extra(self, monkeypatch):
         monkeypatch.setattr("treadstone.services.metering_service.utc_now", lambda: FIXED_NOW)
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("100"),
-            compute_credits_monthly_used=Decimal("98"),
+            compute_units_monthly_limit=Decimal("100"),
+            compute_units_monthly_used=Decimal("98"),
         )
         grant = ComputeGrant(
             user_id="user01",
@@ -404,15 +404,15 @@ class TestConsumeComputeCredits:
         assert result.monthly == Decimal("2")
         assert result.extra == Decimal("3")
         assert result.shortfall == Decimal("0")
-        assert plan.compute_credits_monthly_used == Decimal("100")
+        assert plan.compute_units_monthly_used == Decimal("100")
         assert grant.remaining_amount == Decimal("47")
 
     async def test_both_pools_exhausted_returns_shortfall(self, monkeypatch):
         monkeypatch.setattr("treadstone.services.metering_service.utc_now", lambda: FIXED_NOW)
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("10"),
-            compute_credits_monthly_used=Decimal("10"),
+            compute_units_monthly_limit=Decimal("10"),
+            compute_units_monthly_used=Decimal("10"),
         )
         svc = MeteringService()
         svc._get_user_plan_for_update = AsyncMock(return_value=plan)
@@ -428,8 +428,8 @@ class TestConsumeComputeCredits:
         monkeypatch.setattr("treadstone.services.metering_service.utc_now", lambda: FIXED_NOW)
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("10"),
-            compute_credits_monthly_used=Decimal("10"),
+            compute_units_monthly_limit=Decimal("10"),
+            compute_units_monthly_used=Decimal("10"),
         )
         grant_soon = ComputeGrant(
             user_id="user01",
@@ -462,8 +462,8 @@ class TestConsumeComputeCredits:
         monkeypatch.setattr("treadstone.services.metering_service.utc_now", lambda: FIXED_NOW)
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("10"),
-            compute_credits_monthly_used=Decimal("12"),
+            compute_units_monthly_limit=Decimal("10"),
+            compute_units_monthly_used=Decimal("12"),
         )
         svc = MeteringService()
         svc._get_user_plan_for_update = AsyncMock(return_value=plan)
@@ -747,8 +747,8 @@ class TestCheckComputeQuota:
     async def test_sufficient_monthly_passes(self):
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("100"),
-            compute_credits_monthly_used=Decimal("50"),
+            compute_units_monthly_limit=Decimal("100"),
+            compute_units_monthly_used=Decimal("50"),
         )
         svc = MeteringService()
         svc.get_user_plan = AsyncMock(return_value=plan)
@@ -759,8 +759,8 @@ class TestCheckComputeQuota:
     async def test_monthly_exhausted_but_extra_available(self):
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("100"),
-            compute_credits_monthly_used=Decimal("100"),
+            compute_units_monthly_limit=Decimal("100"),
+            compute_units_monthly_used=Decimal("100"),
         )
         svc = MeteringService()
         svc.get_user_plan = AsyncMock(return_value=plan)
@@ -771,8 +771,8 @@ class TestCheckComputeQuota:
     async def test_both_exhausted_raises(self):
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("100"),
-            compute_credits_monthly_used=Decimal("100"),
+            compute_units_monthly_limit=Decimal("100"),
+            compute_units_monthly_used=Decimal("100"),
         )
         svc = MeteringService()
         svc.get_user_plan = AsyncMock(return_value=plan)
@@ -786,8 +786,8 @@ class TestCheckComputeQuota:
     async def test_exactly_zero_remaining_raises(self):
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("10"),
-            compute_credits_monthly_used=Decimal("10"),
+            compute_units_monthly_limit=Decimal("10"),
+            compute_units_monthly_used=Decimal("10"),
         )
         svc = MeteringService()
         svc.get_user_plan = AsyncMock(return_value=plan)
@@ -800,8 +800,8 @@ class TestCheckComputeQuota:
         """Grace period overage: monthly_used > limit, but extra credits compensate."""
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("100"),
-            compute_credits_monthly_used=Decimal("105"),
+            compute_units_monthly_limit=Decimal("100"),
+            compute_units_monthly_used=Decimal("105"),
         )
         svc = MeteringService()
         svc.get_user_plan = AsyncMock(return_value=plan)
@@ -812,8 +812,8 @@ class TestCheckComputeQuota:
     async def test_error_includes_extra_remaining(self):
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("50"),
-            compute_credits_monthly_used=Decimal("50"),
+            compute_units_monthly_limit=Decimal("50"),
+            compute_units_monthly_used=Decimal("50"),
         )
         svc = MeteringService()
         svc.get_user_plan = AsyncMock(return_value=plan)
@@ -828,8 +828,8 @@ class TestGetTotalComputeRemaining:
     async def test_monthly_plus_extra(self):
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("100"),
-            compute_credits_monthly_used=Decimal("60"),
+            compute_units_monthly_limit=Decimal("100"),
+            compute_units_monthly_used=Decimal("60"),
         )
         svc = MeteringService()
         svc.get_user_plan = AsyncMock(return_value=plan)
@@ -841,8 +841,8 @@ class TestGetTotalComputeRemaining:
     async def test_overspent_returns_negative(self):
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("100"),
-            compute_credits_monthly_used=Decimal("110"),
+            compute_units_monthly_limit=Decimal("100"),
+            compute_units_monthly_used=Decimal("110"),
         )
         svc = MeteringService()
         svc.get_user_plan = AsyncMock(return_value=plan)
@@ -854,8 +854,8 @@ class TestGetTotalComputeRemaining:
     async def test_no_extra_credits(self):
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("100"),
-            compute_credits_monthly_used=Decimal("0"),
+            compute_units_monthly_limit=Decimal("100"),
+            compute_units_monthly_used=Decimal("0"),
         )
         svc = MeteringService()
         svc.get_user_plan = AsyncMock(return_value=plan)
@@ -867,8 +867,8 @@ class TestGetTotalComputeRemaining:
     async def test_monthly_unused_plus_large_extra(self):
         plan = _make_plan(
             "user01",
-            compute_credits_monthly_limit=Decimal("100"),
-            compute_credits_monthly_used=Decimal("0"),
+            compute_units_monthly_limit=Decimal("100"),
+            compute_units_monthly_used=Decimal("0"),
         )
         svc = MeteringService()
         svc.get_user_plan = AsyncMock(return_value=plan)

--- a/tests/unit/test_metering_tasks.py
+++ b/tests/unit/test_metering_tasks.py
@@ -103,8 +103,8 @@ def _make_plan(
     return UserPlan(
         user_id=user_id,
         tier=tier,
-        compute_credits_monthly_limit=monthly_limit,
-        compute_credits_monthly_used=monthly_used,
+        compute_units_monthly_limit=monthly_limit,
+        compute_units_monthly_used=monthly_used,
         storage_capacity_limit_gib=10,
         max_concurrent_running=3,
         max_sandbox_duration_seconds=7200,
@@ -731,7 +731,7 @@ class TestHandlePeriodRollover:
             new_cs = await handle_period_rollover(session, cs, plan)
 
         assert cs.ended_at == period_end
-        assert plan.compute_credits_monthly_used == Decimal("0")
+        assert plan.compute_units_monthly_used == Decimal("0")
         assert plan.period_start == period_end
         assert plan.warning_80_notified_at is None
         assert plan.warning_100_notified_at is None
@@ -813,7 +813,7 @@ class TestResetMonthlyCredits:
             result = await reset_monthly_credits(session)
 
         assert result == 1
-        assert plan.compute_credits_monthly_used == Decimal("0")
+        assert plan.compute_units_monthly_used == Decimal("0")
         assert plan.warning_80_notified_at is None
         assert plan.warning_100_notified_at is None
         session.commit.assert_awaited_once()

--- a/treadstone/api/metering_serializers.py
+++ b/treadstone/api/metering_serializers.py
@@ -18,8 +18,8 @@ def serialize_plan(plan: UserPlan) -> dict:
         "id": plan.id,
         "user_id": plan.user_id,
         "tier": plan.tier,
-        "compute_credits_monthly_limit": float(plan.compute_credits_monthly_limit),
-        "compute_credits_monthly_used": float(plan.compute_credits_monthly_used),
+        "compute_units_monthly_limit": float(plan.compute_units_monthly_limit),
+        "compute_units_monthly_used": float(plan.compute_units_monthly_used),
         "storage_capacity_limit_gib": plan.storage_capacity_limit_gib,
         "max_concurrent_running": plan.max_concurrent_running,
         "max_sandbox_duration_seconds": plan.max_sandbox_duration_seconds,
@@ -39,7 +39,7 @@ def serialize_plan(plan: UserPlan) -> dict:
 def serialize_template(tt: TierTemplate) -> dict:
     return {
         "tier": tt.tier_name,
-        "compute_credits_monthly": float(tt.compute_credits_monthly),
+        "compute_units_monthly": float(tt.compute_units_monthly),
         "storage_capacity_gib": tt.storage_capacity_gib,
         "max_concurrent_running": tt.max_concurrent_running,
         "max_sandbox_duration_seconds": tt.max_sandbox_duration_seconds,

--- a/treadstone/api/schemas.py
+++ b/treadstone/api/schemas.py
@@ -407,14 +407,13 @@ class BillingPeriod(BaseModel):
 
 
 class ComputeUsage(BaseModel):
-    vcpu_hours: float = Field(..., examples=[12.5])
-    memory_gib_hours: float = Field(..., examples=[25.0])
+    compute_unit_hours: float = Field(..., examples=[12.5])
     monthly_limit: float = Field(..., examples=[100.0])
     monthly_used: float = Field(..., examples=[45.5])
     monthly_remaining: float = Field(..., examples=[54.5])
     extra_remaining: float = Field(..., examples=[50.0])
     total_remaining: float = Field(..., examples=[104.5])
-    unit: str = Field(default="credits", examples=["credits"])
+    unit: str = Field(default="CU-hours", examples=["CU-hours"])
 
 
 class StorageUsage(BaseModel):
@@ -454,8 +453,8 @@ class UserPlanResponse(BaseModel):
     id: str = Field(..., examples=["planabc123def456"])
     user_id: str = Field(..., examples=["userabc123def456"])
     tier: str = Field(..., examples=["pro"])
-    compute_credits_monthly_limit: float = Field(..., examples=[100.0])
-    compute_credits_monthly_used: float = Field(..., examples=[45.5])
+    compute_units_monthly_limit: float = Field(..., examples=[100.0])
+    compute_units_monthly_used: float = Field(..., examples=[45.5])
     storage_capacity_limit_gib: int = Field(..., examples=[10])
     max_concurrent_running: int = Field(..., examples=[3])
     max_sandbox_duration_seconds: int = Field(..., examples=[7200])
@@ -482,6 +481,7 @@ class ComputeSessionItem(BaseModel):
     started_at: str = Field(..., examples=["2026-03-26T08:00:00+00:00"])
     ended_at: str | None = Field(default=None)
     duration_seconds: float = Field(..., examples=[7200])
+    compute_unit_hours: float = Field(..., examples=[1.0])
     vcpu_hours: float = Field(..., examples=[1.0])
     memory_gib_hours: float = Field(..., examples=[2.0])
     status: str = Field(..., examples=["active"])
@@ -547,7 +547,7 @@ class GrantsResponse(BaseModel):
 
 class UpdatePlanRequest(BaseModel):
     tier: str | None = Field(default=None, examples=["ultra"])
-    overrides: dict[str, Any] | None = Field(default=None, examples=[{"compute_credits_monthly_limit": 500}])
+    overrides: dict[str, Any] | None = Field(default=None, examples=[{"compute_units_monthly_limit": 500}])
 
     @model_validator(mode="after")
     def at_least_one_field(self) -> UpdatePlanRequest:
@@ -599,7 +599,7 @@ class CreateStorageQuotaGrantResponse(BaseModel):
 
 class TierTemplateItem(BaseModel):
     tier: str = Field(..., examples=["pro"])
-    compute_credits_monthly: float = Field(..., examples=[100.0])
+    compute_units_monthly: float = Field(..., examples=[100.0])
     storage_capacity_gib: int = Field(..., examples=[10])
     max_concurrent_running: int = Field(..., examples=[3])
     max_sandbox_duration_seconds: int = Field(..., examples=[7200])
@@ -617,7 +617,7 @@ class TierTemplateListResponse(BaseModel):
 
 
 class UpdateTierTemplateRequest(BaseModel):
-    compute_credits_monthly: float | None = Field(default=None, examples=[150])
+    compute_units_monthly: float | None = Field(default=None, examples=[150])
     storage_capacity_gib: int | None = Field(default=None, examples=[15])
     max_concurrent_running: int | None = Field(default=None, examples=[5])
     max_sandbox_duration_seconds: int | None = Field(default=None, examples=[14400])
@@ -631,7 +631,7 @@ class UpdateTierTemplateRequest(BaseModel):
     @model_validator(mode="after")
     def at_least_one_update(self) -> UpdateTierTemplateRequest:
         updatable = (
-            self.compute_credits_monthly,
+            self.compute_units_monthly,
             self.storage_capacity_gib,
             self.max_concurrent_running,
             self.max_sandbox_duration_seconds,

--- a/treadstone/api/usage.py
+++ b/treadstone/api/usage.py
@@ -46,6 +46,7 @@ def _serialize_session(cs: ComputeSession) -> dict:
     now = utc_now()
     end = cs.ended_at or now
     duration = (end - cs.started_at).total_seconds()
+    cu_hours = float(max(cs.vcpu_hours, cs.memory_gib_hours / 2))
     return {
         "id": cs.id,
         "sandbox_id": cs.sandbox_id,
@@ -55,6 +56,7 @@ def _serialize_session(cs: ComputeSession) -> dict:
         "started_at": iso(cs.started_at),
         "ended_at": iso(cs.ended_at),
         "duration_seconds": duration,
+        "compute_unit_hours": cu_hours,
         "vcpu_hours": float(cs.vcpu_hours),
         "memory_gib_hours": float(cs.memory_gib_hours),
         "status": "active" if cs.ended_at is None else "completed",

--- a/treadstone/models/metering.py
+++ b/treadstone/models/metering.py
@@ -22,7 +22,7 @@ class TierTemplate(Base):
 
     id: Mapped[str] = mapped_column(String(24), primary_key=True, default=lambda: "tt" + random_id())
     tier_name: Mapped[str] = mapped_column(String(16), unique=True, nullable=False)
-    compute_credits_monthly: Mapped[Decimal] = mapped_column(Numeric(10, 4), nullable=False)
+    compute_units_monthly: Mapped[Decimal] = mapped_column(Numeric(10, 4), nullable=False)
     storage_capacity_gib: Mapped[int] = mapped_column(Integer, nullable=False)
     max_concurrent_running: Mapped[int] = mapped_column(Integer, nullable=False)
     max_sandbox_duration_seconds: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -43,7 +43,7 @@ class UserPlan(Base):
     tier: Mapped[str] = mapped_column(String(16), nullable=False)
 
     # Entitlements (copied from TierTemplate, can be overridden)
-    compute_credits_monthly_limit: Mapped[Decimal] = mapped_column(Numeric(10, 4), nullable=False)
+    compute_units_monthly_limit: Mapped[Decimal] = mapped_column(Numeric(10, 4), nullable=False)
     storage_capacity_limit_gib: Mapped[int] = mapped_column(Integer, nullable=False)
     max_concurrent_running: Mapped[int] = mapped_column(Integer, nullable=False)
     max_sandbox_duration_seconds: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -53,7 +53,7 @@ class UserPlan(Base):
     # Current period state
     period_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     period_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    compute_credits_monthly_used: Mapped[Decimal] = mapped_column(Numeric(10, 4), nullable=False, default=Decimal("0"))
+    compute_units_monthly_used: Mapped[Decimal] = mapped_column(Numeric(10, 4), nullable=False, default=Decimal("0"))
 
     # Admin overrides
     overrides: Mapped[dict | None] = mapped_column(JSON, nullable=True)

--- a/treadstone/services/metering_helpers.py
+++ b/treadstone/services/metering_helpers.py
@@ -1,4 +1,4 @@
-"""Metering helper functions — credit rate calculation, storage size parsing, and shared data types."""
+"""Metering helper functions — Compute Unit rate calculation, storage size parsing, and shared data types."""
 
 import logging
 from dataclasses import dataclass
@@ -37,10 +37,10 @@ def get_template_resource_spec(template: str) -> tuple[Decimal, Decimal]:
     return spec["vcpu"], spec["memory_gib"]
 
 
-def calculate_credit_rate(template: str) -> Decimal:
-    """Return the credit rate (credits/hour) for the given sandbox template.
+def calculate_cu_rate(template: str) -> Decimal:
+    """Return the Compute Unit rate (CU/hour) for the given sandbox template.
 
-    Formula: max(vCPU_request, memory_GiB_request / 2)
+    Formula: CU = max(vCPU_request, memory_GiB_request / 2)
     Checks the K8s-synced runtime cache first, falls back to static TEMPLATE_SPECS.
     """
     spec = _resolve_spec(template)

--- a/treadstone/services/metering_service.py
+++ b/treadstone/services/metering_service.py
@@ -30,7 +30,7 @@ import logging
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import case, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -55,7 +55,7 @@ from treadstone.models.sandbox import Sandbox, SandboxStatus
 from treadstone.models.user import utc_now
 from treadstone.services.metering_helpers import (
     ConsumeResult,
-    calculate_credit_rate,
+    calculate_cu_rate,
     compute_period_bounds,
     get_template_resource_spec,
 )
@@ -69,7 +69,7 @@ WELCOME_BONUS_EXPIRY_DAYS = 90
 
 ALLOWED_PLAN_OVERRIDES = frozenset(
     {
-        "compute_credits_monthly_limit",
+        "compute_units_monthly_limit",
         "storage_capacity_limit_gib",
         "max_concurrent_running",
         "max_sandbox_duration_seconds",
@@ -110,7 +110,7 @@ class MeteringService:
         plan = UserPlan(
             user_id=user_id,
             tier=template.tier_name,
-            compute_credits_monthly_limit=template.compute_credits_monthly,
+            compute_units_monthly_limit=template.compute_units_monthly,
             storage_capacity_limit_gib=template.storage_capacity_gib,
             max_concurrent_running=template.max_concurrent_running,
             max_sandbox_duration_seconds=template.max_sandbox_duration_seconds,
@@ -165,7 +165,7 @@ class MeteringService:
         now = utc_now()
 
         plan.tier = template.tier_name
-        plan.compute_credits_monthly_limit = template.compute_credits_monthly
+        plan.compute_units_monthly_limit = template.compute_units_monthly
         plan.storage_capacity_limit_gib = template.storage_capacity_gib
         plan.max_concurrent_running = template.max_concurrent_running
         plan.max_sandbox_duration_seconds = template.max_sandbox_duration_seconds
@@ -214,13 +214,13 @@ class MeteringService:
         user_id: str,
         amount: Decimal,
     ) -> ConsumeResult:
-        """Consume compute credits using the dual-pool algorithm.
+        """Consume Compute Units using the dual-pool algorithm.
 
         Deduction order:
-          1. Monthly pool  (UserPlan.compute_credits_monthly_used)
-          2. Extra pool    (CreditGrant rows, FIFO by expires_at ASC NULLS LAST)
+          1. Monthly pool  (UserPlan.compute_units_monthly_used)
+          2. Extra pool    (ComputeGrant rows, FIFO by expires_at ASC NULLS LAST)
 
-        CreditGrant rows are locked with SELECT … FOR UPDATE to prevent
+        ComputeGrant rows are locked with SELECT ... FOR UPDATE to prevent
         concurrent over-deduction during leader-overlap or admin operations.
 
         A positive ``shortfall`` in the result means both pools are exhausted.
@@ -229,11 +229,11 @@ class MeteringService:
             return ConsumeResult(monthly=Decimal("0"), extra=Decimal("0"), shortfall=Decimal("0"))
 
         plan = await self._get_user_plan_for_update(session, user_id)
-        monthly_remaining = plan.compute_credits_monthly_limit - plan.compute_credits_monthly_used
+        monthly_remaining = plan.compute_units_monthly_limit - plan.compute_units_monthly_used
 
         # ── Phase 1: Monthly pool ──
         if monthly_remaining >= amount:
-            plan.compute_credits_monthly_used += amount
+            plan.compute_units_monthly_used += amount
             plan.gmt_updated = utc_now()
             session.add(plan)
             return ConsumeResult(monthly=amount, extra=Decimal("0"), shortfall=Decimal("0"))
@@ -242,7 +242,7 @@ class MeteringService:
         extra_needed = amount - monthly_consumed
 
         if monthly_consumed > Decimal("0"):
-            plan.compute_credits_monthly_used = plan.compute_credits_monthly_limit
+            plan.compute_units_monthly_used = plan.compute_units_monthly_limit
             plan.gmt_updated = utc_now()
             session.add(plan)
 
@@ -368,10 +368,10 @@ class MeteringService:
             cs.vcpu_hours += cs.vcpu_request * elapsed_hours
             cs.memory_gib_hours += cs.memory_gib_request * elapsed_hours
 
-            credit_rate = calculate_credit_rate(cs.template)
-            credit_delta = credit_rate * elapsed_hours
-            if credit_delta > Decimal("0"):
-                await self.consume_compute_credits(session, cs.user_id, credit_delta)
+            cu_rate = calculate_cu_rate(cs.template)
+            cu_delta = cu_rate * elapsed_hours
+            if cu_delta > Decimal("0"):
+                await self.consume_compute_credits(session, cs.user_id, cu_delta)
 
         cs.ended_at = now
         cs.last_metered_at = now
@@ -484,19 +484,19 @@ class MeteringService:
         session: AsyncSession,
         user_id: str,
     ) -> None:
-        """Verify that the user has remaining compute credits.
+        """Verify that the user has remaining Compute Units.
 
         Checks monthly remaining + extra ComputeGrants.
         Raises ComputeQuotaExceededError (402) when total_remaining <= 0.
         """
         plan = await self.get_user_plan(session, user_id)
-        monthly_remaining = plan.compute_credits_monthly_limit - plan.compute_credits_monthly_used
+        monthly_remaining = plan.compute_units_monthly_limit - plan.compute_units_monthly_used
         extra_remaining = await self.get_extra_compute_remaining(session, user_id)
         total_remaining = monthly_remaining + extra_remaining
         if total_remaining <= Decimal("0"):
             raise ComputeQuotaExceededError(
-                monthly_used=float(plan.compute_credits_monthly_used),
-                monthly_limit=float(plan.compute_credits_monthly_limit),
+                monthly_used=float(plan.compute_units_monthly_used),
+                monthly_limit=float(plan.compute_units_monthly_limit),
                 extra_remaining=float(extra_remaining),
             )
 
@@ -558,12 +558,12 @@ class MeteringService:
         session: AsyncSession,
         user_id: str,
     ) -> Decimal:
-        """Return total compute credits remaining (monthly + extra).
+        """Return total Compute Units remaining (monthly + extra).
 
         May be negative in grace-period overage scenarios.
         """
         plan = await self.get_user_plan(session, user_id)
-        monthly_remaining = plan.compute_credits_monthly_limit - plan.compute_credits_monthly_used
+        monthly_remaining = plan.compute_units_monthly_limit - plan.compute_units_monthly_used
         extra_remaining = await self.get_extra_compute_remaining(session, user_id)
         return monthly_remaining + extra_remaining
 
@@ -706,6 +706,28 @@ class MeteringService:
         row = result.one()
         return row[0], row[1]
 
+    async def get_compute_unit_hours_for_period(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        period_start: datetime,
+        period_end: datetime,
+    ) -> Decimal:
+        """Sum per-session Compute Unit hours: SUM(max(vcpu_hours, memory_gib_hours / 2))."""
+        mem_half = ComputeSession.memory_gib_hours / 2
+        cu_per_session = case(
+            (ComputeSession.vcpu_hours >= mem_half, ComputeSession.vcpu_hours),
+            else_=mem_half,
+        )
+        result = await session.execute(
+            select(func.coalesce(func.sum(cu_per_session), Decimal("0"))).where(
+                ComputeSession.user_id == user_id,
+                ComputeSession.started_at < period_end,
+                or_(ComputeSession.ended_at.is_(None), ComputeSession.ended_at > period_start),
+            )
+        )
+        return result.scalar_one()
+
     async def get_usage_summary(self, session: AsyncSession, user_id: str) -> dict:
         """Assemble the complete usage overview for GET /v1/usage."""
         plan = await self.get_user_plan(session, user_id)
@@ -714,15 +736,14 @@ class MeteringService:
         current_storage_used = await self.get_current_storage_used(session, user_id)
         running_count = await self._count_running_sandboxes(session, user_id)
 
-        vcpu_hours, memory_gib_hours = await self.get_compute_usage_for_period(
+        compute_unit_hours = await self.get_compute_unit_hours_for_period(
             session, user_id, plan.period_start, plan.period_end
         )
 
         extra_compute_remaining = await self.get_extra_compute_remaining(session, user_id)
-        monthly_remaining = max(Decimal("0"), plan.compute_credits_monthly_limit - plan.compute_credits_monthly_used)
+        monthly_remaining = max(Decimal("0"), plan.compute_units_monthly_limit - plan.compute_units_monthly_used)
         total_compute_remaining = monthly_remaining + extra_compute_remaining
 
-        # Storage gib-hours for the current period
         storage_result = await session.execute(
             select(func.coalesce(func.sum(StorageLedger.gib_hours_consumed), Decimal("0"))).where(
                 StorageLedger.user_id == user_id,
@@ -744,14 +765,13 @@ class MeteringService:
                 "end": plan.period_end.isoformat(),
             },
             "compute": {
-                "vcpu_hours": float(vcpu_hours),
-                "memory_gib_hours": float(memory_gib_hours),
-                "monthly_limit": float(plan.compute_credits_monthly_limit),
-                "monthly_used": float(plan.compute_credits_monthly_used),
+                "compute_unit_hours": float(compute_unit_hours),
+                "monthly_limit": float(plan.compute_units_monthly_limit),
+                "monthly_used": float(plan.compute_units_monthly_used),
                 "monthly_remaining": float(monthly_remaining),
                 "extra_remaining": float(extra_compute_remaining),
                 "total_remaining": float(total_compute_remaining),
-                "unit": "credits",
+                "unit": "CU-hours",
             },
             "storage": {
                 "gib_hours": float(storage_gib_hours),
@@ -910,7 +930,7 @@ class MeteringService:
         result = await session.execute(
             select(TierTemplate)
             .where(TierTemplate.is_active.is_(True))
-            .order_by(TierTemplate.compute_credits_monthly.asc())
+            .order_by(TierTemplate.compute_units_monthly.asc())
         )
         return list(result.scalars().all())
 
@@ -930,7 +950,7 @@ class MeteringService:
         now = utc_now()
 
         updatable_fields = {
-            "compute_credits_monthly",
+            "compute_units_monthly",
             "storage_capacity_gib",
             "max_concurrent_running",
             "max_sandbox_duration_seconds",
@@ -953,7 +973,7 @@ class MeteringService:
             )
             plans = result.scalars().all()
             field_map = {
-                "compute_credits_monthly": "compute_credits_monthly_limit",
+                "compute_units_monthly": "compute_units_monthly_limit",
                 "storage_capacity_gib": "storage_capacity_limit_gib",
                 "max_concurrent_running": "max_concurrent_running",
                 "max_sandbox_duration_seconds": "max_sandbox_duration_seconds",

--- a/treadstone/services/metering_tasks.py
+++ b/treadstone/services/metering_tasks.py
@@ -25,7 +25,7 @@ from treadstone.models.metering import ComputeSession, StorageLedger, StorageSta
 from treadstone.models.sandbox import Sandbox, SandboxStatus
 from treadstone.models.user import utc_now
 from treadstone.services.audit import record_audit_event
-from treadstone.services.metering_helpers import calculate_credit_rate
+from treadstone.services.metering_helpers import calculate_cu_rate
 from treadstone.services.metering_service import MeteringService
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ async def tick_metering(session: AsyncSession) -> int:
     conflict rolls back only that single session, not the entire tick batch.
 
     After accumulating raw hours, computes credit deltas per user using
-    ``calculate_credit_rate()`` and consumes them from the dual pool
+    ``calculate_cu_rate()`` and consumes them from the dual pool
     (monthly first, then ComputeGrant FIFO).
 
     Returns the number of sessions successfully metered.
@@ -101,9 +101,9 @@ async def tick_metering(session: AsyncSession) -> int:
             )
             continue
 
-        credit_rate = calculate_credit_rate(cs.template)
-        credit_delta = credit_rate * elapsed_hours
-        user_credit_deltas[cs.user_id] = user_credit_deltas.get(cs.user_id, Decimal("0")) + credit_delta
+        cu_rate = calculate_cu_rate(cs.template)
+        cu_delta = cu_rate * elapsed_hours
+        user_credit_deltas[cs.user_id] = user_credit_deltas.get(cs.user_id, Decimal("0")) + cu_delta
         metered += 1
 
     for user_id, total_delta in user_credit_deltas.items():
@@ -171,8 +171,8 @@ async def check_warning_thresholds(session: AsyncSession) -> None:
         plan = await _metering.get_user_plan(session, user_id)
         total_remaining = await _metering.get_total_compute_remaining(session, user_id)
 
-        monthly_limit = plan.compute_credits_monthly_limit
-        monthly_used = plan.compute_credits_monthly_used
+        monthly_limit = plan.compute_units_monthly_limit
+        monthly_used = plan.compute_units_monthly_used
         extra_remaining = await _metering.get_extra_compute_remaining(session, user_id)
 
         # 100% warning: monthly + extra fully exhausted
@@ -280,8 +280,8 @@ async def _handle_exhausted(
             metadata={
                 "tier": plan.tier,
                 "grace_period_seconds": plan.grace_period_seconds,
-                "monthly_used": float(plan.compute_credits_monthly_used),
-                "monthly_limit": float(plan.compute_credits_monthly_limit),
+                "monthly_used": float(plan.compute_units_monthly_used),
+                "monthly_limit": float(plan.compute_units_monthly_limit),
             },
         )
         return
@@ -289,7 +289,7 @@ async def _handle_exhausted(
     elapsed = (now - plan.grace_period_started_at).total_seconds()
 
     overage = abs(total_remaining)
-    absolute_cap = plan.compute_credits_monthly_limit * ABSOLUTE_OVERAGE_CAP_RATIO
+    absolute_cap = plan.compute_units_monthly_limit * ABSOLUTE_OVERAGE_CAP_RATIO
     exceeded_absolute_cap = overage > absolute_cap
 
     if elapsed > plan.grace_period_seconds or exceeded_absolute_cap:
@@ -415,7 +415,7 @@ async def handle_period_rollover(
     new_period_start = period_boundary
     new_period_end = period_boundary + relativedelta(months=1)
 
-    plan.compute_credits_monthly_used = Decimal("0")
+    plan.compute_units_monthly_used = Decimal("0")
     plan.period_start = new_period_start
     plan.period_end = new_period_end
     plan.warning_80_notified_at = None
@@ -487,7 +487,7 @@ async def reset_monthly_credits(session: AsyncSession) -> int:
             new_period_start = plan.period_end
             new_period_end = plan.period_end + relativedelta(months=1)
 
-            plan.compute_credits_monthly_used = Decimal("0")
+            plan.compute_units_monthly_used = Decimal("0")
             plan.period_start = new_period_start
             plan.period_end = new_period_end
             plan.warning_80_notified_at = None

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -1255,6 +1255,11 @@ export interface components {
              */
             duration_seconds: number;
             /**
+             * Compute Unit Hours
+             * @example 1
+             */
+            compute_unit_hours: number;
+            /**
              * Vcpu Hours
              * @example 1
              */
@@ -1293,15 +1298,10 @@ export interface components {
         /** ComputeUsage */
         ComputeUsage: {
             /**
-             * Vcpu Hours
+             * Compute Unit Hours
              * @example 12.5
              */
-            vcpu_hours: number;
-            /**
-             * Memory Gib Hours
-             * @example 25
-             */
-            memory_gib_hours: number;
+            compute_unit_hours: number;
             /**
              * Monthly Limit
              * @example 100
@@ -1329,8 +1329,8 @@ export interface components {
             total_remaining: number;
             /**
              * Unit
-             * @default credits
-             * @example credits
+             * @default CU-hours
+             * @example CU-hours
              */
             unit: string;
         };
@@ -2099,10 +2099,10 @@ export interface components {
              */
             tier: string;
             /**
-             * Compute Credits Monthly
+             * Compute Units Monthly
              * @example 100
              */
-            compute_credits_monthly: number;
+            compute_units_monthly: number;
             /**
              * Storage Capacity Gib
              * @example 10
@@ -2190,7 +2190,7 @@ export interface components {
             /**
              * Overrides
              * @example {
-             *       "compute_credits_monthly_limit": 500
+             *       "compute_units_monthly_limit": 500
              *     }
              */
             overrides?: {
@@ -2200,10 +2200,10 @@ export interface components {
         /** UpdateTierTemplateRequest */
         UpdateTierTemplateRequest: {
             /**
-             * Compute Credits Monthly
+             * Compute Units Monthly
              * @example 150
              */
-            compute_credits_monthly?: number | null;
+            compute_units_monthly?: number | null;
             /**
              * Storage Capacity Gib
              * @example 15
@@ -2248,10 +2248,10 @@ export interface components {
              */
             tier: string;
             /**
-             * Compute Credits Monthly
+             * Compute Units Monthly
              * @example 100
              */
-            compute_credits_monthly: number;
+            compute_units_monthly: number;
             /**
              * Storage Capacity Gib
              * @example 10
@@ -2428,15 +2428,15 @@ export interface components {
              */
             tier: string;
             /**
-             * Compute Credits Monthly Limit
+             * Compute Units Monthly Limit
              * @example 100
              */
-            compute_credits_monthly_limit: number;
+            compute_units_monthly_limit: number;
             /**
-             * Compute Credits Monthly Used
+             * Compute Units Monthly Used
              * @example 45.5
              */
-            compute_credits_monthly_used: number;
+            compute_units_monthly_used: number;
             /**
              * Storage Capacity Limit Gib
              * @example 10

--- a/web/src/pages/app/create-sandbox.tsx
+++ b/web/src/pages/app/create-sandbox.tsx
@@ -410,9 +410,9 @@ export function CreateSandboxPage() {
                     Compute usage
                   </p>
                   <p className="mt-1 text-lg font-bold text-foreground">
-                    {usage.compute.vcpu_hours.toFixed(2)}{" "}
+                    {usage.compute.compute_unit_hours.toFixed(2)}{" "}
                     <span className="text-xs font-normal text-muted-foreground">
-                      vCPU-h
+                      CU-h
                     </span>
                   </p>
                 </li>

--- a/web/src/pages/app/dashboard.tsx
+++ b/web/src/pages/app/dashboard.tsx
@@ -50,7 +50,7 @@ function InlineMetrics() {
   const { data: usage } = useUsageOverview()
   const { data: grants } = useGrants()
 
-  const computeVcpuHours = usage ? usage.compute.vcpu_hours.toFixed(2) : "—"
+  const computeUnitHours = usage ? usage.compute.compute_unit_hours.toFixed(2) : "—"
   const tier = usage?.tier ?? "—"
 
   const welcomeBonus = useMemo(() => {
@@ -67,8 +67,8 @@ function InlineMetrics() {
           Compute Usage
         </p>
         <div className="mt-2 flex items-baseline gap-2">
-          <span className="text-2xl font-bold text-foreground">{computeVcpuHours}</span>
-          <span className="text-xs text-muted-foreground">vCPU-hours</span>
+          <span className="text-2xl font-bold text-foreground">{computeUnitHours}</span>
+          <span className="text-xs text-muted-foreground">CU-hours</span>
         </div>
       </div>
       <div className="border-r border-border/15 bg-card px-6 py-6">
@@ -90,7 +90,7 @@ function InlineMetrics() {
         </p>
         <div className="mt-2 flex items-baseline gap-2">
           <span className="text-2xl font-bold text-foreground">{welcomeBonus}</span>
-          <span className="text-xs text-muted-foreground">vCPU-hours remaining</span>
+          <span className="text-xs text-muted-foreground">CU-hours remaining</span>
         </div>
       </div>
     </div>

--- a/web/src/pages/app/usage.tsx
+++ b/web/src/pages/app/usage.tsx
@@ -78,8 +78,7 @@ export function UsagePage() {
       ? formatPeriod(usage.billing_period.start, usage.billing_period.end)
       : "—"
 
-  const computeVcpuHours = usage?.compute.vcpu_hours ?? 0
-  const computeMemGibHours = usage?.compute.memory_gib_hours ?? 0
+  const computeUnitHours = usage?.compute.compute_unit_hours ?? 0
   const monthlyLimit = usage?.compute.monthly_limit ?? 0
   const monthlyUsed = usage?.compute.monthly_used ?? 0
   const totalRemaining = usage?.compute.total_remaining ?? 0
@@ -106,26 +105,20 @@ export function UsagePage() {
             <div className="mt-3 flex flex-col gap-1">
               <div className="flex items-baseline gap-2">
                 <span className="text-2xl font-bold tabular-nums text-foreground">
-                  {computeVcpuHours.toFixed(2)}
+                  {computeUnitHours.toFixed(2)}
                 </span>
-                <span className="text-xs text-muted-foreground">vCPU-hours</span>
-              </div>
-              <div className="flex items-baseline gap-2">
-                <span className="text-lg font-semibold tabular-nums text-foreground">
-                  {computeMemGibHours.toFixed(2)}
-                </span>
-                <span className="text-xs text-muted-foreground">GiB-hours</span>
+                <span className="text-xs text-muted-foreground">CU-hours</span>
               </div>
               <div className="mt-3 border-t border-border/15 pt-3">
                 <p className="text-sm text-foreground">
                   <span className="tabular-nums">{monthlyUsed.toFixed(1)}</span>
                   {" / "}
                   <span className="tabular-nums">{monthlyLimit.toFixed(1)}</span>
-                  {" credits used"}
+                  {" CU-hours used"}
                 </p>
                 <p className="mt-1 text-xs text-muted-foreground">
                   Total remaining:{" "}
-                  <span className="tabular-nums">{totalRemaining.toFixed(1)}</span> credits
+                  <span className="tabular-nums">{totalRemaining.toFixed(1)}</span> CU-hours
                 </p>
               </div>
             </div>
@@ -207,12 +200,11 @@ export function UsagePage() {
               <tr className="border-b border-border/15 bg-card">
                 {(
                   [
-                    ["Sandbox", "w-[20%]"],
-                    ["Template", "w-[14%]"],
-                    ["Duration", "w-[14%]"],
-                    ["vCPU-hours", "w-[14%]"],
-                    ["Mem GiB-hours", "w-[14%]"],
-                    ["Status", "w-[12%]"],
+                    ["Sandbox", "w-[22%]"],
+                    ["Template", "w-[16%]"],
+                    ["Duration", "w-[16%]"],
+                    ["CU-hours", "w-[16%]"],
+                    ["Status", "w-[14%]"],
                   ] as const
                 ).map(([label, cls]) => (
                   <th
@@ -236,7 +228,7 @@ export function UsagePage() {
                 </tr>
               ) : sessions.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="px-6 py-12 text-center text-sm text-muted-foreground">
+                  <td colSpan={5} className="px-6 py-12 text-center text-sm text-muted-foreground">
                     No compute sessions yet.
                   </td>
                 </tr>
@@ -252,10 +244,7 @@ export function UsagePage() {
                       {formatDuration(row.duration_seconds)}
                     </td>
                     <td className="px-6 py-4 text-xs tabular-nums text-foreground">
-                      {row.vcpu_hours.toFixed(4)}
-                    </td>
-                    <td className="px-6 py-4 text-xs tabular-nums text-foreground">
-                      {row.memory_gib_hours.toFixed(4)}
+                      {row.compute_unit_hours.toFixed(4)}
                     </td>
                     <td className="px-6 py-4 text-xs capitalize text-foreground">{row.status}</td>
                   </tr>
@@ -295,7 +284,7 @@ export function UsagePage() {
             Compute grants
           </h3>
           <p className="mt-1 text-[11px] text-muted-foreground/80">
-            Compute credit grants (original / remaining).
+            Compute Unit grants (original / remaining).
           </p>
         </div>
         <div className="overflow-x-auto">
@@ -305,7 +294,7 @@ export function UsagePage() {
                 {(
                   [
                     ["Grant type", "w-[22%]"],
-                    ["Original (vCPU-h)", "w-[18%]"],
+                    ["Original (CU-h)", "w-[18%]"],
                     ["Remaining", "w-[18%]"],
                     ["Status", "w-[14%]"],
                     ["Expires", "w-[28%]"],

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -182,7 +182,7 @@ export function SignUpPage() {
       </form>
 
       <div className="mt-8 border-l-4 border-primary bg-primary/10 px-4 py-3 text-sm leading-relaxed text-muted-foreground">
-        New users start on the free tier: 10 vCPU-hours monthly + 50 vCPU-hours welcome bonus. All sandbox templates
+        New users start on the free tier: 10 CU-hours monthly + 50 CU-hours welcome bonus. All sandbox templates
         included.
       </div>
 

--- a/web/src/pages/internal/admin-metering.tsx
+++ b/web/src/pages/internal/admin-metering.tsx
@@ -31,7 +31,7 @@ interface EditTierDialogProps {
 function EditTierDialog({ tier, onClose }: EditTierDialogProps) {
   const updateTierTemplate = useUpdateTierTemplate()
 
-  const [compute, setCompute] = useState(String(tier.compute_credits_monthly))
+  const [compute, setCompute] = useState(String(tier.compute_units_monthly))
   const [storage, setStorage] = useState(String(tier.storage_capacity_gib))
   const [maxConcurrent, setMaxConcurrent] = useState(String(tier.max_concurrent_running))
   const [maxDuration, setMaxDuration] = useState(String(tier.max_sandbox_duration_seconds))
@@ -66,7 +66,7 @@ function EditTierDialog({ tier, onClose }: EditTierDialogProps) {
       {
         tierName: tier.tier,
         body: {
-          compute_credits_monthly: computeVal,
+          compute_units_monthly: computeVal,
           storage_capacity_gib: storageVal,
           max_concurrent_running: maxConcurrentVal,
           max_sandbox_duration_seconds: maxDurationVal,
@@ -301,7 +301,7 @@ function TierRow({
     <tr className={cn("border-b border-border/15", odd && "bg-[hsl(0,0%,4%)]")}>
       <td className="px-5 py-3 text-xs font-medium text-primary">{tier.tier}</td>
       <td className="px-5 py-3 text-xs text-foreground">
-        {tier.compute_credits_monthly} vCPU-h
+        {tier.compute_units_monthly} CU-h
       </td>
       <td className="px-5 py-3 text-xs text-foreground">
         {tier.storage_capacity_gib} GiB
@@ -399,8 +399,7 @@ function UserPlanSection() {
   }
 
   const tier = usage?.tier ?? "—"
-  const vcpuHours = usage?.compute.vcpu_hours ?? 0
-  const memGibHours = usage?.compute.memory_gib_hours ?? 0
+  const cuHours = usage?.compute.compute_unit_hours ?? 0
   const maxConcurrent = usage?.limits.max_concurrent_running ?? "—"
   const runningNow = usage?.limits.current_running ?? 0
 
@@ -471,15 +470,9 @@ function UserPlanSection() {
                 </div>
                 <div>
                   <p className="text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
-                    VCPU-HOURS
+                    CU-HOURS
                   </p>
-                  <p className="mt-1 text-base font-semibold text-foreground">{vcpuHours.toFixed(2)}</p>
-                </div>
-                <div>
-                  <p className="text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
-                    MEM GIB-HOURS
-                  </p>
-                  <p className="mt-1 text-base font-semibold text-foreground">{memGibHours.toFixed(2)}</p>
+                  <p className="mt-1 text-base font-semibold text-foreground">{cuHours.toFixed(2)}</p>
                 </div>
                 <div>
                   <p className="text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
@@ -510,7 +503,7 @@ function UserPlanSection() {
                 <div className="flex flex-wrap items-end gap-4 border-t border-border/15 pt-4">
                   <div className="flex flex-col gap-1">
                     <label className="text-[10px] font-medium text-muted-foreground">
-                      Compute grant (vCPU-h)
+                      Compute grant (CU-h)
                     </label>
                     <input
                       type="text"
@@ -650,7 +643,7 @@ function BatchGrantsSection() {
           BATCH GRANTS
         </span>
         <span className="text-[11px] text-muted-foreground/50">
-          — compute credits or storage quota, separate workflows
+          — Compute Unit or storage quota, separate workflows
         </span>
       </div>
 
@@ -674,7 +667,7 @@ function BatchGrantsSection() {
             </div>
             <div className="flex flex-col gap-1">
               <label className="text-[11px] font-medium text-muted-foreground">
-                Amount (vCPU-h)
+                Amount (CU-h)
               </label>
               <input
                 type="text"
@@ -771,7 +764,7 @@ export function AdminMeteringPage() {
       <div>
         <h1 className="text-[28px] font-bold tracking-tight text-foreground">Admin Metering</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">
-          Manage tier templates, user plans, and credit grants.
+          Manage tier templates, user plans, and Compute Unit grants.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- Rename `credits` field to `compute_units` in metering models, serializers, and API schemas
- Update metering service, tasks, and helpers to use the new field name
- Update all frontend pages (dashboard, usage, create-sandbox, admin-metering) to use `compute_units`
- Update all unit and API tests to reflect the rename
- Add Alembic migration `e1a2b3c4d5f6` to rename the `credits` column to `compute_units`

## Test Plan
- [x] `make test` passes locally
- [x] `make lint` passes (pre-commit hook ran clean)
- [ ] CI green

Made with [Cursor](https://cursor.com)