### PR TITLE
[codex] add reusable audit skills

### DIFF
--- a/.agents/skills/architecture-data-flow-trace/SKILL.md
+++ b/.agents/skills/architecture-data-flow-trace/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: architecture-data-flow-trace
+description: Trace the real runtime architecture and data flow of a subsystem from the current code. Use when the user asks to map request flow, state transitions, background jobs, repair loops, read paths, sequence diagrams, or explain how data moves through the system end to end.
+---
+
+# Architecture Data Flow Trace
+
+Use this skill when the main task is to explain how a subsystem actually runs, not just what files exist.
+
+This skill is especially useful as support for `system-audit-report` and `audit-report-refresh` when the subsystem has multiple entrypoints, asynchronous jobs, or eventual-consistency behavior.
+
+## Goal
+
+Produce a runtime map of the subsystem that makes these questions easy to answer:
+
+- where requests or events enter
+- how state changes over time
+- where data is persisted
+- which background jobs or watchers participate
+- how drift is repaired
+- how results become visible to users
+
+## Core Rules
+
+1. Trace from the current code, not from docs or assumptions.
+2. Follow real execution paths across layers:
+   - API
+   - service
+   - model
+   - task / worker
+   - external system integration
+   - user-visible read path
+3. Distinguish direct evidence from inferred behavior.
+4. Keep the trace end-to-end; do not stop at the first request handler.
+5. Call out broken or missing edges explicitly.
+
+## Required Workflow
+
+### 1. Lock the Trace Baseline
+
+Record:
+
+- trace date
+- current branch
+- commit hash
+- subsystem being traced
+
+### 2. Define the Trace Slices
+
+Break the subsystem into a few concrete flows, for example:
+
+- create
+- update
+- consume
+- enforce
+- reconcile
+- delete
+
+If the subsystem is large, trace the most important flows first instead of trying to describe everything at once.
+
+### 3. Find the Entrypoints
+
+Use `rg` to identify where each flow starts:
+
+- API routes
+- CLI commands
+- webhooks
+- cron jobs
+- watch loops
+- signal handlers
+- event consumers
+
+List the concrete functions or classes that receive the first input.
+
+### 4. Follow the Write Path
+
+For each flow, identify:
+
+1. the first orchestrating function
+2. downstream service calls
+3. database writes
+4. side effects in external systems
+5. emitted follow-up work
+
+Be explicit about ordering, especially when state is committed before external calls or vice versa.
+
+### 5. Follow the Async and Repair Paths
+
+Do not stop after the synchronous request path.
+
+Trace:
+
+- scheduled jobs
+- task runners
+- reconcile loops
+- best-effort repair paths
+- cleanup or compensation logic
+- watchdogs and auto-stop logic
+
+If consistency depends on a later job, say so.
+
+### 6. Follow the Read Path
+
+Identify how the final state becomes visible:
+
+- API read endpoints
+- admin endpoints
+- UI pages
+- derived summary functions
+- cached views or aggregates
+
+Call out where the read model differs from the write model.
+
+### 7. Identify State Boundaries and Invariants
+
+For each major entity, capture:
+
+- authoritative store
+- derived stores
+- active versus terminal states
+- expected invariants
+- likely drift points
+
+Good traces usually include a small state transition table when the subsystem is stateful.
+
+### 8. Produce Trace Artifacts
+
+The output should usually include:
+
+1. a high-level architecture map
+2. one or more flow descriptions
+3. a state transition table when relevant
+4. a data ownership table
+5. a drift / repair section
+6. Mermaid sequence or flow diagrams when they materially help
+
+## Quality Bar
+
+A strong trace should answer:
+
+- What starts the flow?
+- Which function owns orchestration?
+- Which writes are authoritative?
+- Which later jobs modify or repair the state?
+- Where can the system become temporarily inconsistent?
+- Which path determines what the user actually sees?
+
+## Common Failure Modes to Avoid
+
+- Listing files without tracing execution
+- Treating background jobs as optional when they close the loop
+- Ignoring delete and cleanup paths
+- Confusing intended architecture with running code
+- Omitting read paths and only documenting writes
+
+## Validation
+
+For docs-only changes:
+
+- run `git diff --check`
+
+If the trace is part of a larger audit and representative tests exist, note which flows those tests actually cover.

