### PR TITLE
feat: CU memory divisor constant and landing terminal think animation

### DIFF
--- a/tests/unit/test_metering_models.py
+++ b/tests/unit/test_metering_models.py
@@ -16,6 +16,7 @@ from treadstone.models.metering import (
     UserPlan,
 )
 from treadstone.services.metering_helpers import (
+    CU_MEMORY_GIB_DIVISOR,
     TEMPLATE_SPECS,
     ConsumeResult,
     calculate_cu_rate,
@@ -293,7 +294,9 @@ class TestTemplateSpecs:
 
     def test_ratio_is_1_to_2(self):
         for name, spec in TEMPLATE_SPECS.items():
-            assert spec["memory_gib"] == spec["vcpu"] * 2, f"{name}: memory should be 2x vcpu"
+            assert spec["memory_gib"] == spec["vcpu"] * CU_MEMORY_GIB_DIVISOR, (
+                f"{name}: memory_gib should equal vcpu * CU_MEMORY_GIB_DIVISOR"
+            )
 
 
 class TestParseStorageSizeGib:

--- a/treadstone/api/usage.py
+++ b/treadstone/api/usage.py
@@ -35,6 +35,7 @@ from treadstone.api.schemas import (
 from treadstone.core.database import get_session
 from treadstone.models.metering import ComputeSession, StorageLedger
 from treadstone.models.user import User, utc_now
+from treadstone.services.metering_helpers import CU_MEMORY_GIB_DIVISOR
 from treadstone.services.metering_service import MeteringService
 
 router = APIRouter(prefix="/v1/usage", tags=["usage"])
@@ -46,7 +47,7 @@ def _serialize_session(cs: ComputeSession) -> dict:
     now = utc_now()
     end = cs.ended_at or now
     duration = (end - cs.started_at).total_seconds()
-    cu_hours = float(max(cs.vcpu_hours, cs.memory_gib_hours / 2))
+    cu_hours = float(max(cs.vcpu_hours, cs.memory_gib_hours / CU_MEMORY_GIB_DIVISOR))
     return {
         "id": cs.id,
         "sandbox_id": cs.sandbox_id,

--- a/treadstone/services/metering_helpers.py
+++ b/treadstone/services/metering_helpers.py
@@ -17,6 +17,11 @@ TEMPLATE_SPECS: dict[str, dict[str, Decimal]] = {
     "aio-sandbox-xlarge": {"vcpu": Decimal("4"), "memory_gib": Decimal("8")},
 }
 
+# Divisor applied to memory (GiB) in the Compute Unit formula:
+#   CU/hour = max(vCPU_request, memory_GiB_request / CU_MEMORY_GIB_DIVISOR)
+# Equivalently: one vCPU is billed like CU_MEMORY_GIB_DIVISOR GiB of RAM.
+CU_MEMORY_GIB_DIVISOR: Decimal = Decimal("2")
+
 _template_specs_cache: dict[str, dict[str, Decimal]] = {}
 
 
@@ -40,13 +45,13 @@ def get_template_resource_spec(template: str) -> tuple[Decimal, Decimal]:
 def calculate_cu_rate(template: str) -> Decimal:
     """Return the Compute Unit rate (CU/hour) for the given sandbox template.
 
-    Formula: CU = max(vCPU_request, memory_GiB_request / 2)
+    Formula: CU = max(vCPU_request, memory_GiB_request / CU_MEMORY_GIB_DIVISOR)
     Checks the K8s-synced runtime cache first, falls back to static TEMPLATE_SPECS.
     """
     spec = _resolve_spec(template)
     if spec is None:
         raise BadRequestError(f"Unknown sandbox template: {template}")
-    return max(spec["vcpu"], spec["memory_gib"] / Decimal("2"))
+    return max(spec["vcpu"], spec["memory_gib"] / CU_MEMORY_GIB_DIVISOR)
 
 
 def parse_storage_size_gib(size_str: str) -> int:

--- a/treadstone/services/metering_service.py
+++ b/treadstone/services/metering_service.py
@@ -54,6 +54,7 @@ from treadstone.models.metering import (
 from treadstone.models.sandbox import Sandbox, SandboxStatus
 from treadstone.models.user import utc_now
 from treadstone.services.metering_helpers import (
+    CU_MEMORY_GIB_DIVISOR,
     ConsumeResult,
     calculate_cu_rate,
     compute_period_bounds,
@@ -797,7 +798,7 @@ class MeteringService:
             )
             session_compute_unit_hours = max(
                 compute_session.vcpu_hours,
-                compute_session.memory_gib_hours / Decimal("2"),
+                compute_session.memory_gib_hours / CU_MEMORY_GIB_DIVISOR,
             )
             total_compute_unit_hours += session_compute_unit_hours * overlap_ratio
 

--- a/web/src/pages/public/landing.tsx
+++ b/web/src/pages/public/landing.tsx
@@ -19,27 +19,45 @@ const INSTALL_PIP = "pip install treadstone-cli"
 
 type TermStep =
   | { type: "cmt"; text: string }
+  /** Narration / “thinking” lines — revealed character by character. `tone` matches prior sky vs zinc styling. */
+  | { type: "think"; text: string; pause?: number; speed?: number; tone?: "sky" | "zinc" }
   | { type: "cmd"; text: string; speed?: number }
   | { type: "out"; text: string; pause?: number }
   | { type: "sp" }
 
-// cmd `speed`: ms between keystrokes — lower is faster (not WPM).
+// cmd / think `speed`: ms between keystrokes — lower is faster (not WPM).
 const TERM_STEPS: TermStep[] = [
-  { type: "cmt", text: "# 1. Authenticate" },
-  { type: "cmd", text: "treadstone auth login --email agent@example.com --password ••••••••", speed: 18 },
-  { type: "out", text: "✓ Logged in as agent@example.com", pause: 140 },
+  { type: "think", text: "> request: check the target page (https://treadstone-ai.dev/) and see what’s going on", tone: "zinc", speed: 36 },
+  { type: "think", text: "thinking: install the treadstone-cli skill for control-plane actions", pause: 180, tone: "sky", speed: 36 },
+  { type: "cmd", text: "treadstone skills install --target project", speed: 34 },
+  { type: "out", text: "✓ installed: .agents/skills/treadstone-cli/SKILL.md", pause: 240 },
   { type: "sp" },
-  { type: "cmt", text: "# 2. Install the agent skill (Cursor, Codex, …)" },
-  { type: "cmd", text: "treadstone skills install", speed: 18 },
-  { type: "out", text: "Installed: ~/.agents/skills/treadstone-cli/SKILL.md", pause: 160 },
+
+  { type: "think", text: "thinking: this task needs a real browser and isolated runtime", tone: "zinc", speed: 36 },
   { type: "sp" },
-  { type: "cmt", text: "# 3. Create a sandbox — read the ID from JSON output" },
-  { type: "cmd", text: "treadstone --json sandboxes create --name agent-demo", speed: 20 },
-  { type: "out", text: '{"id":"sb_3kx9m2p","status":"running","urls":{"proxy":"https://sb_3kx9m2p.proxy.treadstone-ai.dev"}}', pause: 250 },
+
+  { type: "think", text: "thinking: confirm identity", tone: "zinc", speed: 36 },
+  { type: "cmd", text: "treadstone auth whoami", speed: 34 },
+  { type: "out", text: "✓ logged in as agent@example.com", pause: 220 },
   { type: "sp" },
-  { type: "cmt", text: "# 4. Hand the browser off to a human" },
-  { type: "cmd", text: "treadstone --json sandboxes web enable sb_3kx9m2p", speed: 20 },
-  { type: "out", text: '{"open_link":"https://sb_3kx9m2p.web.treadstone-ai.dev?token=...","expires_at":"2026-03-30T18:00:00Z"}', pause: 230 },
+
+  { type: "think", text: "thinking: create a sandbox", tone: "zinc", speed: 36 },
+  { type: "cmd", text: "treadstone --json sandboxes create --name page-check", speed: 38 },
+  { type: "out", text: '{"id":"sb_3kx9m2p","status":"running","urls":{"proxy":"https://sb_3kx9m2p.proxy.treadstone-ai.dev"}}', pause: 380 },
+  { type: "sp" },
+
+  { type: "think", text: "thinking: prepare a browser session in case human review is needed", tone: "zinc", speed: 36 },
+  { type: "cmd", text: "treadstone --json sandboxes web enable sb_3kx9m2p", speed: 38 },
+  { type: "out", text: '{"open_link":"https://sb_3kx9m2p.web.treadstone-ai.dev?token=...","expires_at":"2026-03-30T18:00:00Z"}', pause: 350 },
+  { type: "sp" },
+
+  { type: "think", text: "thinking: handoff is ready, stop the runtime", tone: "zinc", speed: 36 },
+  { type: "cmd", text: "treadstone sandboxes stop sb_3kx9m2p", speed: 34 },
+  { type: "out", text: "✓ sandbox stopped", pause: 270 },
+  { type: "sp" },
+
+  { type: "out", text: "✓ browser session ready for review", pause: 160 },
+  { type: "out", text: "awaiting next instruction", pause: 260 },
 ]
 
 // ── How It Works data ────────────────────────────────────────────────────────
@@ -520,6 +538,7 @@ function InstallCard({ os, hint, cmd, first }: { os: string; hint: string; cmd: 
 
 type RenderedLine =
   | { kind: "cmt"; text: string }
+  | { kind: "think"; text: string; tone: "sky" | "zinc" }
   | { kind: "cmd"; prompt: string; text: string }
   | { kind: "out"; text: string }
   | { kind: "sp" }
@@ -536,7 +555,7 @@ function AnimatedTerminal() {
     const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 
     async function run() {
-      await sleep(700)
+      await sleep(950)
       for (const step of TERM_STEPS) {
         if (step.type === "sp") {
           setLines((prev) => [...prev, { kind: "sp" }])
@@ -544,13 +563,33 @@ function AnimatedTerminal() {
         }
         if (step.type === "cmt") {
           setLines((prev) => [...prev, { kind: "cmt", text: step.text }])
-          await sleep(95)
+          await sleep(150)
+          continue
+        }
+        if (step.type === "think") {
+          const tone = step.tone ?? "zinc"
+          const speed = step.speed ?? 40
+          await sleep(step.pause ?? 0)
+          setLines((prev) => [...prev, { kind: "think", text: "", tone }])
+          await sleep(80)
+          for (const ch of step.text) {
+            setLines((prev) => {
+              const next = [...prev]
+              const last = next[next.length - 1]
+              if (last?.kind === "think") {
+                next[next.length - 1] = { kind: "think", text: last.text + ch, tone }
+              }
+              return next
+            })
+            await sleep(speed + Math.random() * speed * 0.25)
+          }
+          await sleep(120)
           continue
         }
         if (step.type === "cmd") {
           const speed = step.speed ?? 40
           setLines((prev) => [...prev, { kind: "cmd", prompt: "$ ", text: "" }])
-          await sleep(95)
+          await sleep(150)
           for (const ch of step.text) {
             setLines((prev) => {
               const next = [...prev]
@@ -562,13 +601,13 @@ function AnimatedTerminal() {
             })
             await sleep(speed + Math.random() * speed * 0.25)
           }
-          await sleep(115)
+          await sleep(180)
           continue
         }
         if (step.type === "out") {
-          await sleep(step.pause ?? 200)
+          await sleep(step.pause ?? 280)
           setLines((prev) => [...prev, { kind: "out", text: step.text }])
-          await sleep(80)
+          await sleep(130)
         }
       }
       setCursor(false)
@@ -592,7 +631,16 @@ function AnimatedTerminal() {
           if (line.kind === "sp") return <div key={i} className="h-[10px]" />
           if (line.kind === "cmt")
             return (
-              <div key={i} className="text-muted-foreground/40">
+              <div key={i} className="text-zinc-400">
+                {line.text}
+              </div>
+            )
+          if (line.kind === "think")
+            return (
+              <div
+                key={i}
+                className={line.tone === "sky" ? "text-sky-300/80" : "text-zinc-400"}
+              >
                 {line.text}
               </div>
             )


### PR DESCRIPTION
## Summary

- **Metering**: Add `CU_MEMORY_GIB_DIVISOR` and use it everywhere the CU formula applies `max(vCPU, memory_GiB/2)` (helpers, usage API, metering service, tests).
- **Web**: Landing animated terminal adds `think` lines (character-by-character), updated demo script, timing and contrast tweaks.

## Test plan

- `uv run pytest tests/unit/test_metering_models.py`
- `make lint` / `make test` (CI)

Made with [Cursor](https://cursor.com)