### PR TITLE
chore: bump version to 0.6.12

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone-cli"
-version = "0.6.11"
+version = "0.6.12"
 description = "CLI for the Treadstone sandbox service."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "treadstone"
-version = "0.6.11"
+version = "0.6.12"
 description = "Agent-native sandbox service. Run code, build projects, deploy environments."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "treadstone-sdk"
-version = "0.6.11"
+version = "0.6.12"
 description = "A client library for accessing treadstone"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1863,7 +1863,7 @@ wheels = [
 
 [[package]]
 name = "treadstone"
-version = "0.6.11"
+version = "0.6.12"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "treadstone-web",
   "private": true,
-  "version": "0.6.11",
+  "version": "0.6.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/app-version.ts
+++ b/web/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.11";
+export const APP_VERSION = "0.6.12";


### PR DESCRIPTION
## Summary
- Version bump to 0.6.12

## Changes in this release
- Fix: sandbox list page size increased from 4 to 8
- Fix: Data Persistence toggle thumb position (correct left-to-right behavior)
- Fix: auto-stop default changed to 60 min, auto-delete default to 7 days
- Fix: frontend validation prevents auto-stop from exceeding plan session limit
- Fix: auto-delete toggle UI unified with Data Persistence toggle style

Made with [Cursor](https://cursor.com)