--- a/.agents/skills/audit-report-refresh/SKILL.md
+++ b/.agents/skills/audit-report-refresh/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: audit-report-refresh
+description: Refresh an existing audit report against the latest code while preserving the parts of the report structure that are still useful. Use when the user asks to redo an audit, run a second or third audit pass, update a previous report, fix inaccuracies in an existing audit document, or keep a strong prior report structure while replacing stale conclusions with code-grounded findings.
+---
+
+# Audit Report Refresh
+
+Use this skill when there is already an audit report or module document and the user wants a new pass based on the latest code.
+
+If there is no prior report and the task is a fresh audit, prefer `system-audit-report`.
+
+If the redesign introduced complicated runtime paths, async jobs, or reconcile loops, pair this skill with `architecture-data-flow-trace`.
+
+## Goal
+
+Keep the good parts of the previous report:
+
+- structure
+- section ordering
+- useful framing
+- strong explanations
+
+Replace the bad parts:
+
+- stale facts
+- outdated conclusions
+- missing deltas
+- gaps that the new code now closes
+
+## Core Rules
+
+1. Sync to the latest code before comparing anything.
+2. Treat the previous report as input material, not truth.
+3. Explicitly identify what changed since the previous report.
+4. Re-audit the subsystem from code; do not “patch” the old report blindly.
+5. Preserve strong structure when it still helps the reader.
+
+## Required Workflow
+
+### 1. Read the Existing Report First
+
+Extract:
+
+- the current section structure
+- strong sections worth preserving
+- explicit prior conclusions
+- prior blocker list
+- known assumptions
+
+### 2. Rebuild the Current Picture from Code
+
+Audit the latest implementation using the same standards as `system-audit-report`:
+
+- models
+- services
+- APIs
+- migrations
+- tasks
+- tests
+- UI if relevant
+
+### 3. Compare Old Conclusions vs. Current Reality
+
+Classify major conclusions into:
+
+- still correct
+- partially correct
+- now outdated
+- reversed by new code
+- still unresolved
+
+This comparison should appear in the refreshed report, usually near the beginning.
+
+### 4. Rewrite, Do Not Merely Edit
+
+When a section is materially outdated:
+
+- rewrite it from current code
+
+When a section is structurally strong but factually stale:
+
+- preserve the section shape
+- replace the content
+
+When a prior conclusion is now wrong:
+
+- say so explicitly and state what changed in the code
+
+## Required Additions in the Refreshed Report
+
+The refreshed report should usually add:
+
+1. current code baseline
+2. what changed since the previous audit
+3. which old blockers were fixed
+4. which old blockers remain
+5. any new defects introduced by the redesign
+
+## Quality Bar
+
+A good refresh report makes it easy to answer:
+
+- What did we think last time?
+- What is true now?
+- What got better?
+- What is still risky?
+- What new problems appeared after the redesign?
+
+## Validation
+
+At minimum:
+
+- run `git diff --check`
+
+If possible, run representative tests around the redesigned area and say whether the new conclusions are supported by passing tests.
+
+## Do Not
+
+- Do not copy old conclusions forward without re-verifying them.
+- Do not keep wording that implies old architecture still exists.
+- Do not preserve structure at the cost of factual accuracy.

