### PR TITLE
fix: make web link expires_at nullable in response schema

### DIFF
--- a/treadstone/api/schemas.py
+++ b/treadstone/api/schemas.py
@@ -148,7 +148,7 @@ class SandboxWebLinkResponse(BaseModel):
         ...,
         examples=["https://sandbox-sbabc123def456.treadstone-ai.dev/_treadstone/open?token=swlabc123"],
     )
-    expires_at: datetime = Field(..., examples=["2026-03-31T12:00:00+00:00"])
+    expires_at: datetime | None = Field(default=None, examples=["2026-03-31T12:00:00+00:00"])
 
 
 class SandboxWebLinkStatusResponse(BaseModel):


### PR DESCRIPTION
## Summary
- `SandboxWebLinkResponse.expires_at` changed from `datetime` (required) to `datetime | None` (optional, default `None`)
- Aligns with the backend change that sets `gmt_expires=None` by default so web links never expire

## Test Plan
- [x] pre-commit checks passed
- [x] make test

Made with [Cursor](https://cursor.com)