### PR TITLE
fix: HelpIcon link prop typing for web Docker build

### DIFF
--- a/web/src/pages/app/dashboard.tsx
+++ b/web/src/pages/app/dashboard.tsx
@@ -300,7 +300,11 @@ function SandboxTable({ sandboxes }: { sandboxes: Sandbox[] }) {
                     {col.label}
                     <HelpIcon
                       content={col.help}
-                      link={"helpLink" in col ? col.helpLink : undefined}
+                      link={
+                        "helpLink" in col
+                          ? (col as { helpLink?: { href: string; label?: string } }).helpLink
+                          : undefined
+                      }
                       side="top"
                     />
                   </div>


### PR DESCRIPTION
Fixes TS2322 in `dashboard.tsx` so `pnpm build` passes in the treadstone-web Docker image (Release docker-web job).

Made with [Cursor](https://cursor.com)