### PR TITLE
fix: improve sandbox UI defaults, validation, and toggle style

### DIFF
--- a/treadstone/api/schemas.py
+++ b/treadstone/api/schemas.py
@@ -36,7 +36,7 @@ class CreateSandboxRequest(BaseModel):
     name: str | None = Field(default=None, examples=["my-sandbox"], description=SANDBOX_NAME_DESCRIPTION)
     labels: dict[str, str] = Field(default_factory=dict, examples=[{"env": "dev"}])
     auto_stop_interval: int = Field(
-        default=15, examples=[15], description="Minutes of inactivity before the sandbox is automatically stopped."
+        default=60, examples=[60], description="Minutes of inactivity before the sandbox is automatically stopped."
     )
     auto_delete_interval: int = Field(
         default=-1,

--- a/web/src/pages/app/create-sandbox.tsx
+++ b/web/src/pages/app/create-sandbox.tsx
@@ -78,14 +78,18 @@ export function CreateSandboxPage() {
   const [selectedTemplate, setSelectedTemplate] = useState<string>("")
   const [name, setName] = useState("")
   const [labelsRaw, setLabelsRaw] = useState("")
-  const [autoStopMinutes, setAutoStopMinutes] = useState("15")
+  const [autoStopMinutes, setAutoStopMinutes] = useState("60")
   const [autoDeleteEnabled, setAutoDeleteEnabled] = useState(false)
-  const [autoDeleteMinutes, setAutoDeleteMinutes] = useState("60")
+  const [autoDeleteMinutes, setAutoDeleteMinutes] = useState("10080")
   const [persist, setPersist] = useState(false)
   const [storageSize, setStorageSize] = useState<"5Gi" | "10Gi" | "20Gi">("5Gi")
   const [nameTouched, setNameTouched] = useState(false)
 
   const activeTemplate = selectedTemplate || defaultTemplate
+
+  const maxAutoStopMinutes = usage
+    ? Math.floor(usage.limits.max_sandbox_duration_seconds / 60)
+    : undefined
 
   const nameTrimmed = name.trim()
   const nameInvalid =
@@ -118,6 +122,10 @@ export function CreateSandboxPage() {
     const stop = parseInt(autoStopMinutes, 10)
     if (Number.isNaN(stop) || stop < 1) {
       toast.error("Auto-stop must be at least 1 minute.")
+      return
+    }
+    if (maxAutoStopMinutes !== undefined && stop > maxAutoStopMinutes) {
+      toast.error(`Auto-stop cannot exceed your plan's max session time (${maxAutoStopMinutes} min).`)
       return
     }
 
@@ -281,6 +289,7 @@ export function CreateSandboxPage() {
                       id="auto-stop"
                       type="number"
                       min={1}
+                      max={maxAutoStopMinutes}
                       inputMode="numeric"
                       value={autoStopMinutes}
                       onChange={(e) => setAutoStopMinutes(e.target.value)}
@@ -290,41 +299,56 @@ export function CreateSandboxPage() {
                       Minutes
                     </span>
                   </div>
+                  {maxAutoStopMinutes !== undefined && (
+                    <p className="mt-1.5 text-[10px] text-muted-foreground/60">
+                      Max {maxAutoStopMinutes} min (plan limit)
+                    </p>
+                  )}
                 </div>
                 <div>
-                  <label
-                    htmlFor="auto-delete"
-                    className="text-[10px] font-bold uppercase tracking-[2px] text-muted-foreground"
-                  >
-                    Auto-delete interval
-                  </label>
-                  <div className="mt-2 flex flex-col gap-2">
-                    <label className="flex cursor-pointer items-center gap-2 text-sm text-foreground">
-                      <input
-                        type="checkbox"
-                        checked={autoDeleteEnabled}
-                        onChange={(e) => setAutoDeleteEnabled(e.target.checked)}
-                        className="size-3.5 rounded border-border accent-primary"
-                      />
-                      <span className="text-xs text-muted-foreground">
-                        Delete automatically after stop
-                      </span>
+                  <div className="flex items-center justify-between gap-4">
+                    <label
+                      htmlFor="auto-delete"
+                      className="text-[10px] font-bold uppercase tracking-[2px] text-muted-foreground"
+                    >
+                      Auto-delete interval
                     </label>
-                    <div className="flex items-center gap-2">
-                      <input
-                        id="auto-delete"
-                        type="number"
-                        min={1}
-                        inputMode="numeric"
-                        disabled={!autoDeleteEnabled}
-                        value={autoDeleteMinutes}
-                        onChange={(e) => setAutoDeleteMinutes(e.target.value)}
-                        className="h-10 w-full min-w-0 flex-1 border border-border/40 bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={autoDeleteEnabled}
+                      onClick={() => setAutoDeleteEnabled((p) => !p)}
+                      className={cn(
+                        "relative h-7 w-12 shrink-0 overflow-hidden rounded-full border transition-colors",
+                        autoDeleteEnabled
+                          ? "border-primary bg-primary/30"
+                          : "border-border/70 bg-muted/60",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "absolute left-0 top-0.5 size-6 rounded-full shadow transition-transform",
+                          autoDeleteEnabled
+                            ? "translate-x-5 bg-primary"
+                            : "translate-x-0.5 bg-foreground/40",
+                        )}
                       />
-                      <span className="shrink-0 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-                        Minutes
-                      </span>
-                    </div>
+                    </button>
+                  </div>
+                  <div className="mt-2 flex items-center gap-2">
+                    <input
+                      id="auto-delete"
+                      type="number"
+                      min={1}
+                      inputMode="numeric"
+                      disabled={!autoDeleteEnabled}
+                      value={autoDeleteMinutes}
+                      onChange={(e) => setAutoDeleteMinutes(e.target.value)}
+                      className="h-10 w-full min-w-0 flex-1 border border-border/40 bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                    <span className="shrink-0 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                      Minutes
+                    </span>
                   </div>
                 </div>
               </div>
@@ -348,7 +372,7 @@ export function CreateSandboxPage() {
                   >
                     <span
                       className={cn(
-                        "absolute top-0.5 size-6 rounded-full shadow transition-transform",
+                        "absolute left-0 top-0.5 size-6 rounded-full shadow transition-transform",
                         persist
                           ? "translate-x-5 bg-primary"
                           : "translate-x-0.5 bg-foreground/40",

--- a/web/src/pages/app/dashboard.tsx
+++ b/web/src/pages/app/dashboard.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner"
 import { useSandboxes, useStartSandbox, useStopSandbox, useDeleteSandbox, type Sandbox } from "@/api/sandboxes"
 import { cn } from "@/lib/utils"
 
-const PAGE_SIZE = 4
+const PAGE_SIZE = 8
 
 function formatRelativeTime(dateStr: string): string {
   const now = Date.now()


### PR DESCRIPTION
## Summary
- Increase sandbox list page size from 4 to 8 for better usability
- Fix Data Persistence toggle thumb starting position (missing `left-0` caused thumb to render on wrong side)
- Change auto-stop default from 15 min → 60 min (both backend schema and frontend state)
- Add frontend validation: auto-stop cannot exceed plan's `max_sandbox_duration_seconds`; shows inline hint with limit
- Change auto-delete default input value from 60 min → 10080 min (7 days) for a more reasonable default
- Replace auto-delete checkbox with a toggle button matching the Data Persistence toggle style

## Test Plan
- [x] `make test` — 579 passed, 0 failures
- [x] `make lint` — all checks passed

Made with [Cursor](https://cursor.com)