### PR TITLE
feat: admin feedback email filter and improved list UI

### DIFF
--- a/sdk/python/treadstone_sdk/api/admin/admin_list_user_feedback.py
+++ b/sdk/python/treadstone_sdk/api/admin/admin_list_user_feedback.py
@@ -14,12 +14,20 @@ def _get_kwargs(
     *,
     limit: int | Unset = 50,
     offset: int | Unset = 0,
+    email: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
     params["limit"] = limit
 
     params["offset"] = offset
+
+    json_email: None | str | Unset
+    if isinstance(email, Unset):
+        json_email = UNSET
+    else:
+        json_email = email
+    params["email"] = json_email
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -67,6 +75,7 @@ def sync_detailed(
     client: AuthenticatedClient,
     limit: int | Unset = 50,
     offset: int | Unset = 0,
+    email: None | str | Unset = UNSET,
 ) -> Response[FeedbackListResponse | HTTPValidationError]:
     """List User Feedback
 
@@ -75,6 +84,7 @@ def sync_detailed(
     Args:
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
+        email (None | str | Unset): Optional case-insensitive substring match on submitter email.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -87,6 +97,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         limit=limit,
         offset=offset,
+        email=email,
     )
 
     response = client.get_httpx_client().request(
@@ -101,6 +112,7 @@ def sync(
     client: AuthenticatedClient,
     limit: int | Unset = 50,
     offset: int | Unset = 0,
+    email: None | str | Unset = UNSET,
 ) -> FeedbackListResponse | HTTPValidationError | None:
     """List User Feedback
 
@@ -109,6 +121,7 @@ def sync(
     Args:
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
+        email (None | str | Unset): Optional case-insensitive substring match on submitter email.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -122,6 +135,7 @@ def sync(
         client=client,
         limit=limit,
         offset=offset,
+        email=email,
     ).parsed
 
 
@@ -130,6 +144,7 @@ async def asyncio_detailed(
     client: AuthenticatedClient,
     limit: int | Unset = 50,
     offset: int | Unset = 0,
+    email: None | str | Unset = UNSET,
 ) -> Response[FeedbackListResponse | HTTPValidationError]:
     """List User Feedback
 
@@ -138,6 +153,7 @@ async def asyncio_detailed(
     Args:
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
+        email (None | str | Unset): Optional case-insensitive substring match on submitter email.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -150,6 +166,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         limit=limit,
         offset=offset,
+        email=email,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -162,6 +179,7 @@ async def asyncio(
     client: AuthenticatedClient,
     limit: int | Unset = 50,
     offset: int | Unset = 0,
+    email: None | str | Unset = UNSET,
 ) -> FeedbackListResponse | HTTPValidationError | None:
     """List User Feedback
 
@@ -170,6 +188,7 @@ async def asyncio(
     Args:
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
+        email (None | str | Unset): Optional case-insensitive substring match on submitter email.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -184,5 +203,6 @@ async def asyncio(
             client=client,
             limit=limit,
             offset=offset,
+            email=email,
         )
     ).parsed

--- a/tests/api/test_admin_api.py
+++ b/tests/api/test_admin_api.py
@@ -606,3 +606,16 @@ async def test_list_feedback_admin(admin_client):
 async def test_list_feedback_forbidden_member(member_client):
     resp = await member_client.get("/v1/admin/support/feedback")
     assert resp.status_code == 403
+
+
+async def test_list_feedback_filter_by_email(admin_client, member_client):
+    await member_client.post("/v1/support/feedback", json={"body": "email filter marker"})
+    resp = await admin_client.get("/v1/admin/support/feedback", params={"email": "member@example.com"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] >= 1
+    assert any("email filter marker" in item["body"] for item in data["items"])
+
+    resp_empty = await admin_client.get("/v1/admin/support/feedback", params={"email": "nomatch@example.com"})
+    assert resp_empty.status_code == 200
+    assert resp_empty.json()["total"] == 0

--- a/treadstone/api/admin.py
+++ b/treadstone/api/admin.py
@@ -74,6 +74,12 @@ from treadstone.services.metering_service import MeteringService
 
 logger = logging.getLogger(__name__)
 
+
+def _sql_like_escape_fragment(value: str) -> str:
+    """Escape `\\`, `%`, and `_` for use in PostgreSQL ILIKE with ESCAPE '\\'."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 router = APIRouter(prefix="/v1/admin", tags=["admin"])
 
 _metering = MeteringService()
@@ -632,18 +638,25 @@ async def list_waitlist_applications(
 async def list_user_feedback(
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
+    email: str | None = Query(
+        default=None,
+        description="Optional case-insensitive substring match on submitter email.",
+    ),
     _admin: User = Depends(get_current_admin),
     session: AsyncSession = Depends(get_session),
 ) -> FeedbackListResponse:
     """List user-submitted support feedback (newest first)."""
     count_query = select(func.count()).select_from(UserFeedback)
+    query = select(UserFeedback)
+    if email and (trimmed := email.strip()):
+        pattern = f"%{_sql_like_escape_fragment(trimmed)}%"
+        email_filter = UserFeedback.email.ilike(pattern, escape="\\")
+        count_query = count_query.where(email_filter)
+        query = query.where(email_filter)
+
     total = (await session.execute(count_query)).scalar_one()
     rows = (
-        (
-            await session.execute(
-                select(UserFeedback).order_by(UserFeedback.gmt_created.desc()).limit(limit).offset(offset)
-            )
-        )
+        (await session.execute(query.order_by(UserFeedback.gmt_created.desc()).limit(limit).offset(offset)))
         .scalars()
         .all()
     )

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -3355,6 +3355,8 @@ export interface operations {
             query?: {
                 limit?: number;
                 offset?: number;
+                /** @description Optional case-insensitive substring match on submitter email. */
+                email?: string | null;
             };
             header?: never;
             path?: never;

--- a/web/src/api/support.ts
+++ b/web/src/api/support.ts
@@ -20,13 +20,20 @@ export function useSubmitFeedback() {
   })
 }
 
-/** First page only (`offset=0`). Add a `page` argument here if the admin UI gains pagination. */
-export function useAdminFeedbackList() {
+/** First page only (`offset=0`). Optional `emailFilter` is a case-insensitive substring match on submitter email. */
+export function useAdminFeedbackList(emailFilter?: string) {
+  const trimmed = emailFilter?.trim() ?? ""
   return useQuery({
-    queryKey: ["admin", "support-feedback"],
+    queryKey: ["admin", "support-feedback", trimmed],
     queryFn: async () => {
       const { data } = await client.GET("/v1/admin/support/feedback", {
-        params: { query: { limit: ADMIN_FEEDBACK_PAGE_SIZE, offset: 0 } },
+        params: {
+          query: {
+            limit: ADMIN_FEEDBACK_PAGE_SIZE,
+            offset: 0,
+            ...(trimmed ? { email: trimmed } : {}),
+          },
+        },
       })
       return data!
     },

--- a/web/src/pages/internal/admin-feedback.tsx
+++ b/web/src/pages/internal/admin-feedback.tsx
@@ -1,5 +1,7 @@
+import * as Dialog from "@radix-ui/react-dialog"
 import { MessageSquareText } from "lucide-react"
-import { ADMIN_FEEDBACK_PAGE_SIZE, useAdminFeedbackList } from "@/api/support"
+import { useEffect, useState } from "react"
+import { ADMIN_FEEDBACK_PAGE_SIZE, type FeedbackItem, useAdminFeedbackList } from "@/api/support"
 
 function formatTimestamp(iso: string): string {
   try {
@@ -17,8 +19,63 @@ function formatTimestamp(iso: string): string {
   }
 }
 
+function FeedbackDetailDialog({
+  item,
+  onClose,
+}: {
+  item: FeedbackItem | null
+  onClose: () => void
+}) {
+  const open = item !== null
+  return (
+    <Dialog.Root open={open} onOpenChange={(next) => !next && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(100vw-2rem,560px)] max-h-[min(90vh,720px)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto border border-border/20 bg-card p-6 shadow-xl outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
+          <Dialog.Title className="text-base font-semibold text-foreground">Feedback detail</Dialog.Title>
+          <Dialog.Description className="sr-only">Full message and metadata for this feedback entry.</Dialog.Description>
+          {item && (
+            <div className="mt-4 flex flex-col gap-3 text-xs">
+              <div>
+                <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Time</div>
+                <div className="mt-0.5 tabular-nums text-foreground">{formatTimestamp(item.gmt_created)}</div>
+              </div>
+              <div>
+                <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">User ID</div>
+                <div className="mt-0.5 break-all font-mono text-[11px] text-foreground">{item.user_id}</div>
+              </div>
+              <div>
+                <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Email</div>
+                <div className="mt-0.5 break-all text-foreground">{item.email}</div>
+              </div>
+              <div>
+                <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Message</div>
+                <pre className="mt-1 max-h-[50vh] overflow-y-auto whitespace-pre-wrap break-words rounded border border-border/15 bg-muted/30 p-3 text-[13px] leading-relaxed text-foreground">
+                  {item.body}
+                </pre>
+              </div>
+            </div>
+          )}
+          <Dialog.Close className="mt-6 rounded border border-border/40 bg-secondary px-4 py-2 text-xs font-semibold text-secondary-foreground transition-colors hover:bg-secondary/80">
+            Close
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
 export function AdminFeedbackPage() {
-  const { data, isLoading, isError, isFetching, refetch } = useAdminFeedbackList()
+  const [emailDraft, setEmailDraft] = useState("")
+  const [emailQuery, setEmailQuery] = useState("")
+  const [selected, setSelected] = useState<FeedbackItem | null>(null)
+
+  useEffect(() => {
+    const t = setTimeout(() => setEmailQuery(emailDraft.trim()), 350)
+    return () => clearTimeout(t)
+  }, [emailDraft])
+
+  const { data, isLoading, isError, isFetching, refetch } = useAdminFeedbackList(emailQuery)
 
   const total = data?.total ?? 0
   const items = data?.items ?? []
@@ -26,28 +83,43 @@ export function AdminFeedbackPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex flex-col gap-1">
           <h1 className="text-lg font-semibold text-foreground">Support feedback</h1>
           <p className="text-xs text-muted-foreground">
-            Messages submitted from the console Support panel (newest first).
+            Messages from the console Support panel, newest first (by submission time).
             {!showingAll && (
               <span className="block pt-1 text-[10px] text-muted-foreground/80">
-                Showing the {ADMIN_FEEDBACK_PAGE_SIZE} most recent of {total}.
+                {emailQuery
+                  ? `Showing up to ${ADMIN_FEEDBACK_PAGE_SIZE} of ${total} matching “${emailQuery}”.`
+                  : `Showing the ${ADMIN_FEEDBACK_PAGE_SIZE} most recent of ${total}.`}
               </span>
             )}
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <span className="text-[10px] text-muted-foreground tabular-nums">{total} total</span>
-          <button
-            type="button"
-            onClick={() => refetch()}
-            disabled={isFetching}
-            className="rounded border border-border/30 bg-card px-3 py-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-card/80 disabled:opacity-50"
-          >
-            Refresh
-          </button>
+        <div className="flex flex-col items-stretch gap-2 sm:items-end">
+          <label className="flex flex-col gap-1 text-left sm:items-end">
+            <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Filter by email</span>
+            <input
+              type="search"
+              value={emailDraft}
+              onChange={(e) => setEmailDraft(e.target.value)}
+              placeholder="Substring match, e.g. @company.com"
+              autoComplete="off"
+              className="w-full min-w-[220px] rounded border border-border/30 bg-background px-3 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/60 focus:border-border focus:outline-none focus:ring-1 focus:ring-border/50 sm:max-w-xs"
+            />
+          </label>
+          <div className="flex items-center justify-end gap-2">
+            <span className="text-[10px] text-muted-foreground tabular-nums">{total} matching</span>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              disabled={isFetching}
+              className="rounded border border-border/30 bg-card px-3 py-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-card/80 disabled:opacity-50"
+            >
+              Refresh
+            </button>
+          </div>
         </div>
       </div>
 
@@ -79,13 +151,16 @@ export function AdminFeedbackPage() {
               <tr>
                 <td colSpan={4} className="px-3 py-12 text-center text-muted-foreground">
                   <MessageSquareText className="mx-auto mb-2 size-8 opacity-40" />
-                  No feedback yet.
+                  {emailQuery ? "No feedback matches this email filter." : "No feedback yet."}
                 </td>
               </tr>
             )}
             {!isLoading &&
               items.map((row) => (
-                <tr key={row.id} className="border-b border-border/10 align-top hover:bg-accent/30">
+                <tr
+                  key={row.id}
+                  className="group border-b border-border/10 align-top hover:bg-accent/30"
+                >
                   <td className="whitespace-nowrap px-3 py-2.5 text-muted-foreground tabular-nums">
                     {formatTimestamp(row.gmt_created)}
                   </td>
@@ -93,14 +168,22 @@ export function AdminFeedbackPage() {
                     {row.user_id}
                   </td>
                   <td className="max-w-[180px] truncate px-3 py-2.5 text-muted-foreground">{row.email}</td>
-                  <td className="px-3 py-2.5 text-foreground">
-                    <span className="whitespace-pre-wrap break-words">{row.body}</span>
+                  <td className="max-w-0 px-3 py-2.5">
+                    <button
+                      type="button"
+                      onClick={() => setSelected(row)}
+                      className="w-full text-left text-foreground underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border/50"
+                    >
+                      <span className="line-clamp-3 whitespace-pre-wrap break-words">{row.body}</span>
+                    </button>
                   </td>
                 </tr>
               ))}
           </tbody>
         </table>
       </div>
+
+      <FeedbackDetailDialog item={selected} onClose={() => setSelected(null)} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add optional `email` query parameter on `GET /v1/admin/support/feedback` for case-insensitive substring match (ILIKE with escaped wildcards).
- Internal admin feedback page: debounced email filter, message preview (`line-clamp-3`), Radix dialog for full message and metadata.
- API test for email filter.

## Generated / mechanical
- `web/src/api/schema.d.ts` and `sdk/python/treadstone_sdk/api/admin/admin_list_user_feedback.py` updated via OpenAPI generation (`make gen-web-types` / `make gen-sdk-python`). `sdk/python/pyproject.toml` version kept at **0.7.4** (not the generator default).

## Test plan
- [x] `make test`
- [x] `ruff check` (pre-commit)

Made with [Cursor](https://cursor.com)