### PR TITLE
fix: sandbox pod security (automount SA token + PSS baseline)

### DIFF
--- a/deploy/sandbox-runtime/README.md
+++ b/deploy/sandbox-runtime/README.md
@@ -1,0 +1,20 @@
+# sandbox-runtime Helm chart
+
+Deploys `SandboxTemplate` and optional `SandboxWarmPool` CRs for the agent-sandbox controller.
+
+## Provisioning paths vs `init-home`
+
+Treadstone uses two sandbox provisioning paths:
+
+1. **SandboxClaim + SandboxTemplate (this chart)** — Ephemeral sandboxes from Helm-defined templates. Pods have **no PVC** and **no init container** in the template.
+2. **Direct `Sandbox` CR from the API** (`treadstone/services/k8s_client.py`) — Used when persistent storage is requested. The API adds `volumeClaimTemplates` and an `**init-home` init container** only in this path.
+
+The init container exists because mounting a PVC at `/home/gem` **hides the image’s home directory**; the init seeds the volume from the image layer (mounted at a separate path) on first boot. It is **not** used by Claim-only workloads.
+
+Security contexts for the main container are defined in `values.yaml` (`sandboxPodSecurityContext`, `sandboxContainerSecurityContext`). The direct path mirrors the same baseline in code; keep them aligned when changing defaults.
+
+## Pod Security Standards (PSS)
+
+Defaults are **less strict** on purpose: `readOnlyRootFilesystem` is **false** so the stock sandbox image can write where it expects (e.g. under `/tmp`). That is closer to the **baseline** profile than to **restricted** (which requires a read-only root filesystem and writable paths only through declared volumes). Namespaces that **enforce restricted** may reject these Pods unless you tighten the image/volumes first and set `readOnlyRootFilesystem: true` (and related overrides) in values.
+
+Workspace PVCs rely on **fsGroup** for permissions; confirm your **StorageClass / CSI** supports `fsGroup` behavior for production.

--- a/deploy/sandbox-runtime/templates/sandbox-templates.yaml
+++ b/deploy/sandbox-runtime/templates/sandbox-templates.yaml
@@ -22,6 +22,7 @@ spec:
         {{- end }}
         treadstone-ai.dev/provision-mode: "claim"
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: sandbox
           image: {{ $.Values.image }}

--- a/deploy/sandbox-runtime/templates/sandbox-templates.yaml
+++ b/deploy/sandbox-runtime/templates/sandbox-templates.yaml
@@ -23,6 +23,10 @@ spec:
         treadstone-ai.dev/provision-mode: "claim"
     spec:
       automountServiceAccountToken: false
