### PR TITLE
chore: bump version to 0.6.8

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.6.7"
+version = "0.6.8"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.6.7"
+version = "0.6.8"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.6.7"
+version = "0.6.8"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1863,7 +1863,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.6.7"
+version = "0.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "treadstone-web",
   "private": true,
-  "version": "0.6.7",
+  "version": "0.6.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/app-version.ts
+++ b/web/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.7";
+export const APP_VERSION = "0.6.8";


### PR DESCRIPTION
## Summary
- Bump version to 0.6.8 across all packages (server, CLI, SDK, web)

## Changes
- `pyproject.toml`: 0.6.7 → 0.6.8
- `cli/pyproject.toml`: 0.6.7 → 0.6.8
- `sdk/python/pyproject.toml`: 0.6.7 → 0.6.8
- `web/package.json`: 0.6.7 → 0.6.8
- `web/src/lib/app-version.ts`: updated
- `uv.lock`: updated

## Release Note
Includes `feat: rename credits to compute_units across metering system`.

Made with [Cursor](https://cursor.com)