### PR TITLE
feat(web): unify Console naming and home navigation

### DIFF
--- a/web/public/docs/api-reference.md
+++ b/web/public/docs/api-reference.md
@@ -12,7 +12,7 @@ Most endpoints require an API key passed as a Bearer token:
 Authorization: Bearer sk_your_api_key_here
 ```
 
-Obtain an API key via the web dashboard or CLI:
+Obtain an API key via the web console or CLI:
 
 ```bash
 treadstone api-keys create --name my-key --save

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -13,7 +13,7 @@ import { SignUpPage } from "@/pages/auth/sign-up"
 import { VerifyEmailPage } from "@/pages/auth/verify-email"
 import { CliLoginPage } from "@/pages/auth/cli-login"
 
-import { DashboardPage } from "@/pages/app/dashboard"
+import { SandboxesPage } from "@/pages/app/sandboxes"
 import { CreateSandboxPage } from "@/pages/app/create-sandbox"
 import { SandboxDetailPage } from "@/pages/app/sandbox-detail"
 import { ApiKeysPage } from "@/pages/app/api-keys"
@@ -67,7 +67,7 @@ const router = createBrowserRouter([
     path: "app",
     element: <AppLayout />,
     children: [
-      { index: true, element: <DashboardPage /> },
+      { index: true, element: <SandboxesPage /> },
       { path: "sandboxes/new", element: <CreateSandboxPage /> },
       { path: "sandboxes/:id", element: <SandboxDetailPage /> },
       { path: "api-keys", element: <ApiKeysPage /> },

--- a/web/src/components/layout/public-layout.tsx
+++ b/web/src/components/layout/public-layout.tsx
@@ -73,7 +73,7 @@ export function PublicLayout() {
               to="/app"
               className="rounded bg-primary px-4 py-1.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              Dashboard
+              Console
             </Link>
           ) : (
             <Link

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router"
+import { Link, NavLink } from "react-router"
 import {
   Box,
   Key,
@@ -34,14 +34,18 @@ export function Sidebar() {
 
   return (
     <aside className="flex h-screen w-64 shrink-0 flex-col border-r border-sidebar-border bg-sidebar">
-      <div className="flex items-center gap-3.5 px-6 py-6">
-        <div className="flex size-10 items-center justify-center bg-primary">
+      <Link
+        to="/app"
+        className="flex items-center gap-3.5 px-6 py-6 transition-colors hover:bg-sidebar-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+        aria-label="Go to Sandboxes"
+      >
+        <div className="flex size-10 shrink-0 items-center justify-center bg-primary">
           <TreadstoneSymbol className="size-8 text-primary-foreground" />
         </div>
         <span className="text-2xl font-bold tracking-tight text-primary">
           Treadstone
         </span>
-      </div>
+      </Link>
 
       <nav className="flex flex-1 flex-col pt-4">
         {navItems.map((item) => (

--- a/web/src/components/layout/topbar.tsx
+++ b/web/src/components/layout/topbar.tsx
@@ -77,7 +77,12 @@ export function Topbar() {
   return (
     <header className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-background px-6">
       <div className="flex items-center gap-2 text-xs uppercase tracking-widest">
-        <span className="text-muted-foreground">Console</span>
+        <Link
+          to="/app"
+          className="text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Console
+        </Link>
         <span className="text-muted-foreground">&rsaquo;</span>
         <span className="font-medium text-foreground">{pageLabel}</span>
       </div>

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -2,7 +2,7 @@
 
 /*
  * Treadstone Design Tokens — dark-first, flat, minimal.
- * Visual reference: Neon Console / Resend Dashboard.
+ * Visual reference: Neon Console–style shell.
  *
  * shadcn/ui convention: each semantic slot has a foreground pair.
  * Colors use oklch for perceptual uniformity.

--- a/web/src/pages/app/sandboxes.tsx
+++ b/web/src/pages/app/sandboxes.tsx
@@ -440,7 +440,7 @@ function SandboxTable({ sandboxes }: { sandboxes: Sandbox[] }) {
   )
 }
 
-export function DashboardPage() {
+export function SandboxesPage() {
   const { data: sandboxData, isLoading } = useSandboxes()
   const sandboxes = sandboxData?.items ?? []
 

--- a/web/src/pages/auth/verify-email.tsx
+++ b/web/src/pages/auth/verify-email.tsx
@@ -54,7 +54,7 @@ export function VerifyEmailPage() {
           to="/app"
           className="mt-8 inline-block bg-primary px-6 py-2.5 text-sm font-bold uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary/90"
         >
-          Go to Dashboard
+          Go to Console
         </Link>
       </div>
     )
@@ -70,7 +70,7 @@ export function VerifyEmailPage() {
         to="/app"
         className="mt-8 inline-block bg-primary px-6 py-2.5 text-sm font-bold uppercase tracking-widest text-primary-foreground transition-colors hover:bg-primary/90"
       >
-        Go to Dashboard
+        Go to Console
       </Link>
     </div>
   )

--- a/web/src/pages/public/landing.tsx
+++ b/web/src/pages/public/landing.tsx
@@ -728,7 +728,7 @@ export function LandingPage() {
                 to="/app"
                 className="rounded-[10px] bg-primary px-7 py-3.5 text-[15px] font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
-                Open Dashboard
+                Open Console
               </Link>
             ) : (
               <Link


### PR DESCRIPTION
## Summary
- Link sidebar brand lockup and topbar "Console" breadcrumb to `/app` (Sandboxes home).
- Rename the main app route component from `DashboardPage` to `SandboxesPage` (`dashboard.tsx` → `sandboxes.tsx`).
- Align user-facing copy with **Console** (landing, public layout, email verification, API reference).

## Test Plan
- [x] `make lint`

Made with [Cursor](https://cursor.com)