### PR TITLE
[codex] clamp sandbox auto-stop default to plan limit

### DIFF
--- a/web/src/pages/app/create-sandbox.tsx
+++ b/web/src/pages/app/create-sandbox.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type FormEvent } from "react"
+import { useEffect, useMemo, useState, type FormEvent } from "react"
 import { Link, useNavigate } from "react-router"
 import { toast } from "sonner"
 
@@ -90,6 +90,19 @@ export function CreateSandboxPage() {
   const maxAutoStopMinutes = usage
     ? Math.floor(usage.limits.max_sandbox_duration_seconds / 60)
     : undefined
+
+  useEffect(() => {
+    if (maxAutoStopMinutes === undefined) {
+      return
+    }
+
+    const currentMinutes = parseInt(autoStopMinutes, 10)
+    if (Number.isNaN(currentMinutes) || currentMinutes <= maxAutoStopMinutes) {
+      return
+    }
+
+    setAutoStopMinutes(String(maxAutoStopMinutes))
+  }, [autoStopMinutes, maxAutoStopMinutes])
 
   const nameTrimmed = name.trim()
   const nameInvalid =


### PR DESCRIPTION
## Summary
- clamp the create-sandbox auto-stop default to the loaded plan limit
- prevent free-tier users from landing on an invalid 60-minute default

## Root Cause
Commit `09b59bf` raised the UI default auto-stop interval to 60 minutes while the free tier still caps sandbox duration at 30 minutes.

## Validation
- Not run per request
- pre-commit auto-ran during commit and passed