+      {{- with $.Values.sandboxPodSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: sandbox
           image: {{ $.Values.image }}
@@ -62,5 +66,9 @@ spec:
             limits:
               cpu: {{ .cpu.limits | quote }}
               memory: {{ .memory.limits | quote }}
+          {{- with $.Values.sandboxContainerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
 {{- end }}

--- a/deploy/sandbox-runtime/values.yaml
+++ b/deploy/sandbox-runtime/values.yaml
@@ -24,6 +24,31 @@ sandboxProbes:
 sandboxPodSelectorLabels:
   treadstone-ai.dev/workload: "sandbox"
 
+# Pod Security Standards (PSS): these defaults intentionally target the LESS strict end of the
+# spectrum (closer to the "baseline" profile): readOnlyRootFilesystem stays false so the AIO
+# sandbox image can write outside declared volumes (e.g. /tmp). That does NOT satisfy the
+# "restricted" profile, which requires a read-only root filesystem and writable paths only via volumes.
+# If your namespace enforces restricted, override values and/or change the image layout first.
+# Keep in sync with treadstone/services/k8s_client.py (SANDBOX_READ_ONLY_ROOT_FILESYSTEM).
+sandboxPodSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+sandboxContainerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+      - ALL
+
 sandboxTemplates:
   - name: aio-sandbox-tiny
     displayName: "AIO Sandbox Tiny"

--- a/tests/unit/test_k8s_client.py
+++ b/tests/unit/test_k8s_client.py
@@ -142,6 +142,7 @@ async def test_create_claim_also_creates_sandbox():
     sb = await client.get_sandbox("my-sb", "treadstone-local")
     assert sb is not None
     assert sb["kind"] == "Sandbox"
+    assert sb["spec"]["podTemplate"]["spec"]["automountServiceAccountToken"] is False
     assert sb["status"]["serviceFQDN"] == "my-sb.treadstone-local.svc.cluster.local"
 
 
@@ -261,6 +262,7 @@ async def test_create_sandbox_direct_without_storage():
     )
     assert sb["kind"] == "Sandbox"
     assert "volumeClaimTemplates" not in sb["spec"]
+    assert sb["spec"]["podTemplate"]["spec"]["automountServiceAccountToken"] is False
 
 
 async def test_get_storage_class():
@@ -375,7 +377,9 @@ async def test_create_sandbox_requests_expected_manifest_with_probes():
     call = api.calls[0]
     assert call["method"] == "POST"
     assert call["base"] == "/apis/agents.x-k8s.io/v1alpha1/namespaces/treadstone-prod/sandboxes"
-    container = call["json"]["spec"]["podTemplate"]["spec"]["containers"][0]
+    pod_spec = call["json"]["spec"]["podTemplate"]["spec"]
+    assert pod_spec["automountServiceAccountToken"] is False
+    container = pod_spec["containers"][0]
     assert container["startupProbe"]["httpGet"]["path"] == "/v1/sandbox"
     assert container["readinessProbe"]["failureThreshold"] == 3
     assert "livenessProbe" not in container
@@ -417,6 +421,7 @@ async def test_create_sandbox_manifest_mounts_pvc_at_home_dir():
     assert len(api.calls) == 1
     manifest = api.calls[0]["json"]
     pod_spec = manifest["spec"]["podTemplate"]["spec"]
+    assert pod_spec["automountServiceAccountToken"] is False
 
     # Main container mounts PVC at the image's home directory
     main = pod_spec["containers"][0]
@@ -440,7 +445,7 @@ async def test_create_sandbox_manifest_mounts_pvc_at_home_dir():
 
 
 async def test_create_sandbox_manifest_without_pvc_has_no_init_or_security_context():
-    """Ephemeral sandbox (no PVC) must not add securityContext or initContainers."""
+    """Ephemeral sandbox (no PVC) disables SA token automount and skips PVC extras."""
     client = Kr8sClient()
     api = _RecordingAPI()
 
@@ -460,6 +465,7 @@ async def test_create_sandbox_manifest_without_pvc_has_no_init_or_security_conte
     manifest = api.calls[0]["json"]
     pod_spec = manifest["spec"]["podTemplate"]["spec"]
 
+    assert pod_spec["automountServiceAccountToken"] is False
     assert "securityContext" not in pod_spec
     assert "initContainers" not in pod_spec
     assert "volumeMounts" not in pod_spec["containers"][0]
@@ -525,6 +531,7 @@ async def test_kr8s_client_preserves_explicit_pod_labels() -> None:
 
     manifest = api.calls[0]["json"]
     pod_spec = manifest["spec"]["podTemplate"]["spec"]
+    assert pod_spec["automountServiceAccountToken"] is False
     assert "tolerations" not in pod_spec
     labels = manifest["spec"]["podTemplate"]["metadata"]["labels"]
     assert labels["treadstone-ai.dev/workload"] == "sandbox"

--- a/tests/unit/test_k8s_client.py
+++ b/tests/unit/test_k8s_client.py
@@ -3,13 +3,14 @@
 from datetime import UTC, datetime, timedelta
 
 from treadstone.services.k8s_client import (
-    SANDBOX_GID,
     SANDBOX_HOME_DIR,
-    SANDBOX_UID,
     WATCH_TIMEOUT_SECONDS,
     FakeK8sClient,
     Kr8sClient,
     _parse_sandbox_template,
+    _sandbox_init_container_security_context,
+    _sandbox_main_container_security_context,
+    _sandbox_pod_security_context,
     format_shutdown_time,
 )
 
@@ -142,7 +143,10 @@ async def test_create_claim_also_creates_sandbox():
     sb = await client.get_sandbox("my-sb", "treadstone-local")
     assert sb is not None
     assert sb["kind"] == "Sandbox"
-    assert sb["spec"]["podTemplate"]["spec"]["automountServiceAccountToken"] is False
+    ps = sb["spec"]["podTemplate"]["spec"]
+    assert ps["automountServiceAccountToken"] is False
+    assert ps["securityContext"] == _sandbox_pod_security_context(with_pvc=False)
+    assert ps["containers"][0]["securityContext"] == _sandbox_main_container_security_context()
     assert sb["status"]["serviceFQDN"] == "my-sb.treadstone-local.svc.cluster.local"
 
 
@@ -262,7 +266,10 @@ async def test_create_sandbox_direct_without_storage():
     )
     assert sb["kind"] == "Sandbox"
     assert "volumeClaimTemplates" not in sb["spec"]
-    assert sb["spec"]["podTemplate"]["spec"]["automountServiceAccountToken"] is False
+    ps = sb["spec"]["podTemplate"]["spec"]
+    assert ps["automountServiceAccountToken"] is False
+    assert ps["securityContext"] == _sandbox_pod_security_context(with_pvc=False)
+    assert ps["containers"][0]["securityContext"] == _sandbox_main_container_security_context()
 
 
 async def test_get_storage_class():
@@ -379,7 +386,9 @@ async def test_create_sandbox_requests_expected_manifest_with_probes():
     assert call["base"] == "/apis/agents.x-k8s.io/v1alpha1/namespaces/treadstone-prod/sandboxes"
     pod_spec = call["json"]["spec"]["podTemplate"]["spec"]
     assert pod_spec["automountServiceAccountToken"] is False
+    assert pod_spec["securityContext"] == _sandbox_pod_security_context(with_pvc=False)
     container = pod_spec["containers"][0]
+    assert container["securityContext"] == _sandbox_main_container_security_context()
     assert container["startupProbe"]["httpGet"]["path"] == "/v1/sandbox"
     assert container["readinessProbe"]["failureThreshold"] == 3
     assert "livenessProbe" not in container
@@ -426,26 +435,24 @@ async def test_create_sandbox_manifest_mounts_pvc_at_home_dir():
     # Main container mounts PVC at the image's home directory
     main = pod_spec["containers"][0]
     assert main["volumeMounts"] == [{"name": "workspace", "mountPath": SANDBOX_HOME_DIR}]
+    assert main["securityContext"] == _sandbox_main_container_security_context()
 
-    # Pod-level security context lets the gem user write to the volume
-    sc = pod_spec["securityContext"]
-    assert sc["fsGroup"] == SANDBOX_GID
-    assert sc["fsGroupChangePolicy"] == "OnRootMismatch"
+    assert pod_spec["securityContext"] == _sandbox_pod_security_context(with_pvc=True)
 
     # initContainer seeds home contents on first boot using a sentinel file
     # (not ls -A empty-check, which breaks on ext4 volumes with lost+found)
     init = pod_spec["initContainers"][0]
     assert init["name"] == "init-home"
     assert init["image"] == image
-    assert init["securityContext"] == {"runAsUser": 0}
+    assert init["securityContext"] == _sandbox_init_container_security_context()
     assert init["volumeMounts"] == [{"name": "workspace", "mountPath": "/mnt/home"}]
     script = init["command"][2]
     assert ".treadstone-home-initialized" in script
-    assert f"chown {SANDBOX_UID}:{SANDBOX_GID}" in script
+    assert "chown" not in script
 
 
-async def test_create_sandbox_manifest_without_pvc_has_no_init_or_security_context():
-    """Ephemeral sandbox (no PVC) disables SA token automount and skips PVC extras."""
+async def test_create_sandbox_manifest_without_pvc_has_baseline_security_no_init():
+    """Ephemeral sandbox (no PVC): PSS baseline on pod/main container; no init or PVC mounts."""
     client = Kr8sClient()
     api = _RecordingAPI()
 
@@ -466,7 +473,8 @@ async def test_create_sandbox_manifest_without_pvc_has_no_init_or_security_conte
     pod_spec = manifest["spec"]["podTemplate"]["spec"]
 
     assert pod_spec["automountServiceAccountToken"] is False
-    assert "securityContext" not in pod_spec
+    assert pod_spec["securityContext"] == _sandbox_pod_security_context(with_pvc=False)
+    assert pod_spec["containers"][0]["securityContext"] == _sandbox_main_container_security_context()
     assert "initContainers" not in pod_spec
     assert "volumeMounts" not in pod_spec["containers"][0]
     assert "volumeClaimTemplates" not in manifest["spec"]
@@ -532,6 +540,7 @@ async def test_kr8s_client_preserves_explicit_pod_labels() -> None:
     manifest = api.calls[0]["json"]
     pod_spec = manifest["spec"]["podTemplate"]["spec"]
     assert pod_spec["automountServiceAccountToken"] is False
+    assert pod_spec["securityContext"] == _sandbox_pod_security_context(with_pvc=False)
     assert "tolerations" not in pod_spec
     labels = manifest["spec"]["podTemplate"]["metadata"]["labels"]
     assert labels["treadstone-ai.dev/workload"] == "sandbox"

--- a/treadstone/services/k8s_client.py
+++ b/treadstone/services/k8s_client.py
@@ -249,7 +249,11 @@ class Kr8sClient:
             liveness_probe=liveness_probe,
         )
 
-        pod_spec: dict[str, Any] = {"containers": [container], "restartPolicy": "OnFailure"}
+        pod_spec: dict[str, Any] = {
+            "automountServiceAccountToken": False,
+            "containers": [container],
+            "restartPolicy": "OnFailure",
+        }
 
         if volume_claim_templates:
             vol_names = [vct["metadata"]["name"] for vct in volume_claim_templates]
@@ -753,7 +757,12 @@ class FakeK8sClient:
             "apiVersion": f"{SANDBOX_API_GROUP}/{SANDBOX_API_VERSION}",
             "kind": "Sandbox",
             "metadata": {"name": sandbox_name, "namespace": namespace, "resourceVersion": "1"},
-            "spec": {"replicas": 1, "podTemplate": {"spec": {"containers": [container]}}},
+            "spec": {
+                "replicas": 1,
+                "podTemplate": {
+                    "spec": {"automountServiceAccountToken": False, "containers": [container]},
+                },
+            },
             "status": {
                 "conditions": [_make_ready_condition("False", "DependenciesNotReady", "Pod does not exist")],
                 "serviceFQDN": f"{sandbox_name}.{namespace}.svc.cluster.local",
@@ -799,6 +808,7 @@ class FakeK8sClient:
             sb_metadata["annotations"] = annotations
 
         pod_spec: dict[str, Any] = {
+            "automountServiceAccountToken": False,
             "containers": [{"name": "sandbox", "image": image, "resources": resources}],
         }
         _apply_container_probes(

--- a/treadstone/services/k8s_client.py
+++ b/treadstone/services/k8s_client.py
@@ -1,9 +1,20 @@
 """K8s client for agent-sandbox CRD operations.
 
 Treadstone uses dual-path sandbox provisioning:
-- SandboxClaim path (extensions.agents.x-k8s.io) — ephemeral sandboxes, WarmPool-eligible
-- Direct Sandbox path (agents.x-k8s.io) — persistent storage via volumeClaimTemplates
-- SandboxTemplate (extensions.agents.x-k8s.io) — Read-only config catalog
+- SandboxClaim path (extensions.agents.x-k8s.io) — ephemeral sandboxes, WarmPool-eligible.
+  Pods come from Helm ``SandboxTemplate`` resources (no PVC in template, no init container).
+- Direct Sandbox path (agents.x-k8s.io) — persistent storage via ``volumeClaimTemplates``.
+  When PVCs mount ``SANDBOX_HOME_DIR``, the volume hides the image home; ``init-home``
+  seeds the PVC from the image layer on first boot (see ``Kr8sClient.create_sandbox``).
+- SandboxTemplate (extensions.agents.x-k8s.io) — read-only catalog for the claim path.
+
+Pod/container ``securityContext`` defaults here should stay aligned with
+``deploy/sandbox-runtime/values.yaml`` (``sandboxPodSecurityContext``,
+``sandboxContainerSecurityContext``).
+
+PSS note: defaults match the chart — non-root, seccomp, dropped caps, but **writable root FS**
+(``readOnlyRootFilesystem`` false). That aligns with **baseline-oriented** hardening, not the
+Kubernetes **restricted** profile (which needs read-only root plus writable paths only on volumes).
 
 Two implementations:
 - FakeK8sClient: In-memory stub for testing
@@ -39,6 +50,11 @@ SANDBOX_HOME_DIR = "/home/gem"
 SANDBOX_UID = 1000
 SANDBOX_GID = 1000
 
+# Align default with deploy/sandbox-runtime/values.yaml sandboxContainerSecurityContext.
+# False = less strict (baseline-friendly): image may write to paths not backed by a volume.
+# True = required for PSS "restricted"; needs emptyDir/tmpfs (or similar) for every writable path.
+SANDBOX_READ_ONLY_ROOT_FILESYSTEM = False
+
 DEFAULT_STARTUP_PROBE: dict[str, Any] = {
     "httpGet": {"path": "/v1/sandbox", "port": 8080},
     "periodSeconds": 5,
@@ -60,6 +76,45 @@ class WatchExpiredError(Exception):
 def format_shutdown_time(dt: datetime) -> str:
     """Format a datetime as RFC3339 for K8s shutdownTime field."""
     return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sandbox_pod_security_context(*, with_pvc: bool) -> dict[str, Any]:
+    """Pod-level securityContext (baseline-oriented PSS hardening). Adds fsGroup when a workspace PVC is used."""
+    ctx: dict[str, Any] = {
+        "runAsNonRoot": True,
+        "runAsUser": SANDBOX_UID,
+        "runAsGroup": SANDBOX_GID,
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+    if with_pvc:
+        ctx["fsGroup"] = SANDBOX_GID
+        ctx["fsGroupChangePolicy"] = "OnRootMismatch"
+    return ctx
+
+
+def _sandbox_main_container_security_context() -> dict[str, Any]:
+    """Main sandbox container: matches Helm sandboxContainerSecurityContext defaults."""
+    return {
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "readOnlyRootFilesystem": SANDBOX_READ_ONLY_ROOT_FILESYSTEM,
+        "runAsNonRoot": True,
+        "runAsUser": SANDBOX_UID,
+        "runAsGroup": SANDBOX_GID,
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+
+
+def _sandbox_init_container_security_context() -> dict[str, Any]:
+    """init-home runs as the same UID as the main process; root is not required for cp with fsGroup."""
+    return {
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "runAsNonRoot": True,
+        "runAsUser": SANDBOX_UID,
+        "runAsGroup": SANDBOX_GID,
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
 
 
 @runtime_checkable
@@ -248,34 +303,31 @@ class Kr8sClient:
             readiness_probe=readiness_probe,
             liveness_probe=liveness_probe,
         )
+        container["securityContext"] = _sandbox_main_container_security_context()
 
         pod_spec: dict[str, Any] = {
             "automountServiceAccountToken": False,
             "containers": [container],
             "restartPolicy": "OnFailure",
+            "securityContext": _sandbox_pod_security_context(with_pvc=bool(volume_claim_templates)),
         }
 
         if volume_claim_templates:
             vol_names = [vct["metadata"]["name"] for vct in volume_claim_templates]
             container["volumeMounts"] = [{"name": n, "mountPath": SANDBOX_HOME_DIR} for n in vol_names]
 
-            pod_spec["securityContext"] = {
-                "fsGroup": SANDBOX_GID,
-                "fsGroupChangePolicy": "OnRootMismatch",
-            }
-
             # On first boot the PVC shadows the image's home dir.  Seed the
             # volume with the image-layer skeleton (dotfiles from useradd -m,
             # etc.) so the main container's entrypoint can layer runtime state
             # on top.  A sentinel file tracks whether seeding has happened —
             # `ls -A` empty-checks break on ext4 volumes that ship lost+found.
+            # Runs as UID/GID SANDBOX_* with pod fsGroup; no chown (PSS restricted).
             _sentinel = "/mnt/home/.treadstone-home-initialized"
             init_script = (
                 f"if [ ! -f {_sentinel} ]; then "
                 f"cp -a {SANDBOX_HOME_DIR}/. /mnt/home/ 2>/dev/null || true; "
                 f"touch {_sentinel}; "
-                f"fi; "
-                f"chown {SANDBOX_UID}:{SANDBOX_GID} /mnt/home"
+                f"fi"
             )
             pod_spec["initContainers"] = [
                 {
@@ -283,7 +335,7 @@ class Kr8sClient:
                     "image": image,
                     "command": ["sh", "-c", init_script],
                     "volumeMounts": [{"name": n, "mountPath": "/mnt/home"} for n in vol_names],
-                    "securityContext": {"runAsUser": 0},
+                    "securityContext": _sandbox_init_container_security_context(),
                 }
             ]
 
@@ -752,6 +804,7 @@ class FakeK8sClient:
                 readiness_probe=template.get("readiness_probe"),
                 liveness_probe=template.get("liveness_probe"),
             )
+        container["securityContext"] = _sandbox_main_container_security_context()
 
         self._sandboxes[key] = {
             "apiVersion": f"{SANDBOX_API_GROUP}/{SANDBOX_API_VERSION}",
@@ -760,7 +813,12 @@ class FakeK8sClient:
             "spec": {
                 "replicas": 1,
                 "podTemplate": {
-                    "spec": {"automountServiceAccountToken": False, "containers": [container]},
+                    "spec": {
+                        "automountServiceAccountToken": False,
+                        "restartPolicy": "OnFailure",
+                        "securityContext": _sandbox_pod_security_context(with_pvc=False),
+                        "containers": [container],
+                    },
                 },
             },
             "status": {
@@ -807,16 +865,46 @@ class FakeK8sClient:
         if annotations:
             sb_metadata["annotations"] = annotations
 
-        pod_spec: dict[str, Any] = {
-            "automountServiceAccountToken": False,
-            "containers": [{"name": "sandbox", "image": image, "resources": resources}],
+        main: dict[str, Any] = {
+            "name": "sandbox",
+            "image": image,
+            "resources": resources,
         }
         _apply_container_probes(
-            pod_spec["containers"][0],
+            main,
             startup_probe=startup_probe,
             readiness_probe=readiness_probe,
             liveness_probe=liveness_probe,
         )
+        main["securityContext"] = _sandbox_main_container_security_context()
+
+        pod_spec: dict[str, Any] = {
+            "automountServiceAccountToken": False,
+            "containers": [main],
+            "restartPolicy": "OnFailure",
+            "securityContext": _sandbox_pod_security_context(with_pvc=bool(volume_claim_templates)),
+        }
+
+        if volume_claim_templates:
+            vol_names = [vct["metadata"]["name"] for vct in volume_claim_templates]
+            main["volumeMounts"] = [{"name": n, "mountPath": SANDBOX_HOME_DIR} for n in vol_names]
+            _sentinel = "/mnt/home/.treadstone-home-initialized"
+            init_script = (
+                f"if [ ! -f {_sentinel} ]; then "
+                f"cp -a {SANDBOX_HOME_DIR}/. /mnt/home/ 2>/dev/null || true; "
+                f"touch {_sentinel}; "
+                f"fi"
+            )
+            pod_spec["initContainers"] = [
+                {
+                    "name": "init-home",
+                    "image": image,
+                    "command": ["sh", "-c", init_script],
+                    "volumeMounts": [{"name": n, "mountPath": "/mnt/home"} for n in vol_names],
+                    "securityContext": _sandbox_init_container_security_context(),
+                }
+            ]
+
         pod_template: dict[str, Any] = {"spec": pod_spec}
         if pod_labels:
             pod_template["metadata"] = {"labels": pod_labels}


### PR DESCRIPTION
## Summary
- **#299:** Set `automountServiceAccountToken: false` on SandboxTemplate and direct Sandbox manifests (`Kr8sClient` / `FakeK8sClient`).
- **#298:** Add PSS **baseline-oriented** `securityContext` (non-root, seccomp RuntimeDefault, capabilities drop ALL, writable root FS by default). Helm `sandboxPodSecurityContext` / `sandboxContainerSecurityContext`; direct path uses shared helpers; `init-home` runs as UID 1000 without trailing `chown`. Document Claim vs direct+PVC, **baseline vs restricted** PSS, and `fsGroup` / StorageClass expectations (`deploy/sandbox-runtime/README.md`).

## Test Plan
- [x] `make test`
- [x] `make lint`
- [x] `helm template` for `deploy/sandbox-runtime`

Closes #298.
Closes #299.