### PR TITLE
chore: bump version to 0.6.9

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.6.8"
+version = "0.6.9"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.6.8"
+version = "0.6.9"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.6.8"
+version = "0.6.9"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1863,7 +1863,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.6.8"
+version = "0.6.9"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "treadstone-web",
   "private": true,
-  "version": "0.6.8",
+  "version": "0.6.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/app-version.ts
+++ b/web/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.8";
+export const APP_VERSION = "0.6.9";


### PR DESCRIPTION
## Summary

Bump version to 0.6.9.

## Included in this release

- **fix**: soft-delete sandbox to resolve FK violation on delete
- **fix**: update k8s sync and sandbox service to use soft-delete pattern
- **fix**: disable metering enforcement in tests (`.env` was leaking into test env)
- **chore**: update k8s sync unit tests for soft-delete assertions
- **feat**: admin metering UI — full grant forms (grant_type, reason, campaign_id, expires_at)
- **chore**: usage & sandbox list UI improvements

## Test plan

- [x] `make test` — 569 passed, 1 skipped

Made with [Cursor](https://cursor.com)