--- a/.agents/skills/system-audit-report/SKILL.md
+++ b/.agents/skills/system-audit-report/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: system-audit-report
+description: Produce a code-grounded audit report for any subsystem in this repository. Use when the user asks to audit a system, explain how it works in detail, review data flow or architecture, assess whether it is production-ready, compare implementation against docs, or generate a detailed report based on the current code rather than assumptions.
+---
+
+# System Audit Report
+
+Use this skill when the user wants a detailed, code-based audit of a subsystem, not a lightweight explanation.
+
+If the user already has an audit report and wants it updated against the latest code while preserving the existing structure, prefer `audit-report-refresh`.
+
+If the hardest part of the task is reconstructing runtime architecture or end-to-end flow, pair this skill with `architecture-data-flow-trace`.
+
+## Output Standard
+
+The deliverable is an audit report, not a generic overview. It must:
+
+- be grounded in the current code
+- distinguish facts from inferences
+- identify defects, risks, and missing coverage
+- judge whether the system is closed-loop and fit for launch
+
+## Core Rules
+
+1. Sync to the latest code before auditing.
+2. Treat the current code as the source of truth.
+3. Use existing docs, plans, and PR context only as references.
+4. Every important conclusion should be backed by evidence:
+   - file
+   - function
+   - API
+   - migration
+   - test
+   - UI code
+5. Do not stop at “what exists”; also evaluate:
+   - what is partial
+   - what is inconsistent
+   - what is untested
+   - what would block launch
+
+## Required Workflow
+
+### 1. Lock the Code Baseline
+
+Record:
+
+- audit date
+- current branch
+- commit hash
+- audit scope
+
+### 2. Gather the System Map
+
+Read the smallest set of files that explains the subsystem end to end:
+
+- current docs for the subsystem
+- models
+- services
+- API routers
+- schemas / serializers
+- migrations
+- scheduled tasks / watchers / reconcile loops
+- tests
+- relevant frontend pages if user-facing
+
+Prefer `rg` to build the map before opening files.
+
+### 3. Trace the Real Runtime Paths
+
+For each major capability, identify:
+
+- request path entrypoints
+- service-layer orchestration
+- database writes
+- background task participation
+- watch / reconcile / repair behavior
+- user-visible read path
+
+Pay special attention to:
+
+- partial implementations
+- config-gated enforcement
+- best-effort code paths
+- eventual consistency
+- concurrency risks
+
+### 4. Check the Closed Loops
+
+For every important mechanism, verify the whole loop:
+
+1. where data is created
+2. how it is updated
+3. how it is consumed
+4. how limits are enforced
+5. how failures are repaired
+6. whether tests cover the path
+
+If a loop is broken, say exactly where.
+
+### 5. Compare Code vs. Existing Docs
+
+If there is an existing design doc or module doc:
+
+- preserve useful framing and structure
+- replace stale facts
+- call out meaningful deltas from the previous understanding
+
+Never let older docs override the code.
+
+## Required Report Structure
+
+The report should usually include:
+
+1. Audit metadata
+2. Sources reviewed
+3. Executive summary
+4. Current-state status table
+5. System goal and scope
+6. Architecture and data flow
+7. Data model and key tables
+8. Runtime flow and background jobs
+9. Key functions and interfaces
+10. Enforcement and failure handling
+11. Test coverage and gaps
+12. Defects, risks, and improvement opportunities
+13. Launch-readiness conclusion
+
+Use Mermaid when a flow or architecture diagram would materially help.
+
+## Quality Bar
+
+A good audit report should answer all of these:
+
+- What exactly does the system do today?
+- What data model does it use?
+- What triggers the core state transitions?
+- What is real and running versus planned or stale?
+- Where can the system drift or break?
+- What has test coverage, and what does not?
+- Is it suitable for launch, and under what claims?
+
+## Validation
+
+For docs-only changes:
+
+- run `git diff --check`
+
+If feasible, run representative tests for the audited subsystem and report:
+
+- what was run
+- what passed
+- what was not run
+
+## Do Not
+
+- Do not rely on memory over code.
+- Do not write vague statements like “the system seems robust”.
+- Do not bury the key risks deep in the document.
+- Do not equate the existence of tests with full reliability.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@ Use the matching local skill before you act:
 | Make any shippable change | `dev-lifecycle` |
 | Add or change SQLAlchemy models / Alembic migrations | `database-migration` |
 | Answer Neon-specific questions or plan Neon usage | `neon-postgres` |
+| Audit a subsystem against the current code and write a detailed report | `system-audit-report` |
+| Refresh an existing audit report against the latest code | `audit-report-refresh` |
+| Trace runtime architecture and end-to-end data flow | `architecture-data-flow-trace` |
 
 Skills live under `.agents/skills/*/SKILL.md`. AGENTS.md defines repo facts and guardrails; skills define procedures.
 
@@ -59,6 +62,9 @@ scripts/           # Helper scripts (release, install, deploy, E2E)
 | `dev-lifecycle` | Every feature/fix: branch, TDD, ship, PR, merge |
 | `database-migration` | Adding/modifying SQLAlchemy models and Alembic migrations |
 | `neon-postgres` | Neon-specific questions (branching, connection methods, SDKs) |
+| `system-audit-report` | First-pass or general subsystem audits grounded in the current code |
+| `audit-report-refresh` | Re-auditing a subsystem and updating an existing report against the latest code |
+| `architecture-data-flow-trace` | Tracing runtime architecture, state transitions, and end-to-end data flow |
 
 For K8s deployment (Kind cluster, Helm, smoke tests), see [`deploy/README.md`](deploy/README.md).
 


### PR DESCRIPTION
## Summary
- add a reusable `system-audit-report` skill for first-pass, code-grounded subsystem audits
- add a reusable `audit-report-refresh` skill for second and third audit passes against the latest code
- add an `architecture-data-flow-trace` helper skill for runtime architecture, state transitions, and end-to-end data-flow tracing
- update `AGENTS.md` so future sessions can discover the new audit skills quickly

## Why
The repository now has a repeatable audit workflow that matches the metering audit work already done in this codebase. Splitting the capability into a first-pass audit skill, a refresh skill, and a trace helper keeps each skill narrower and easier to trigger correctly.

## Validation
- `git diff --check`

## Notes
- Docs/skills-only change; no test suite was run.
