### PR TITLE
fix(web): increase sidebar brand symbol size

### DIFF
--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -36,7 +36,7 @@ export function Sidebar() {
     <aside className="flex h-screen w-64 shrink-0 flex-col border-r border-sidebar-border bg-sidebar">
       <div className="flex items-center gap-3 px-6 py-6">
         <div className="flex size-8 items-center justify-center bg-primary">
-          <TreadstoneSymbol className="size-4 text-primary-foreground" />
+          <TreadstoneSymbol className="size-6 text-primary-foreground" />
         </div>
         <span className="text-xl font-bold tracking-tight text-primary">
           Treadstone


### PR DESCRIPTION
## Summary
- Increase `TreadstoneSymbol` in the app sidebar from `size-4` to `size-6` so the mark reads clearly against the primary square.

## Test Plan
- [x] `cd web && pnpm lint` (pre-commit passed)

Made with [Cursor](https://cursor.com)