### PR TITLE
fix: sandbox status stuck at creating after start from error state

### DIFF
--- a/tests/unit/test_sandbox_service.py
+++ b/tests/unit/test_sandbox_service.py
@@ -58,6 +58,7 @@ def _mock_k8s_client():
     k8s.delete_sandbox = AsyncMock(return_value=True)
     k8s.scale_sandbox = AsyncMock(return_value=True)
     k8s.get_storage_class = AsyncMock(return_value={"metadata": {"name": "treadstone-workspace"}})
+    k8s.get_sandbox = AsyncMock(return_value=None)
     k8s.get_sandbox_claim = AsyncMock(return_value=None)
     k8s.list_sandbox_templates = AsyncMock(
         return_value=[

--- a/treadstone/services/k8s_sync.py
+++ b/treadstone/services/k8s_sync.py
@@ -243,10 +243,15 @@ async def reconcile(
                 continue
 
             cr_rv = cr.get("metadata", {}).get("resourceVersion")
-            if sandbox.k8s_resource_version == cr_rv:
-                continue
-
             new_status, message = derive_status_from_sandbox_cr(cr)
+
+            # Skip only when both the resource version AND the derived status already
+            # match what is stored in the DB.  Checking resource version alone is not
+            # enough: a previous Watch event may have stored the resource version but
+            # failed to update the status (e.g. due to an optimistic-lock conflict or
+            # because the transition was previously blocked by the state machine).
+            if sandbox.k8s_resource_version == cr_rv and new_status == sandbox.status:
+                continue
 
             if new_status != sandbox.status and is_valid_transition(sandbox.status, new_status):
                 old_status = sandbox.status

--- a/treadstone/services/sandbox_service.py
+++ b/treadstone/services/sandbox_service.py
@@ -340,6 +340,34 @@ class SandboxService:
             sandbox.version += 1
             self.session.add(sandbox)
             await self.session.commit()
+            return sandbox
+
+        # The sandbox may already be READY in K8s (e.g. it auto-recovered from ERROR
+        # while the DB still showed ERROR, or a no-op scale was issued).  In that case
+        # K8s will not fire a new Watch MODIFIED event, so we do a single GET and apply
+        # the status immediately rather than waiting for the Watch loop or next reconcile.
+        try:
+            cr = await self.k8s.get_sandbox(name=k8s_name, namespace=sandbox.k8s_namespace)
+            if cr is not None:
+                from treadstone.services.k8s_sync import derive_status_from_sandbox_cr
+
+                actual_status, msg = derive_status_from_sandbox_cr(cr)
+                if actual_status == SandboxStatus.READY:
+                    cr_rv = cr.get("metadata", {}).get("resourceVersion")
+                    refreshed = await self.get(sandbox_id, owner_id)
+                    if refreshed is not None and is_valid_transition(refreshed.status, SandboxStatus.READY):
+                        logger.info("Sandbox %s already READY in K8s after start, updating DB immediately", sandbox_id)
+                        refreshed.status = SandboxStatus.READY
+                        refreshed.status_message = msg
+                        refreshed.version += 1
+                        refreshed.gmt_started = utc_now()
+                        refreshed.k8s_resource_version = cr_rv
+                        self.session.add(refreshed)
+                        await self.session.commit()
+                        await self.session.refresh(refreshed)
+                        return refreshed
+        except Exception:
+            logger.debug("Post-start K8s status check failed for %s; Watch/reconcile will sync later", sandbox_id)
 
         return sandbox
 

--- a/web/src/pages/app/dashboard.tsx
+++ b/web/src/pages/app/dashboard.tsx
@@ -47,11 +47,11 @@ function StatusDot({ status }: { status: string }) {
 
 
 const TABLE_COLUMNS = [
-  { key: "id", label: "Sandbox", className: "w-[22%]" },
-  { key: "status", label: "Status", className: "w-[10%]" },
+  { key: "id", label: "Sandbox", className: "w-[16%]" },
+  { key: "status", label: "Status", className: "w-[8%]" },
   { key: "template", label: "Template", className: "w-[15%]" },
   { key: "created_at", label: "Created At", className: "w-[12%]" },
-  { key: "lifecycle", label: "Lifecycle", className: "w-[10%]" },
+  { key: "lifecycle", label: "Lifecycle", className: "w-[18%]" },
   { key: "web_url", label: "Web URL", className: "w-[23%]" },
   { key: "actions", label: "", className: "w-[8%]" },
 ] as const
@@ -296,7 +296,7 @@ function SandboxTable({ sandboxes }: { sandboxes: Sandbox[] }) {
                   <div className="flex flex-col gap-0.5">
                     <Link
                       to={`/app/sandboxes/${sandbox.id}`}
-                      className="font-mono text-xs font-medium text-foreground hover:text-primary"
+                      className="font-mono text-xs font-medium text-primary"
                     >
                       {sandbox.name || sandbox.id}
                     </Link>


### PR DESCRIPTION
## Summary

- **Bug 1 (`k8s_sync.py`)**: `reconcile()` skipped sandboxes based on `k8s_resource_version` alone. A previous Watch event could have stored the resource version without updating the status (e.g. the `ERROR→READY` transition was blocked by the old state machine before #161). On the next reconcile the versions matched so the sandbox was silently skipped, leaving the DB stuck at `error` after a new deployment.
  - Fix: skip only when **both** resource version AND derived status match.

- **Bug 2 (`sandbox_service.py`)**: `start()` on an already-READY K8s sandbox issued a no-op `scale_sandbox(replicas=1)`. Kubernetes does not fire a new Watch MODIFIED event for a no-op patch, so the Watch loop never advanced the DB from `creating` to `ready`. Combined with Bug 1 the status stayed stuck at `creating` indefinitely.
  - Fix: after `scale_sandbox` succeeds, do a single K8s GET and immediately update the DB to `ready` if the sandbox is already ready — no need to wait for a Watch event that may never arrive.

- **Dashboard (`dashboard.tsx`)**: Widen the Lifecycle column (`w-[10%]` → `w-[18%]`), narrow Sandbox and Status columns slightly, and default sandbox name link color to `text-primary` (green).

## Test Plan

- [x] `make test` — 390 unit tests pass, 0 warnings
- [x] `make lint` — all checks pass

Made with [Cursor](https://cursor.com)