### PR TITLE
feat: platform-wide limits for users, sandboxes, storage, and waitlist

### DIFF
--- a/alembic/versions/0d5c9f8a7b6e_add_platform_limits_table.py
+++ b/alembic/versions/0d5c9f8a7b6e_add_platform_limits_table.py
@@ -1,0 +1,63 @@
+"""add platform limits table
+
+Revision ID: 0d5c9f8a7b6e
+Revises: 4b3f2f3fd7d8
+Create Date: 2026-04-10 10:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0d5c9f8a7b6e"
+down_revision: str | Sequence[str] | None = "4b3f2f3fd7d8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "platform_limits",
+        sa.Column("id", sa.String(length=24), nullable=False),
+        sa.Column("max_registered_users", sa.Integer(), nullable=True),
+        sa.Column("max_total_sandboxes", sa.Integer(), nullable=True),
+        sa.Column("max_total_storage_gib", sa.Integer(), nullable=True),
+        sa.Column("max_waitlist_applications", sa.Integer(), nullable=True),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_updated", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    platform_limits = sa.table(
+        "platform_limits",
+        sa.column("id", sa.String(length=24)),
+        sa.column("max_registered_users", sa.Integer()),
+        sa.column("max_total_sandboxes", sa.Integer()),
+        sa.column("max_total_storage_gib", sa.Integer()),
+        sa.column("max_waitlist_applications", sa.Integer()),
+        sa.column("gmt_created", sa.DateTime(timezone=True)),
+        sa.column("gmt_updated", sa.DateTime(timezone=True)),
+    )
+    now = datetime.now(UTC)
+    op.bulk_insert(
+        platform_limits,
+        [
+            {
+                "id": "platform_limits",
+                "max_registered_users": None,
+                "max_total_sandboxes": None,
+                "max_total_storage_gib": None,
+                "max_waitlist_applications": None,
+                "gmt_created": now,
+                "gmt_updated": now,
+            }
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("platform_limits")

--- a/alembic/versions/8d53041b011f_merge_platform_limits_and_password_.py
+++ b/alembic/versions/8d53041b011f_merge_platform_limits_and_password_.py
@@ -1,0 +1,25 @@
+"""merge platform_limits and password_reset heads
+
+Revision ID: 8d53041b011f
+Revises: 0d5c9f8a7b6e, a4d2e5f7c1b9
+Create Date: 2026-04-10 15:55:34.913859
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "8d53041b011f"
+down_revision: str | Sequence[str] | None = ("0d5c9f8a7b6e", "a4d2e5f7c1b9")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/tests/api/test_admin_api.py
+++ b/tests/api/test_admin_api.py
@@ -19,6 +19,7 @@ from treadstone.core.users import UserManager, get_user_db, get_user_manager
 from treadstone.main import app
 from treadstone.models.audit_event import AuditEvent
 from treadstone.models.metering import TierTemplate
+from treadstone.models.platform_limits import PlatformLimits  # noqa: F401 — register model for SQLite metadata
 from treadstone.models.user import OAuthAccount, User
 from treadstone.models.user_feedback import UserFeedback  # noqa: F401 — register model for SQLite metadata
 from treadstone.models.waitlist import WaitlistApplication  # noqa: F401 — register model for SQLite metadata
@@ -165,6 +166,58 @@ async def test_list_tier_templates(admin_client):
 async def test_list_tier_templates_requires_admin(member_client):
     resp = await member_client.get("/v1/admin/tier-templates")
     assert resp.status_code == 403
+
+
+async def test_get_platform_limits_returns_live_config_and_usage(admin_client, anon_client):
+    await anon_client.post("/v1/auth/register", json={"email": "platform-user@example.com", "password": "Pass123!"})
+    await anon_client.post(
+        "/v1/waitlist",
+        json={"email": "platform-waitlist@example.com", "name": "Waitlist User", "target_tier": "pro"},
+    )
+
+    patch_resp = await admin_client.patch(
+        "/v1/admin/platform-limits",
+        json={"max_registered_users": 10, "max_waitlist_applications": 20},
+    )
+    assert patch_resp.status_code == 200
+
+    resp = await admin_client.get("/v1/admin/platform-limits")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["config"]["max_registered_users"] == 10
+    assert data["config"]["max_waitlist_applications"] == 20
+    assert data["usage"]["registered_users"] >= 2
+    assert data["usage"]["waitlist_applications"] >= 1
+
+
+async def test_patch_platform_limits_allows_clearing_values(admin_client):
+    first = await admin_client.patch(
+        "/v1/admin/platform-limits",
+        json={"max_registered_users": 5, "max_total_sandboxes": 8},
+    )
+    assert first.status_code == 200
+
+    second = await admin_client.patch(
+        "/v1/admin/platform-limits",
+        json={"max_registered_users": None},
+    )
+    assert second.status_code == 200
+    assert second.json()["config"]["max_registered_users"] is None
+    assert second.json()["config"]["max_total_sandboxes"] == 8
+
+    update_events = await _list_audit_events("admin.platform_limits.updated")
+    assert update_events[-1].event_metadata["updates"] == {"max_registered_users": None}
+
+
+async def test_platform_limits_admin_endpoints_require_admin_session(member_client):
+    get_resp = await member_client.get("/v1/admin/platform-limits")
+    assert get_resp.status_code == 403
+
+
+async def test_platform_limits_admin_endpoints_reject_api_key_auth(admin_client):
+    api_key = await _create_control_plane_api_key(admin_client, "platform-limits")
+    resp = await admin_client.get("/v1/admin/platform-limits", headers={"Authorization": f"Bearer {api_key}"})
+    assert resp.status_code == 401
 
 
 # ── PATCH /v1/admin/tier-templates/{tier_name} ──────────────────────────────

--- a/tests/api/test_auth_api.py
+++ b/tests/api/test_auth_api.py
@@ -10,6 +10,7 @@ from treadstone.core.database import Base, get_session
 from treadstone.core.users import UserManager, get_jwt_strategy, get_user_db, get_user_manager
 from treadstone.main import app
 from treadstone.models.audit_event import AuditEvent
+from treadstone.models.platform_limits import PLATFORM_LIMITS_SINGLETON_ID, PlatformLimits
 from treadstone.models.user import OAuthAccount, User
 
 _test_session_factory = None
@@ -48,6 +49,18 @@ async def db_session():
     await test_engine.dispose()
 
 
+async def _set_platform_limits(**limits) -> None:
+    async with _test_session_factory() as session:
+        row = await session.get(PlatformLimits, PLATFORM_LIMITS_SINGLETON_ID)
+        if row is None:
+            row = PlatformLimits(id=PLATFORM_LIMITS_SINGLETON_ID)
+        for field, value in limits.items():
+            setattr(row, field, value)
+        session.add(row)
+        await session.commit()
+        await app.state.platform_limits_runtime.refresh_from_session(session)
+
+
 @pytest.mark.asyncio
 async def test_register_first_user_becomes_admin(db_session):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -74,6 +87,43 @@ async def test_register_duplicate_email(db_session):
         await client.post("/v1/auth/register", json={"email": "a@b.com", "password": "Pass123!"})
         resp = await client.post("/v1/auth/register", json={"email": "a@b.com", "password": "Pass123!"})
     assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_register_respects_global_user_cap(db_session):
+    await _set_platform_limits(max_registered_users=0)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/v1/auth/register", json={"email": "cap@example.com", "password": "Pass123!"})
+
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "user_registration_cap_exceeded"
+
+    async with _test_session_factory() as session:
+        event = (
+            (
+                await session.execute(
+                    select(AuditEvent).where(AuditEvent.action == "auth.register").order_by(AuditEvent.created_at)
+                )
+            )
+            .scalars()
+            .all()[-1]
+        )
+
+    assert event.result == "failure"
+    assert event.error_code == "user_registration_cap_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_email_wins_before_global_cap(db_session):
+    await _set_platform_limits(max_registered_users=1)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        first = await client.post("/v1/auth/register", json={"email": "dup@example.com", "password": "Pass123!"})
+        second = await client.post("/v1/auth/register", json={"email": "dup@example.com", "password": "Pass123!"})
+
+    assert first.status_code == 201
+    assert second.status_code == 409
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -13,6 +13,7 @@ from treadstone.core.database import Base, get_session
 from treadstone.core.users import UserManager, get_user_db, get_user_manager
 from treadstone.main import app
 from treadstone.models.audit_event import AuditEvent
+from treadstone.models.platform_limits import PLATFORM_LIMITS_SINGLETON_ID, PlatformLimits
 from treadstone.models.user import OAuthAccount, User
 from treadstone.services import browser_login as browser_login_service
 
@@ -94,6 +95,18 @@ def _extract_state(location: str) -> str:
     return parse_qs(urlparse(location).query)["state"][0]
 
 
+async def _set_platform_limits(**limits) -> None:
+    async with _test_session_factory() as session:
+        row = await session.get(PlatformLimits, PLATFORM_LIMITS_SINGLETON_ID)
+        if row is None:
+            row = PlatformLimits(id=PLATFORM_LIMITS_SINGLETON_ID)
+        for field, value in limits.items():
+            setattr(row, field, value)
+        session.add(row)
+        await session.commit()
+        await app.state.platform_limits_runtime.refresh_from_session(session)
+
+
 def _enable_browser_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
     monkeypatch.setattr(auth_api.settings, "sandbox_domain", "sandbox.localhost")
@@ -152,6 +165,46 @@ async def test_google_callback_creates_user_and_sets_session_cookie(db_session, 
     assert user.has_local_password is False
     assert oauth_account.oauth_name == "google"
     assert oauth_account.account_id == "acct-new"
+
+
+@pytest.mark.asyncio
+async def test_google_callback_blocks_new_user_when_global_cap_reached(db_session, monkeypatch):
+    monkeypatch.setattr(auth_api.settings, "app_base_url", "http://test")
+    await _set_platform_limits(max_registered_users=0)
+    client = FakeOAuthClient("google", account_id="acct-capped", account_email="capped@example.com")
+    monkeypatch.setattr(auth_api, "get_google_oauth_client", lambda: client, raising=False)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http_client:
+        authorize = await http_client.get("/v1/auth/google/authorize", follow_redirects=False)
+        state = _extract_state(authorize.headers["location"])
+        callback = await http_client.get(
+            "/v1/auth/google/callback",
+            params={"code": "oauth-code", "state": state},
+            follow_redirects=False,
+        )
+
+    assert callback.status_code == 503
+    assert callback.json()["error"]["code"] == "user_registration_cap_exceeded"
+
+    async with _test_session_factory() as session:
+        user = (
+            (await session.execute(select(User).where(User.email == "capped@example.com")))
+            .unique()
+            .scalar_one_or_none()
+        )
+        event = (
+            (
+                await session.execute(
+                    select(AuditEvent).where(AuditEvent.action == "auth.register").order_by(AuditEvent.created_at)
+                )
+            )
+            .scalars()
+            .all()[-1]
+        )
+
+    assert user is None
+    assert event.result == "failure"
+    assert event.error_code == "user_registration_cap_exceeded"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_sandboxes_api.py
+++ b/tests/api/test_sandboxes_api.py
@@ -12,6 +12,7 @@ from treadstone.core.database import Base, get_session
 from treadstone.core.users import UserManager, get_user_db, get_user_manager
 from treadstone.main import app
 from treadstone.models.audit_event import AuditEvent
+from treadstone.models.platform_limits import PLATFORM_LIMITS_SINGLETON_ID, PlatformLimits
 from treadstone.models.sandbox import Sandbox, SandboxStatus, StorageBackendMode
 from treadstone.models.user import OAuthAccount, User
 from treadstone.services.k8s_client import FakeK8sClient, get_k8s_client, set_k8s_client
@@ -49,6 +50,18 @@ async def db_session():
     async with test_engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
     await test_engine.dispose()
+
+
+async def _set_platform_limits(**limits) -> None:
+    async with _test_session_factory() as session:
+        row = await session.get(PlatformLimits, PLATFORM_LIMITS_SINGLETON_ID)
+        if row is None:
+            row = PlatformLimits(id=PLATFORM_LIMITS_SINGLETON_ID)
+        for field, value in limits.items():
+            setattr(row, field, value)
+        session.add(row)
+        await session.commit()
+        await app.state.platform_limits_runtime.refresh_from_session(session)
 
 
 @pytest.fixture
@@ -143,6 +156,51 @@ class TestCreateSandbox:
         )
         assert resp.status_code == 404
         assert resp.json()["error"]["code"] == "template_not_found"
+
+    async def test_create_respects_total_sandbox_cap(self, auth_client):
+        await _set_platform_limits(max_total_sandboxes=1)
+
+        first = await auth_client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny", "name": "cap-a"})
+        second = await auth_client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny", "name": "cap-b"})
+
+        assert first.status_code == 202
+        assert second.status_code == 503
+        assert second.json()["error"]["code"] == "sandbox_cap_exceeded"
+
+        async with _test_session_factory() as session:
+            event = (
+                (
+                    await session.execute(
+                        select(AuditEvent).where(AuditEvent.action == "sandbox.create").order_by(AuditEvent.created_at)
+                    )
+                )
+                .scalars()
+                .all()[-1]
+            )
+
+        assert event.result == "failure"
+        assert event.error_code == "sandbox_cap_exceeded"
+
+    async def test_create_persistent_sandbox_respects_global_storage_cap(self, auth_client):
+        await _set_platform_limits(max_total_storage_gib=0)
+
+        resp = await auth_client.post(
+            "/v1/sandboxes",
+            json={"template": "aio-sandbox-tiny", "name": "persist-capped", "persist": True, "storage_size": "5Gi"},
+        )
+
+        assert resp.status_code == 503
+        assert resp.json()["error"]["code"] == "global_storage_cap_exceeded"
+
+    async def test_create_non_persistent_sandbox_ignores_global_storage_cap(self, auth_client):
+        await _set_platform_limits(max_total_storage_gib=0)
+
+        resp = await auth_client.post(
+            "/v1/sandboxes",
+            json={"template": "aio-sandbox-tiny", "name": "ephemeral-ok", "persist": False},
+        )
+
+        assert resp.status_code == 202
 
     async def test_create_with_persist_returns_202(self, auth_client):
         resp = await auth_client.post(

--- a/tests/api/test_sandboxes_api.py
+++ b/tests/api/test_sandboxes_api.py
@@ -64,6 +64,12 @@ async def _set_platform_limits(**limits) -> None:
         await app.state.platform_limits_runtime.refresh_from_session(session)
 
 
+async def _refresh_platform_limits_runtime_cache() -> None:
+    """Align the API process snapshot with the database (tests only)."""
+    async with _test_session_factory() as session:
+        await app.state.platform_limits_runtime.refresh_from_session(session)
+
+
 @pytest.fixture
 async def auth_client(db_session):
     """Register + login, return client with auth cookie."""
@@ -161,9 +167,10 @@ class TestCreateSandbox:
         await _set_platform_limits(max_total_sandboxes=1)
 
         first = await auth_client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny", "name": "cap-a"})
+        assert first.status_code == 202
+        await _refresh_platform_limits_runtime_cache()
         second = await auth_client.post("/v1/sandboxes", json={"template": "aio-sandbox-tiny", "name": "cap-b"})
 
-        assert first.status_code == 202
         assert second.status_code == 503
         assert second.json()["error"]["code"] == "sandbox_cap_exceeded"
 

--- a/tests/api/test_waitlist_api.py
+++ b/tests/api/test_waitlist_api.py
@@ -10,6 +10,7 @@ from treadstone.core.database import Base, get_session
 from treadstone.core.users import UserManager, get_user_db, get_user_manager
 from treadstone.main import app
 from treadstone.models.metering import TierTemplate
+from treadstone.models.platform_limits import PLATFORM_LIMITS_SINGLETON_ID, PlatformLimits
 from treadstone.models.user import OAuthAccount, User
 from treadstone.models.waitlist import WaitlistApplication
 
@@ -65,6 +66,18 @@ async def session_factory():
     await test_engine.dispose()
 
 
+async def _set_platform_limits(session_factory, **limits) -> None:
+    async with session_factory() as session:
+        row = await session.get(PlatformLimits, PLATFORM_LIMITS_SINGLETON_ID)
+        if row is None:
+            row = PlatformLimits(id=PLATFORM_LIMITS_SINGLETON_ID)
+        for field, value in limits.items():
+            setattr(row, field, value)
+        session.add(row)
+        await session.commit()
+        await app.state.platform_limits_runtime.refresh_from_session(session)
+
+
 @pytest.fixture
 async def anon_client(session_factory):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -103,3 +116,32 @@ async def test_post_waitlist_succeeds_even_if_post_commit_refresh_fails(anon_cli
         )
 
     assert len(rows) == 1
+
+
+async def test_post_waitlist_respects_global_cap(anon_client, session_factory):
+    await _set_platform_limits(session_factory, max_waitlist_applications=0)
+
+    response = await anon_client.post(
+        "/v1/waitlist",
+        json={
+            "email": "waitlist-cap@example.com",
+            "name": "Waitlist Cap",
+            "target_tier": "pro",
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "waitlist_cap_exceeded"
+
+    async with session_factory() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(WaitlistApplication).where(WaitlistApplication.email == "waitlist-cap@example.com")
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert rows == []

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -48,6 +48,8 @@ async def test_lifespan_passes_session_factory_to_supervisor_when_leader_electio
     )
     monkeypatch.setattr(sync_supervisor, "LeaderControlledSyncSupervisor", CapturingSupervisor)
     monkeypatch.setattr(main, "close_http_client", close_http_client)
+    monkeypatch.setattr(main.app.state.platform_limits_runtime, "start", AsyncMock())
+    monkeypatch.setattr(main.app.state.platform_limits_runtime, "stop", AsyncMock())
 
     async with main.lifespan(main.app):
         assert captured["session_factory"] is async_session
@@ -90,6 +92,8 @@ async def test_lifespan_starts_metering_loop_when_leader_election_disabled(monke
     monkeypatch.setattr(k8s_client, "get_k8s_client", lambda: object())
     monkeypatch.setattr(k8s_sync, "start_sync_loop", fake_sync_loop)
     monkeypatch.setattr(main, "close_http_client", close_http_client)
+    monkeypatch.setattr(main.app.state.platform_limits_runtime, "start", AsyncMock())
+    monkeypatch.setattr(main.app.state.platform_limits_runtime, "stop", AsyncMock())
 
     async with main.lifespan(main.app):
         await asyncio.wait_for(sync_started.wait(), timeout=0.5)

--- a/tests/unit/test_metering_models.py
+++ b/tests/unit/test_metering_models.py
@@ -314,8 +314,9 @@ class TestParseStorageSizeGib:
     def test_20gi(self):
         assert parse_storage_size_gib("20Gi") == 20
 
-    def test_1ti(self):
-        assert parse_storage_size_gib("1Ti") == 1024
+    def test_ti_rejected(self):
+        with pytest.raises(BadRequestError, match="Unsupported storage size format"):
+            parse_storage_size_gib("1Ti")
 
     def test_invalid_suffix_raises(self):
         with pytest.raises(BadRequestError, match="Unsupported storage size format"):

--- a/tests/unit/test_platform_limits.py
+++ b/tests/unit/test_platform_limits.py
@@ -118,22 +118,30 @@ async def test_build_snapshot_counts_usage_from_models():
 
 
 @pytest.mark.asyncio
-async def test_runtime_apply_local_delta_updates_snapshot_counts():
+async def test_runtime_refresh_from_session_reflects_committed_rows():
     session_factory = await _make_session_factory()
     runtime = PlatformLimitsRuntime()
 
     async with session_factory() as session:
-        snapshot = await runtime.ensure_snapshot(session)
+        snapshot = await runtime.refresh_from_session(session)
 
     assert snapshot.usage.registered_users == 0
 
-    await runtime.apply_local_delta(users=1, sandboxes=2, storage_gib=5, waitlist_applications=3)
+    async with session_factory() as session:
+        session.add(
+            User(
+                email="postcommit@example.com",
+                hashed_password="hashed",
+                has_local_password=True,
+                is_active=True,
+                is_verified=True,
+                role="rw",
+            )
+        )
+        await session.commit()
+        snapshot = await runtime.refresh_from_session(session)
 
-    assert runtime.snapshot is not None
-    assert runtime.snapshot.usage.registered_users == 1
-    assert runtime.snapshot.usage.total_sandboxes == 2
-    assert runtime.snapshot.usage.total_storage_gib == 5
-    assert runtime.snapshot.usage.waitlist_applications == 3
+    assert snapshot.usage.registered_users == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_platform_limits.py
+++ b/tests/unit/test_platform_limits.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from treadstone.core.database import Base
+from treadstone.models.platform_limits import PLATFORM_LIMITS_SINGLETON_ID, PlatformLimits
+from treadstone.models.sandbox import Sandbox
+from treadstone.models.user import User, utc_now
+from treadstone.models.waitlist import ApplicationStatus, WaitlistApplication
+from treadstone.services.platform_limits import PlatformLimitsRuntime, PlatformLimitsService
+
+
+async def _make_session_factory() -> async_sessionmaker[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest.mark.asyncio
+async def test_build_snapshot_without_config_row_is_unlimited():
+    session_factory = await _make_session_factory()
+    service = PlatformLimitsService()
+
+    async with session_factory() as session:
+        snapshot = await service.build_snapshot(session)
+
+    assert snapshot.config.max_registered_users is None
+    assert snapshot.config.max_total_sandboxes is None
+    assert snapshot.config.max_total_storage_gib is None
+    assert snapshot.config.max_waitlist_applications is None
+    assert snapshot.usage.registered_users == 0
+    assert snapshot.usage.total_sandboxes == 0
+    assert snapshot.usage.total_storage_gib == 0
+    assert snapshot.usage.waitlist_applications == 0
+
+
+@pytest.mark.asyncio
+async def test_build_snapshot_counts_usage_from_models():
+    session_factory = await _make_session_factory()
+    service = PlatformLimitsService()
+
+    async with session_factory() as session:
+        session.add(
+            PlatformLimits(
+                id=PLATFORM_LIMITS_SINGLETON_ID,
+                max_registered_users=10,
+                max_total_sandboxes=20,
+                max_total_storage_gib=30,
+                max_waitlist_applications=40,
+            )
+        )
+        user = User(
+            email="usage@example.com",
+            hashed_password="hashed",
+            has_local_password=True,
+            is_active=True,
+            is_verified=True,
+            role="rw",
+        )
+        session.add(user)
+        await session.flush()
+        session.add_all(
+            [
+                Sandbox(
+                    id="sb_active_001",
+                    name="active-sb",
+                    owner_id=user.id,
+                    template="aio-sandbox-tiny",
+                    labels={},
+                    endpoints={},
+                    status="creating",
+                    version=1,
+                    k8s_namespace="default",
+                    gmt_created=utc_now(),
+                    gmt_last_active=utc_now(),
+                    persist=True,
+                    storage_size="10Gi",
+                ),
+                Sandbox(
+                    id="sb_deleted_01",
+                    name="deleted-sb",
+                    owner_id=user.id,
+                    template="aio-sandbox-tiny",
+                    labels={},
+                    endpoints={},
+                    status="deleted",
+                    version=1,
+                    k8s_namespace="default",
+                    gmt_created=utc_now(),
+                    gmt_last_active=utc_now(),
+                    persist=True,
+                    storage_size="20Gi",
+                    gmt_deleted=utc_now(),
+                ),
+                WaitlistApplication(
+                    email="waitlist@example.com",
+                    name="Waitlist User",
+                    target_tier="pro",
+                    status=ApplicationStatus.PENDING,
+                ),
+            ]
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        snapshot = await service.build_snapshot(session)
+
+    assert snapshot.config.max_registered_users == 10
+    assert snapshot.config.max_total_sandboxes == 20
+    assert snapshot.config.max_total_storage_gib == 30
+    assert snapshot.config.max_waitlist_applications == 40
+    assert snapshot.usage.registered_users == 1
+    assert snapshot.usage.total_sandboxes == 1
+    assert snapshot.usage.total_storage_gib == 10
+    assert snapshot.usage.waitlist_applications == 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_apply_local_delta_updates_snapshot_counts():
+    session_factory = await _make_session_factory()
+    runtime = PlatformLimitsRuntime()
+
+    async with session_factory() as session:
+        snapshot = await runtime.ensure_snapshot(session)
+
+    assert snapshot.usage.registered_users == 0
+
+    await runtime.apply_local_delta(users=1, sandboxes=2, storage_gib=5, waitlist_applications=3)
+
+    assert runtime.snapshot is not None
+    assert runtime.snapshot.usage.registered_users == 1
+    assert runtime.snapshot.usage.total_sandboxes == 2
+    assert runtime.snapshot.usage.total_storage_gib == 5
+    assert runtime.snapshot.usage.waitlist_applications == 3
+
+
+@pytest.mark.asyncio
+async def test_runtime_refreshes_when_session_bind_changes():
+    runtime = PlatformLimitsRuntime()
+    factory_one = await _make_session_factory()
+    factory_two = await _make_session_factory()
+
+    async with factory_one() as session:
+        session.add(
+            User(
+                email="one@example.com",
+                hashed_password="hashed",
+                has_local_password=True,
+                is_active=True,
+                is_verified=True,
+                role="rw",
+            )
+        )
+        await session.commit()
+
+    async with factory_two() as session:
+        session.add_all(
+            [
+                User(
+                    email="two@example.com",
+                    hashed_password="hashed",
+                    has_local_password=True,
+                    is_active=True,
+                    is_verified=True,
+                    role="rw",
+                ),
+                User(
+                    email="three@example.com",
+                    hashed_password="hashed",
+                    has_local_password=True,
+                    is_active=True,
+                    is_verified=True,
+                    role="rw",
+                ),
+            ]
+        )
+        await session.commit()
+
+    async with factory_one() as session:
+        snapshot_one = await runtime.ensure_snapshot(session)
+    async with factory_two() as session:
+        snapshot_two = await runtime.ensure_snapshot(session)
+
+    assert snapshot_one.usage.registered_users == 1
+    assert snapshot_two.usage.registered_users == 2

--- a/treadstone/api/admin.py
+++ b/treadstone/api/admin.py
@@ -2,6 +2,8 @@
 
 Endpoints:
   GET    /v1/admin/stats                        — platform-level operational statistics
+  GET    /v1/admin/platform-limits              — read platform-wide global cap configuration
+  PATCH  /v1/admin/platform-limits              — update platform-wide global cap configuration
   GET    /v1/admin/tier-templates               — list all tier templates
   PATCH  /v1/admin/tier-templates/{tier_name}    — update a tier template
   GET    /v1/admin/users/lookup-by-email        — find user by email
@@ -43,6 +45,7 @@ from treadstone.api.schemas import (
     CreateStorageQuotaGrantResponse,
     FeedbackItemResponse,
     FeedbackListResponse,
+    PlatformLimitsResponse,
     PlatformStatsResponse,
     ResolveEmailsRequest,
     ResolveEmailsResponse,
@@ -51,6 +54,7 @@ from treadstone.api.schemas import (
     StorageStats,
     TierTemplateListResponse,
     UpdatePlanRequest,
+    UpdatePlatformLimitsRequest,
     UpdateTierTemplateRequest,
     UpdateTierTemplateResponse,
     UpdateWaitlistApplicationRequest,
@@ -66,12 +70,14 @@ from treadstone.core.database import get_session
 from treadstone.core.errors import ConflictError, NotFoundError
 from treadstone.models.email_verification_log import EmailVerificationLog
 from treadstone.models.metering import ComputeGrant, StorageLedger, StorageQuotaGrant, UserPlan
+from treadstone.models.platform_limits import PLATFORM_LIMITS_SINGLETON_ID
 from treadstone.models.sandbox import Sandbox
-from treadstone.models.user import User
+from treadstone.models.user import User, utc_now
 from treadstone.models.user_feedback import UserFeedback
 from treadstone.models.waitlist import ApplicationStatus, WaitlistApplication
 from treadstone.services.audit import record_audit_event
 from treadstone.services.metering_service import MeteringService
+from treadstone.services.platform_limits import PlatformLimitsService, PlatformLimitsSnapshot
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +119,7 @@ async def _load_existing_user_ids(session: AsyncSession, user_ids: list[str]) ->
 router = APIRouter(prefix="/v1/admin", tags=["admin"])
 
 _metering = MeteringService()
+_platform_limits = PlatformLimitsService()
 
 
 def serialize_compute_grant_response(grant: ComputeGrant) -> dict:
@@ -143,6 +150,24 @@ def serialize_storage_quota_grant_response(grant: StorageQuotaGrant) -> dict:
         "campaign_id": base["campaign_id"],
         "granted_at": base["granted_at"],
         "expires_at": base["expires_at"],
+    }
+
+
+def _serialize_platform_limits(snapshot: PlatformLimitsSnapshot) -> dict:
+    return {
+        "config": {
+            "max_registered_users": snapshot.config.max_registered_users,
+            "max_total_sandboxes": snapshot.config.max_total_sandboxes,
+            "max_total_storage_gib": snapshot.config.max_total_storage_gib,
+            "max_waitlist_applications": snapshot.config.max_waitlist_applications,
+        },
+        "usage": {
+            "registered_users": snapshot.usage.registered_users,
+            "total_sandboxes": snapshot.usage.total_sandboxes,
+            "total_storage_gib": snapshot.usage.total_storage_gib,
+            "waitlist_applications": snapshot.usage.waitlist_applications,
+        },
+        "refreshed_at": snapshot.refreshed_at,
     }
 
 
@@ -202,6 +227,55 @@ async def get_platform_stats(
     )
 
     return PlatformStatsResponse(users=users, sandboxes=sandboxes, compute=compute, storage=storage)
+
+
+# ── Platform Limits ───────────────────────────────────────────────────────────
+
+
+@router.get("/platform-limits", response_model=PlatformLimitsResponse)
+async def get_platform_limits(
+    request: Request,
+    _admin: User = Depends(get_current_admin_session),
+    session: AsyncSession = Depends(get_session),
+) -> PlatformLimitsResponse:
+    snapshot = await _platform_limits.build_snapshot(session)
+    await _record_sensitive_admin_read(
+        session,
+        request=request,
+        action="admin.platform_limits.read",
+        target_type="platform_limits",
+        target_id=PLATFORM_LIMITS_SINGLETON_ID,
+        metadata=_serialize_platform_limits(snapshot)["config"],
+    )
+    await session.commit()
+    return _serialize_platform_limits(snapshot)
+
+
+@router.patch("/platform-limits", response_model=PlatformLimitsResponse)
+async def update_platform_limits(
+    body: UpdatePlatformLimitsRequest,
+    request: Request,
+    admin: User = Depends(get_current_admin_session),
+    session: AsyncSession = Depends(get_session),
+) -> PlatformLimitsResponse:
+    config = await _platform_limits.get_or_create_config(session)
+    updates = body.model_dump(exclude_unset=True)
+    for field, value in updates.items():
+        setattr(config, field, value)
+    config.gmt_updated = utc_now()
+    session.add(config)
+    await record_audit_event(
+        session,
+        action="admin.platform_limits.updated",
+        target_type="platform_limits",
+        target_id=config.id,
+        actor_user_id=admin.id,
+        metadata={"updates": updates},
+        request=request,
+    )
+    await session.commit()
+    snapshot = await request.app.state.platform_limits_runtime.refresh_from_session(session)
+    return _serialize_platform_limits(snapshot)
 
 
 # ── Tier Templates ───────────────────────────────────────────────────────────

--- a/treadstone/api/auth.py
+++ b/treadstone/api/auth.py
@@ -45,6 +45,7 @@ from treadstone.core.errors import (
     EmailVerificationTokenInvalidError,
     ForbiddenError,
     NotFoundError,
+    TreadstoneError,
     ValidationError,
 )
 from treadstone.core.request_context import set_request_context
@@ -70,10 +71,12 @@ from treadstone.models.user import OAuthAccount, Role, User, random_id, utc_now
 from treadstone.services.audit import record_audit_event
 from treadstone.services.browser_login import validate_browser_return_to
 from treadstone.services.cli_login_flow import approve_cli_flow
+from treadstone.services.platform_limits import PlatformLimitsService
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/auth", tags=["auth"])
+_platform_limits = PlatformLimitsService()
 
 OAUTH_STATE_AUDIENCE = "treadstone:oauth-state"
 OAUTH_STATE_TTL_SECONDS = 600
@@ -149,6 +152,10 @@ def _oauth_error_message(provider: str, error: str, error_description: str | Non
     if error_description:
         return error_description
     return f"{provider.title()} login failed."
+
+
+def _get_platform_limits_runtime(request: Request):
+    return request.app.state.platform_limits_runtime
 
 
 async def _validate_cli_flow_pending(
@@ -493,6 +500,22 @@ async def register(
     if existing.unique().scalar_one_or_none():
         raise ConflictError("Email already registered")
 
+    snapshot = await _get_platform_limits_runtime(request).ensure_snapshot(session)
+    try:
+        _platform_limits.check_user_registration_allowed(snapshot)
+    except TreadstoneError as exc:
+        await record_audit_event(
+            session,
+            action="auth.register",
+            target_type="user",
+            result="failure",
+            error_code=getattr(exc, "code", None),
+            metadata={"email": body.email},
+            request=request,
+        )
+        await session.commit()
+        raise
+
     ph = PasswordHelper()
     hashed = ph.hash(body.password)
 
@@ -519,6 +542,7 @@ async def register(
     )
     await session.commit()
     await session.refresh(user)
+    await _get_platform_limits_runtime(request).apply_local_delta(users=1)
 
     verification_email_sent = False
     if not user.is_verified:
@@ -697,6 +721,23 @@ async def _oauth_callback(
         existing_user = await session.execute(select(User).where(User.email == account_email))
         outcome = "link" if existing_user.unique().scalar_one_or_none() is not None else "register"
 
+    if outcome == "register":
+        snapshot = await _get_platform_limits_runtime(request).ensure_snapshot(session)
+        try:
+            _platform_limits.check_user_registration_allowed(snapshot)
+        except TreadstoneError as exc:
+            await record_audit_event(
+                session,
+                action="auth.register",
+                target_type="user",
+                result="failure",
+                error_code=getattr(exc, "code", None),
+                metadata={"email": account_email, "provider": provider, "surface": surface},
+                request=request,
+            )
+            await session.commit()
+            raise
+
     try:
         user = await user_manager.oauth_callback(
             provider,
@@ -747,6 +788,8 @@ async def _oauth_callback(
             return response
 
     await session.commit()
+    if outcome == "register":
+        await _get_platform_limits_runtime(request).apply_local_delta(users=1)
 
     if cli_flow_id_from_state:
         response: Response = _cli_oauth_redirect(cli_flow_id_from_state, "approved")

--- a/treadstone/api/auth.py
+++ b/treadstone/api/auth.py
@@ -542,7 +542,6 @@ async def register(
     )
     await session.commit()
     await session.refresh(user)
-    await _get_platform_limits_runtime(request).apply_local_delta(users=1)
 
     verification_email_sent = False
     if not user.is_verified:
@@ -788,8 +787,6 @@ async def _oauth_callback(
             return response
 
     await session.commit()
-    if outcome == "register":
-        await _get_platform_limits_runtime(request).apply_local_delta(users=1)
 
     if cli_flow_id_from_state:
         response: Response = _cli_oauth_redirect(cli_flow_id_from_state, "approved")

--- a/treadstone/api/sandboxes.py
+++ b/treadstone/api/sandboxes.py
@@ -338,10 +338,6 @@ async def create_sandbox(
         request=request,
     )
     await session.commit()
-    await runtime.apply_local_delta(
-        sandboxes=1,
-        storage_gib=requested_storage_gib if sandbox.persist else 0,
-    )
     return _to_response(sandbox, public_control_plane_base_url(request), web_link)
 
 
@@ -418,7 +414,6 @@ async def delete_sandbox(
     user: User = Depends(get_current_control_plane_user),
     session: AsyncSession = Depends(get_session),
 ):
-    runtime = _get_platform_limits_runtime(request)
     service = SandboxService(session=session, metering=_metering)
     sandbox = await service.delete(sandbox_id=sandbox_id, owner_id=user.id)
     if sandbox.status == SandboxStatus.ERROR:
@@ -441,11 +436,6 @@ async def delete_sandbox(
         request=request,
     )
     await session.commit()
-    await runtime.ensure_snapshot(session)
-    await runtime.apply_local_delta(
-        sandboxes=-1,
-        storage_gib=-_platform_limits.parse_storage_size_gib(sandbox.storage_size) if sandbox.persist else 0,
-    )
 
 
 @router.post("/{sandbox_id}/snapshot", status_code=status.HTTP_202_ACCEPTED, response_model=SandboxDetailResponse)

--- a/treadstone/api/sandboxes.py
+++ b/treadstone/api/sandboxes.py
@@ -22,6 +22,7 @@ from treadstone.core.errors import (
     ConflictError,
     EmailVerificationRequiredError,
     SandboxNotFoundError,
+    TreadstoneError,
     ValidationError,
 )
 from treadstone.core.public_base_url import public_control_plane_base_url
@@ -32,11 +33,13 @@ from treadstone.models.user import User, utc_now
 from treadstone.services.audit import record_audit_event
 from treadstone.services.browser_auth import build_open_link_token, build_open_link_url
 from treadstone.services.metering_service import MeteringService
+from treadstone.services.platform_limits import PlatformLimitsService
 from treadstone.services.sandbox_service import SandboxService
 
 router = APIRouter(prefix="/v1/sandboxes", tags=["sandboxes"])
 
 _metering = MeteringService()
+_platform_limits = PlatformLimitsService()
 
 
 def _web_port_suffix(api_base: str) -> str:
@@ -126,6 +129,10 @@ def _get_web_url(sb, base_url: str) -> str:
     if web_url is None:
         raise ValidationError("sandbox_domain must be configured to use sandbox Web UI links.")
     return web_url
+
+
+def _get_platform_limits_runtime(request: Request):
+    return request.app.state.platform_limits_runtime
 
 
 async def _load_active_web_link(session: AsyncSession, sandbox_id: str) -> SandboxWebLink | None:
@@ -266,6 +273,34 @@ async def create_sandbox(
         await session.commit()
         raise EmailVerificationRequiredError()
 
+    runtime = _get_platform_limits_runtime(request)
+    snapshot = await runtime.ensure_snapshot(session)
+    try:
+        _platform_limits.check_sandbox_creation_allowed(snapshot)
+        if body.persist:
+            requested_storage_gib = _platform_limits.parse_storage_size_gib(
+                body.storage_size or settings.sandbox_default_storage_size
+            )
+            _platform_limits.check_storage_allocation_allowed(snapshot, requested_storage_gib)
+        else:
+            requested_storage_gib = 0
+    except TreadstoneError as exc:
+        await record_audit_event(
+            session,
+            action="sandbox.create",
+            target_type="sandbox",
+            result="failure",
+            error_code=getattr(exc, "code", None),
+            metadata={
+                "template": body.template,
+                "persist": body.persist,
+                "storage_size": (body.storage_size or settings.sandbox_default_storage_size) if body.persist else None,
+            },
+            request=request,
+        )
+        await session.commit()
+        raise
+
     service = SandboxService(session=session, metering=_metering)
     sandbox = await service.create(
         owner_id=user.id,
@@ -303,6 +338,10 @@ async def create_sandbox(
         request=request,
     )
     await session.commit()
+    await runtime.apply_local_delta(
+        sandboxes=1,
+        storage_gib=requested_storage_gib if sandbox.persist else 0,
+    )
     return _to_response(sandbox, public_control_plane_base_url(request), web_link)
 
 
@@ -379,6 +418,7 @@ async def delete_sandbox(
     user: User = Depends(get_current_control_plane_user),
     session: AsyncSession = Depends(get_session),
 ):
+    runtime = _get_platform_limits_runtime(request)
     service = SandboxService(session=session, metering=_metering)
     sandbox = await service.delete(sandbox_id=sandbox_id, owner_id=user.id)
     if sandbox.status == SandboxStatus.ERROR:
@@ -401,6 +441,11 @@ async def delete_sandbox(
         request=request,
     )
     await session.commit()
+    await runtime.ensure_snapshot(session)
+    await runtime.apply_local_delta(
+        sandboxes=-1,
+        storage_gib=-_platform_limits.parse_storage_size_gib(sandbox.storage_size) if sandbox.persist else 0,
+    )
 
 
 @router.post("/{sandbox_id}/snapshot", status_code=status.HTTP_202_ACCEPTED, response_model=SandboxDetailResponse)

--- a/treadstone/api/schemas.py
+++ b/treadstone/api/schemas.py
@@ -806,6 +806,51 @@ class PlatformStatsResponse(BaseModel):
     storage: StorageStats
 
 
+class PlatformLimitsConfig(BaseModel):
+    max_registered_users: int | None = Field(default=None, examples=[200])
+    max_total_sandboxes: int | None = Field(default=None, examples=[1000])
+    max_total_storage_gib: int | None = Field(default=None, examples=[1000])
+    max_waitlist_applications: int | None = Field(default=None, examples=[500])
+
+
+class PlatformLimitsUsage(BaseModel):
+    registered_users: int = Field(..., examples=[42])
+    total_sandboxes: int = Field(..., examples=[120])
+    total_storage_gib: int = Field(..., examples=[250])
+    waitlist_applications: int = Field(..., examples=[75])
+
+
+class PlatformLimitsResponse(BaseModel):
+    config: PlatformLimitsConfig
+    usage: PlatformLimitsUsage
+    refreshed_at: datetime = Field(..., examples=["2026-04-10T00:00:00Z"])
+
+
+class UpdatePlatformLimitsRequest(BaseModel):
+    max_registered_users: int | None = Field(default=None, examples=[200])
+    max_total_sandboxes: int | None = Field(default=None, examples=[1000])
+    max_total_storage_gib: int | None = Field(default=None, examples=[1000])
+    max_waitlist_applications: int | None = Field(default=None, examples=[500])
+
+    @field_validator(
+        "max_registered_users",
+        "max_total_sandboxes",
+        "max_total_storage_gib",
+        "max_waitlist_applications",
+    )
+    @classmethod
+    def validate_non_negative(cls, v: int | None) -> int | None:
+        if v is not None and v < 0:
+            raise ValueError("limit must be greater than or equal to 0")
+        return v
+
+    @model_validator(mode="after")
+    def validate_has_updates(self) -> UpdatePlatformLimitsRequest:
+        if not self.model_fields_set:
+            raise ValueError("At least one field to update must be provided.")
+        return self
+
+
 # ── Waitlist ──────────────────────────────────────────────────────────────────
 
 

--- a/treadstone/api/schemas.py
+++ b/treadstone/api/schemas.py
@@ -26,8 +26,8 @@ SANDBOX_NAME_RULE = (
 SANDBOX_NAME_DESCRIPTION = (
     f"Optional custom sandbox name. {SANDBOX_NAME_RULE} Sandbox names only need to be unique for the current user."
 )
-STORAGE_SIZE_PATTERN = re.compile(r"^\d+(?:Gi|Ti)$")
-STORAGE_SIZE_RULE = "storage_size must match format '<number>Gi' or '<number>Ti' (e.g. 5Gi, 10Gi, 20Gi, 1Ti)."
+STORAGE_SIZE_PATTERN = re.compile(r"^\d+Gi$")
+STORAGE_SIZE_RULE = "storage_size must match format '<integer>Gi' (e.g. 5Gi, 10Gi, 20Gi)."
 
 # ── Sandbox ──────────────────────────────────────────────────────────────────
 
@@ -50,7 +50,7 @@ class CreateSandboxRequest(BaseModel):
     storage_size: str | None = Field(
         default=None,
         examples=["5Gi"],
-        description="Persistent volume size (e.g. 5Gi, 10Gi, 20Gi). "
+        description="Persistent volume size as '<integer>Gi' only (e.g. 5Gi, 10Gi, 20Gi). "
         "Allowed values depend on the sandbox template's annotation.",
     )
 

--- a/treadstone/api/waitlist.py
+++ b/treadstone/api/waitlist.py
@@ -8,16 +8,20 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from treadstone.api.schemas import WaitlistApplicationRequest, WaitlistApplicationResponse
 from treadstone.core.database import get_session
+from treadstone.core.errors import TreadstoneError
 from treadstone.models.waitlist import ApplicationStatus, WaitlistApplication
+from treadstone.services.audit import record_audit_event
+from treadstone.services.platform_limits import PlatformLimitsService
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/waitlist", tags=["waitlist"])
+_platform_limits = PlatformLimitsService()
 
 
 def _serialize_application(app: WaitlistApplication) -> dict:
@@ -37,6 +41,7 @@ def _serialize_application(app: WaitlistApplication) -> dict:
 
 @router.post("", status_code=201, response_model=WaitlistApplicationResponse)
 async def submit_waitlist_application(
+    request: Request,
     body: WaitlistApplicationRequest,
     session: AsyncSession = Depends(get_session),
 ) -> WaitlistApplicationResponse:
@@ -45,6 +50,23 @@ async def submit_waitlist_application(
     No authentication required — users may apply before registering. Multiple
     applications from the same email (including same tier) are allowed.
     """
+    runtime = request.app.state.platform_limits_runtime
+    snapshot = await runtime.ensure_snapshot(session)
+    try:
+        _platform_limits.check_waitlist_submission_allowed(snapshot)
+    except TreadstoneError as exc:
+        await record_audit_event(
+            session,
+            action="waitlist.submit",
+            target_type="waitlist_application",
+            result="failure",
+            error_code=getattr(exc, "code", None),
+            metadata={"email": body.email.lower(), "target_tier": body.target_tier},
+            request=request,
+        )
+        await session.commit()
+        raise
+
     email_lower = body.email.lower()
 
     application = WaitlistApplication(
@@ -65,4 +87,5 @@ async def submit_waitlist_application(
         body.target_tier,
         application.id,
     )
+    await runtime.apply_local_delta(waitlist_applications=1)
     return _serialize_application(application)

--- a/treadstone/api/waitlist.py
+++ b/treadstone/api/waitlist.py
@@ -87,5 +87,4 @@ async def submit_waitlist_application(
         body.target_tier,
         application.id,
     )
-    await runtime.apply_local_delta(waitlist_applications=1)
     return _serialize_application(application)

--- a/treadstone/core/errors.py
+++ b/treadstone/core/errors.py
@@ -225,6 +225,55 @@ class FeedbackRateLimitError(TreadstoneError):
         )
 
 
+class UserRegistrationCapExceededError(TreadstoneError):
+    def __init__(self, current_registered_users: int, max_registered_users: int):
+        super().__init__(
+            code="user_registration_cap_exceeded",
+            message=(
+                "User registration is temporarily unavailable. "
+                f"Registered users: {current_registered_users} / {max_registered_users}."
+            ),
+            status=503,
+        )
+
+
+class SandboxCapExceededError(TreadstoneError):
+    def __init__(self, current_sandboxes: int, max_total_sandboxes: int):
+        super().__init__(
+            code="sandbox_cap_exceeded",
+            message=(
+                "Sandbox creation is temporarily unavailable. "
+                f"Total sandboxes: {current_sandboxes} / {max_total_sandboxes}."
+            ),
+            status=503,
+        )
+
+
+class GlobalStorageCapExceededError(TreadstoneError):
+    def __init__(self, current_storage_gib: int, requested_storage_gib: int, max_total_storage_gib: int):
+        super().__init__(
+            code="global_storage_cap_exceeded",
+            message=(
+                "Persistent sandbox creation is temporarily unavailable. "
+                f"Allocated storage: {current_storage_gib} GiB, requested: {requested_storage_gib} GiB, "
+                f"limit: {max_total_storage_gib} GiB."
+            ),
+            status=503,
+        )
+
+
+class WaitlistCapExceededError(TreadstoneError):
+    def __init__(self, current_waitlist_applications: int, max_waitlist_applications: int):
+        super().__init__(
+            code="waitlist_cap_exceeded",
+            message=(
+                "Waitlist submissions are temporarily unavailable. "
+                f"Applications: {current_waitlist_applications} / {max_waitlist_applications}."
+            ),
+            status=503,
+        )
+
+
 class TemplateNotAllowedError(TreadstoneError):
     def __init__(self, tier: str, template: str, allowed_templates: list[str]):
         allowed_str = ", ".join(allowed_templates) if allowed_templates else "none"

--- a/treadstone/main.py
+++ b/treadstone/main.py
@@ -30,6 +30,7 @@ from treadstone.core.errors import TreadstoneError
 from treadstone.middleware.request_logging import RequestLoggingMiddleware
 from treadstone.middleware.sandbox_subdomain import SandboxSubdomainMiddleware
 from treadstone.openapi_spec import build_full_openapi_spec, filter_public_openapi, merge_sandbox_paths
+from treadstone.services.platform_limits import PlatformLimitsRuntime
 from treadstone.services.sandbox_proxy import close_http_client
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,8 @@ async def lifespan(app: FastAPI):
     from treadstone.services.leader_election import K8sLeaseStore, LeaderElector
     from treadstone.services.sync_supervisor import LeaderControlledSyncSupervisor
 
+    await app.state.platform_limits_runtime.start(async_session)
+
     if settings.leader_election_enabled:
         holder_identity = settings.pod_name or os.getenv("HOSTNAME") or "treadstone-api"
         lease_namespace = settings.pod_namespace or settings.sandbox_namespace
@@ -121,6 +124,7 @@ async def lifespan(app: FastAPI):
             sync_task.cancel()
             with suppress(asyncio.CancelledError):
                 await sync_task
+            await app.state.platform_limits_runtime.stop()
             await close_http_client()
         return
 
@@ -144,6 +148,7 @@ async def lifespan(app: FastAPI):
             await lifecycle_task
         with suppress(asyncio.CancelledError):
             await snapshot_task
+        await app.state.platform_limits_runtime.stop()
         await close_http_client()
 
 
@@ -160,6 +165,7 @@ app = FastAPI(
     lifespan=lifespan,
     servers=[{"url": "https://api.treadstone-ai.dev", "description": "Production"}],
 )
+app.state.platform_limits_runtime = PlatformLimitsRuntime()
 
 
 @app.exception_handler(TreadstoneError)

--- a/treadstone/models/__init__.py
+++ b/treadstone/models/__init__.py
@@ -11,6 +11,7 @@ from treadstone.models.metering import (
     TierTemplate,
     UserPlan,
 )
+from treadstone.models.platform_limits import PlatformLimits
 from treadstone.models.sandbox import Sandbox, SandboxPendingOperation, SandboxStatus, StorageBackendMode
 from treadstone.models.sandbox_web_link import SandboxWebLink
 from treadstone.models.user import OAuthAccount, Role, User
@@ -29,6 +30,7 @@ __all__ = [
     "StorageQuotaGrant",
     "StorageState",
     "TierTemplate",
+    "PlatformLimits",
     "User",
     "UserPlan",
     "OAuthAccount",

--- a/treadstone/models/platform_limits.py
+++ b/treadstone/models/platform_limits.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from treadstone.core.database import Base
+from treadstone.models.user import utc_now
+
+PLATFORM_LIMITS_SINGLETON_ID = "platform_limits"
+
+
+class PlatformLimits(Base):
+    __tablename__ = "platform_limits"
+
+    id: Mapped[str] = mapped_column(String(24), primary_key=True, default=PLATFORM_LIMITS_SINGLETON_ID)
+    max_registered_users: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    max_total_sandboxes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    max_total_storage_gib: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    max_waitlist_applications: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    gmt_created: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)

--- a/treadstone/services/metering_helpers.py
+++ b/treadstone/services/metering_helpers.py
@@ -57,18 +57,15 @@ def calculate_cu_rate(template: str) -> Decimal:
 
 
 def parse_storage_size_gib(size_str: str) -> int:
-    """Convert K8s-style size strings ('5Gi', '10Gi', '1Ti') to integer GiB."""
+    """Convert Kubernetes-style Gi strings (e.g. ``5Gi``, ``10Gi``) to integer GiB."""
     if size_str.endswith("Gi"):
         try:
             return int(size_str[:-2])
         except ValueError:
             raise BadRequestError(f"Invalid storage size value: {size_str}")
-    if size_str.endswith("Ti"):
-        try:
-            return int(size_str[:-2]) * 1024
-        except ValueError:
-            raise BadRequestError(f"Invalid storage size value: {size_str}")
-    raise BadRequestError(f"Unsupported storage size format: {size_str}. Use 'Gi' or 'Ti' suffix.")
+    raise BadRequestError(
+        f"Unsupported storage size format: {size_str}. Use a '<integer>Gi' value (e.g. 5Gi, 10Gi, 20Gi)."
+    )
 
 
 def compute_period_bounds(now: datetime) -> tuple[datetime, datetime]:

--- a/treadstone/services/platform_limits.py
+++ b/treadstone/services/platform_limits.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, replace
+from datetime import datetime
+
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from treadstone.core.errors import (
+    GlobalStorageCapExceededError,
+    SandboxCapExceededError,
+    UserRegistrationCapExceededError,
+    WaitlistCapExceededError,
+)
+from treadstone.models.platform_limits import PLATFORM_LIMITS_SINGLETON_ID, PlatformLimits
+from treadstone.models.sandbox import Sandbox
+from treadstone.models.user import User, utc_now
+from treadstone.models.waitlist import WaitlistApplication
+
+PLATFORM_LIMITS_REFRESH_INTERVAL_SECONDS = 15
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PlatformLimitsConfigSnapshot:
+    max_registered_users: int | None = None
+    max_total_sandboxes: int | None = None
+    max_total_storage_gib: int | None = None
+    max_waitlist_applications: int | None = None
+
+
+@dataclass(frozen=True)
+class PlatformLimitsUsageSnapshot:
+    registered_users: int = 0
+    total_sandboxes: int = 0
+    total_storage_gib: int = 0
+    waitlist_applications: int = 0
+
+
+@dataclass(frozen=True)
+class PlatformLimitsSnapshot:
+    config: PlatformLimitsConfigSnapshot
+    usage: PlatformLimitsUsageSnapshot
+    refreshed_at: datetime
+
+
+class PlatformLimitsService:
+    @staticmethod
+    def _storage_size_gib_case():
+        return case(
+            (Sandbox.storage_size == "5Gi", 5),
+            (Sandbox.storage_size == "10Gi", 10),
+            (Sandbox.storage_size == "20Gi", 20),
+            else_=0,
+        )
+
+    @staticmethod
+    def parse_storage_size_gib(storage_size: str | None) -> int:
+        if storage_size is None:
+            return 0
+        if storage_size.endswith("Gi"):
+            return int(storage_size[:-2])
+        if storage_size.endswith("Ti"):
+            return int(storage_size[:-2]) * 1024
+        raise ValueError(f"Unsupported storage size format: {storage_size}")
+
+    async def get_config(self, session: AsyncSession) -> PlatformLimits | None:
+        return await session.get(PlatformLimits, PLATFORM_LIMITS_SINGLETON_ID)
+
+    async def get_or_create_config(self, session: AsyncSession) -> PlatformLimits:
+        config = await self.get_config(session)
+        if config is None:
+            config = PlatformLimits(id=PLATFORM_LIMITS_SINGLETON_ID)
+            session.add(config)
+            await session.flush()
+        return config
+
+    async def build_snapshot(self, session: AsyncSession) -> PlatformLimitsSnapshot:
+        config = await self.get_config(session)
+
+        registered_users = int((await session.execute(select(func.count()).select_from(User))).scalar_one())
+        total_sandboxes = int(
+            (
+                await session.execute(select(func.count()).select_from(Sandbox).where(Sandbox.gmt_deleted.is_(None)))
+            ).scalar_one()
+        )
+        total_storage_gib = int(
+            (
+                await session.execute(
+                    select(func.coalesce(func.sum(self._storage_size_gib_case()), 0)).where(
+                        Sandbox.gmt_deleted.is_(None),
+                        Sandbox.persist.is_(True),
+                    )
+                )
+            ).scalar_one()
+        )
+        waitlist_applications = int(
+            (await session.execute(select(func.count()).select_from(WaitlistApplication))).scalar_one()
+        )
+
+        return PlatformLimitsSnapshot(
+            config=PlatformLimitsConfigSnapshot(
+                max_registered_users=config.max_registered_users if config is not None else None,
+                max_total_sandboxes=config.max_total_sandboxes if config is not None else None,
+                max_total_storage_gib=config.max_total_storage_gib if config is not None else None,
+                max_waitlist_applications=config.max_waitlist_applications if config is not None else None,
+            ),
+            usage=PlatformLimitsUsageSnapshot(
+                registered_users=registered_users,
+                total_sandboxes=total_sandboxes,
+                total_storage_gib=total_storage_gib,
+                waitlist_applications=waitlist_applications,
+            ),
+            refreshed_at=utc_now(),
+        )
+
+    def check_user_registration_allowed(self, snapshot: PlatformLimitsSnapshot) -> None:
+        maximum = snapshot.config.max_registered_users
+        if maximum is not None and snapshot.usage.registered_users >= maximum:
+            raise UserRegistrationCapExceededError(snapshot.usage.registered_users, maximum)
+
+    def check_sandbox_creation_allowed(self, snapshot: PlatformLimitsSnapshot) -> None:
+        maximum = snapshot.config.max_total_sandboxes
+        if maximum is not None and snapshot.usage.total_sandboxes >= maximum:
+            raise SandboxCapExceededError(snapshot.usage.total_sandboxes, maximum)
+
+    def check_storage_allocation_allowed(self, snapshot: PlatformLimitsSnapshot, requested_gib: int) -> None:
+        maximum = snapshot.config.max_total_storage_gib
+        if maximum is not None and (snapshot.usage.total_storage_gib + requested_gib) > maximum:
+            raise GlobalStorageCapExceededError(snapshot.usage.total_storage_gib, requested_gib, maximum)
+
+    def check_waitlist_submission_allowed(self, snapshot: PlatformLimitsSnapshot) -> None:
+        maximum = snapshot.config.max_waitlist_applications
+        if maximum is not None and snapshot.usage.waitlist_applications >= maximum:
+            raise WaitlistCapExceededError(snapshot.usage.waitlist_applications, maximum)
+
+
+class PlatformLimitsRuntime:
+    def __init__(
+        self,
+        *,
+        service: PlatformLimitsService | None = None,
+        refresh_interval_seconds: int = PLATFORM_LIMITS_REFRESH_INTERVAL_SECONDS,
+    ) -> None:
+        self._service = service or PlatformLimitsService()
+        self._refresh_interval_seconds = refresh_interval_seconds
+        self._snapshot: PlatformLimitsSnapshot | None = None
+        self._task: asyncio.Task | None = None
+        self._lock = asyncio.Lock()
+        self._session_factory: async_sessionmaker[AsyncSession] | None = None
+        self._bind_token: int | None = None
+
+    @property
+    def snapshot(self) -> PlatformLimitsSnapshot | None:
+        return self._snapshot
+
+    async def start(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+        await self.force_refresh()
+        if self._task is None:
+            self._task = asyncio.create_task(self._run_refresh_loop())
+
+    async def stop(self) -> None:
+        task = self._task
+        self._task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._session_factory = None
+        self._snapshot = None
+        self._bind_token = None
+
+    async def _run_refresh_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._refresh_interval_seconds)
+            try:
+                await self.force_refresh()
+            except Exception:
+                logger.exception("Platform limits refresh failed")
+
+    @staticmethod
+    def _session_bind_token(session: AsyncSession) -> int | None:
+        bind = session.sync_session.bind
+        return id(bind) if bind is not None else None
+
+    async def ensure_snapshot(self, session: AsyncSession) -> PlatformLimitsSnapshot:
+        token = self._session_bind_token(session)
+        if self._snapshot is not None and self._bind_token == token:
+            return self._snapshot
+        return await self.refresh_from_session(session)
+
+    async def refresh_from_session(self, session: AsyncSession) -> PlatformLimitsSnapshot:
+        async with self._lock:
+            token = self._session_bind_token(session)
+            snapshot = await self._service.build_snapshot(session)
+            self._snapshot = snapshot
+            self._bind_token = token
+            return snapshot
+
+    async def force_refresh(self) -> PlatformLimitsSnapshot | None:
+        if self._session_factory is None:
+            return self._snapshot
+
+        async with self._lock:
+            async with self._session_factory() as session:
+                snapshot = await self._service.build_snapshot(session)
+                self._snapshot = snapshot
+                self._bind_token = self._session_bind_token(session)
+                return snapshot
+
+    async def apply_local_delta(
+        self,
+        *,
+        users: int = 0,
+        sandboxes: int = 0,
+        storage_gib: int = 0,
+        waitlist_applications: int = 0,
+    ) -> PlatformLimitsSnapshot | None:
+        async with self._lock:
+            if self._snapshot is None:
+                return None
+            usage = self._snapshot.usage
+            updated_usage = replace(
+                usage,
+                registered_users=max(0, usage.registered_users + users),
+                total_sandboxes=max(0, usage.total_sandboxes + sandboxes),
+                total_storage_gib=max(0, usage.total_storage_gib + storage_gib),
+                waitlist_applications=max(0, usage.waitlist_applications + waitlist_applications),
+            )
+            self._snapshot = replace(self._snapshot, usage=updated_usage, refreshed_at=utc_now())
+            return self._snapshot

--- a/treadstone/services/platform_limits.py
+++ b/treadstone/services/platform_limits.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import datetime
 
 from sqlalchemy import case, func, select
@@ -18,6 +18,7 @@ from treadstone.models.platform_limits import PLATFORM_LIMITS_SINGLETON_ID, Plat
 from treadstone.models.sandbox import Sandbox
 from treadstone.models.user import User, utc_now
 from treadstone.models.waitlist import WaitlistApplication
+from treadstone.services.metering_helpers import parse_storage_size_gib as _parse_storage_size_gib_str
 
 PLATFORM_LIMITS_REFRESH_INTERVAL_SECONDS = 15
 
@@ -61,11 +62,7 @@ class PlatformLimitsService:
     def parse_storage_size_gib(storage_size: str | None) -> int:
         if storage_size is None:
             return 0
-        if storage_size.endswith("Gi"):
-            return int(storage_size[:-2])
-        if storage_size.endswith("Ti"):
-            return int(storage_size[:-2]) * 1024
-        raise ValueError(f"Unsupported storage size format: {storage_size}")
+        return _parse_storage_size_gib_str(storage_size)
 
     async def get_config(self, session: AsyncSession) -> PlatformLimits | None:
         return await session.get(PlatformLimits, PLATFORM_LIMITS_SINGLETON_ID)
@@ -153,10 +150,6 @@ class PlatformLimitsRuntime:
         self._session_factory: async_sessionmaker[AsyncSession] | None = None
         self._bind_token: int | None = None
 
-    @property
-    def snapshot(self) -> PlatformLimitsSnapshot | None:
-        return self._snapshot
-
     async def start(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._session_factory = session_factory
         await self.force_refresh()
@@ -196,6 +189,11 @@ class PlatformLimitsRuntime:
         return await self.refresh_from_session(session)
 
     async def refresh_from_session(self, session: AsyncSession) -> PlatformLimitsSnapshot:
+        """Rebuild the in-process snapshot from the database (same aggregates as ``force_refresh``).
+
+        Used by admin usage responses, tests, and any caller that needs an up-to-date snapshot
+        without waiting for the periodic refresh loop. Uses the same lock as ``force_refresh``.
+        """
         async with self._lock:
             token = self._session_bind_token(session)
             snapshot = await self._service.build_snapshot(session)
@@ -213,25 +211,3 @@ class PlatformLimitsRuntime:
                 self._snapshot = snapshot
                 self._bind_token = self._session_bind_token(session)
                 return snapshot
-
-    async def apply_local_delta(
-        self,
-        *,
-        users: int = 0,
-        sandboxes: int = 0,
-        storage_gib: int = 0,
-        waitlist_applications: int = 0,
-    ) -> PlatformLimitsSnapshot | None:
-        async with self._lock:
-            if self._snapshot is None:
-                return None
-            usage = self._snapshot.usage
-            updated_usage = replace(
-                usage,
-                registered_users=max(0, usage.registered_users + users),
-                total_sandboxes=max(0, usage.total_sandboxes + sandboxes),
-                total_storage_gib=max(0, usage.total_storage_gib + storage_gib),
-                waitlist_applications=max(0, usage.waitlist_applications + waitlist_applications),
-            )
-            self._snapshot = replace(self._snapshot, usage=updated_usage, refreshed_at=utc_now())
-            return self._snapshot

--- a/web/src/api/admin.ts
+++ b/web/src/api/admin.ts
@@ -10,6 +10,36 @@ export type TierTemplate = components["schemas"]["TierTemplateItem"]
 export type UsageSummary = components["schemas"]["UsageSummaryResponse"]
 export type UserItem = components["schemas"]["UserResponse"]
 export type PlatformStats = components["schemas"]["PlatformStatsResponse"]
+export type PlatformLimitsResponse = components["schemas"]["PlatformLimitsResponse"]
+
+/** String fields for limit inputs; empty string means unlimited (null in API). */
+export type PlatformLimitsFormState = {
+  max_registered_users: string
+  max_total_sandboxes: string
+  max_total_storage_gib: string
+  max_waitlist_applications: string
+}
+
+export function usePlatformLimitsConfig() {
+  return useQuery({
+    queryKey: ["admin", "platform-limits"],
+    queryFn: async () => {
+      const { data } = await client.GET("/v1/admin/platform-limits")
+      return data!
+    },
+  })
+}
+
+export function useUpdatePlatformLimits() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (body: components["schemas"]["UpdatePlatformLimitsRequest"]) => {
+      const { data } = await client.PATCH("/v1/admin/platform-limits", { body })
+      return data!
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["admin", "platform-limits"] }),
+  })
+}
 
 export function usePlatformStats() {
   return useQuery({

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -67,6 +67,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/platform-limits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Platform Limits */
+        get: operations["admin-get_platform_limits"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Platform Limits */
+        patch: operations["admin-update_platform_limits"];
+        trace?: never;
+    };
     "/v1/admin/tier-templates": {
         parameters: {
             query?: never;
@@ -1732,7 +1750,7 @@ export interface components {
             persist: boolean;
             /**
              * Storage Size
-             * @description Persistent volume size (e.g. 5Gi, 10Gi, 20Gi). Allowed values depend on the sandbox template's annotation.
+             * @description Persistent volume size as '<integer>Gi' only (e.g. 5Gi, 10Gi, 20Gi). Allowed values depend on the sandbox template's annotation.
              * @example 5Gi
              */
             storage_size?: string | null;
@@ -1944,6 +1962,63 @@ export interface components {
              * @example user@example.com
              */
             email: string;
+        };
+        /** PlatformLimitsConfig */
+        PlatformLimitsConfig: {
+            /**
+             * Max Registered Users
+             * @example 200
+             */
+            max_registered_users?: number | null;
+            /**
+             * Max Total Sandboxes
+             * @example 1000
+             */
+            max_total_sandboxes?: number | null;
+            /**
+             * Max Total Storage Gib
+             * @example 1000
+             */
+            max_total_storage_gib?: number | null;
+            /**
+             * Max Waitlist Applications
+             * @example 500
+             */
+            max_waitlist_applications?: number | null;
+        };
+        /** PlatformLimitsResponse */
+        PlatformLimitsResponse: {
+            config: components["schemas"]["PlatformLimitsConfig"];
+            usage: components["schemas"]["PlatformLimitsUsage"];
+            /**
+             * Refreshed At
+             * Format: date-time
+             * @example 2026-04-10T00:00:00Z
+             */
+            refreshed_at: string;
+        };
+        /** PlatformLimitsUsage */
+        PlatformLimitsUsage: {
+            /**
+             * Registered Users
+             * @example 42
+             */
+            registered_users: number;
+            /**
+             * Total Sandboxes
+             * @example 120
+             */
+            total_sandboxes: number;
+            /**
+             * Total Storage Gib
+             * @example 250
+             */
+            total_storage_gib: number;
+            /**
+             * Waitlist Applications
+             * @example 75
+             */
+            waitlist_applications: number;
         };
         /** PlatformStatsResponse */
         PlatformStatsResponse: {
@@ -2607,6 +2682,29 @@ export interface components {
                 [key: string]: unknown;
             } | null;
         };
+        /** UpdatePlatformLimitsRequest */
+        UpdatePlatformLimitsRequest: {
+            /**
+             * Max Registered Users
+             * @example 200
+             */
+            max_registered_users?: number | null;
+            /**
+             * Max Total Sandboxes
+             * @example 1000
+             */
+            max_total_sandboxes?: number | null;
+            /**
+             * Max Total Storage Gib
+             * @example 1000
+             */
+            max_total_storage_gib?: number | null;
+            /**
+             * Max Waitlist Applications
+             * @example 500
+             */
+            max_waitlist_applications?: number | null;
+        };
         /**
          * UpdateSandboxRequest
          * @description Partial update for sandbox metadata (control plane). Immutable fields: template, persist, storage.
@@ -3167,6 +3265,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PlatformStatsResponse"];
+                };
+            };
+        };
+    };
+    "admin-get_platform_limits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformLimitsResponse"];
+                };
+            };
+        };
+    };
+    "admin-update_platform_limits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePlatformLimitsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformLimitsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -26,6 +26,7 @@ import { AdminMeteringPage } from "@/pages/internal/admin-metering"
 import { AdminOverviewPage } from "@/pages/internal/admin-overview"
 import { AdminUsersPage } from "@/pages/internal/admin-users"
 import { AdminFeedbackPage } from "@/pages/internal/admin-feedback"
+import { AdminPlatformLimitsPage } from "@/pages/internal/admin-platform-limits"
 import { AuditEventsPage } from "@/pages/internal/audit-events"
 
 function NotFoundPage() {
@@ -88,6 +89,7 @@ const router = createBrowserRouter([
     children: [
       { path: "admin/overview", element: <AdminOverviewPage /> },
       { path: "admin/users", element: <AdminUsersPage /> },
+      { path: "admin/platform-limits", element: <AdminPlatformLimitsPage /> },
       { path: "admin/metering", element: <AdminMeteringPage /> },
       { path: "admin/feedback", element: <AdminFeedbackPage /> },
       { path: "audit", element: <AuditEventsPage /> },

--- a/web/src/components/layout/admin-layout.tsx
+++ b/web/src/components/layout/admin-layout.tsx
@@ -5,6 +5,9 @@ import { useCurrentUser, useLogout } from "@/hooks/use-auth"
 import { APP_VERSION } from "@/lib/app-version"
 
 const ADMIN_ROUTE_LABELS: Record<string, string> = {
+  "/internal/admin/overview": "OVERVIEW",
+  "/internal/admin/users": "USER MANAGEMENT",
+  "/internal/admin/platform-limits": "PLATFORM LIMITS",
   "/internal/admin/metering": "METERING",
   "/internal/admin/feedback": "FEEDBACK",
   "/internal/audit": "AUDIT EVENTS",

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   Users,
   LayoutDashboard,
   MessageSquareText,
+  SlidersHorizontal,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useCurrentUser } from "@/hooks/use-auth"
@@ -25,6 +26,7 @@ const navItems = [
 const adminNavItems = [
   { to: "/internal/admin/overview", icon: LayoutDashboard, label: "Overview" },
   { to: "/internal/admin/users", icon: Users, label: "User Management" },
+  { to: "/internal/admin/platform-limits", icon: SlidersHorizontal, label: "Platform Limits" },
   { to: "/internal/admin/metering", icon: Activity, label: "Admin Metering" },
   { to: "/internal/admin/feedback", icon: MessageSquareText, label: "Feedback" },
   { to: "/internal/audit", icon: FileText, label: "Audit Events" },

--- a/web/src/pages/internal/admin-platform-limits.tsx
+++ b/web/src/pages/internal/admin-platform-limits.tsx
@@ -1,0 +1,241 @@
+import { useMemo, useState } from "react"
+import { toast } from "sonner"
+import { RefreshCw, SlidersHorizontal } from "lucide-react"
+import { cn } from "@/lib/utils"
+import {
+  usePlatformLimitsConfig,
+  useUpdatePlatformLimits,
+  type PlatformLimitsFormState,
+  type PlatformLimitsResponse,
+} from "@/api/admin"
+import type { components } from "@/api/schema"
+
+type Config = components["schemas"]["PlatformLimitsConfig"]
+
+function configToForm(c: Config): PlatformLimitsFormState {
+  const s = (n: number | null | undefined) => (n != null ? String(n) : "")
+  return {
+    max_registered_users: s(c.max_registered_users),
+    max_total_sandboxes: s(c.max_total_sandboxes),
+    max_total_storage_gib: s(c.max_total_storage_gib),
+    max_waitlist_applications: s(c.max_waitlist_applications),
+  }
+}
+
+function parseLimitField(raw: string): number | null {
+  const t = raw.trim()
+  if (t === "") return null
+  const n = Number.parseInt(t, 10)
+  if (Number.isNaN(n) || n < 0) return null
+  return n
+}
+
+function buildPatch(
+  initial: PlatformLimitsFormState,
+  draft: PlatformLimitsFormState,
+): components["schemas"]["UpdatePlatformLimitsRequest"] | null {
+  const out: components["schemas"]["UpdatePlatformLimitsRequest"] = {}
+  const keys = [
+    "max_registered_users",
+    "max_total_sandboxes",
+    "max_total_storage_gib",
+    "max_waitlist_applications",
+  ] as const
+  for (const k of keys) {
+    const a = parseLimitField(String(initial[k]))
+    const b = parseLimitField(String(draft[k]))
+    if (a !== b) {
+      out[k] = b
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null
+}
+
+export function AdminPlatformLimitsPage() {
+  const { data, isLoading, isError, refetch, isFetching, dataUpdatedAt } = usePlatformLimitsConfig()
+
+  const lastUpdated = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })
+    : null
+
+  return (
+    <div className="flex flex-col gap-8 p-8">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <SlidersHorizontal className="size-5 text-muted-foreground" />
+            <h1 className="text-lg font-semibold text-foreground">Platform limits</h1>
+          </div>
+          <p className="max-w-2xl text-xs text-muted-foreground">
+            Best-effort global caps (registered users, sandboxes, persistent storage GiB, waitlist
+            submissions). Leave a field empty for no limit. Changes apply on save; enforcement uses
+            periodic refresh across API pods.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {lastUpdated && (
+            <span className="text-[10px] text-muted-foreground">Loaded {lastUpdated}</span>
+          )}
+          <button
+            type="button"
+            onClick={() => refetch()}
+            disabled={isFetching}
+            className="flex items-center gap-1.5 rounded border border-border/30 bg-card px-3 py-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-card/80 disabled:opacity-50"
+          >
+            <RefreshCw className={cn("size-3", isFetching && "animate-spin")} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {isError && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-xs text-destructive">
+          Failed to load platform limits. Ensure you are signed in as an admin.
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      ) : data ? (
+        <>
+          <UsagePanel data={data} />
+          <PlatformLimitsEditor key={data.refreshed_at} data={data} />
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+function UsagePanel({ data }: { data: PlatformLimitsResponse }) {
+  return (
+    <div className="rounded-lg border border-border/20 bg-card/50 p-5">
+      <h2 className="mb-4 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+        Current usage (live)
+      </h2>
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <UsagePill label="Registered users" value={data.usage.registered_users} />
+        <UsagePill label="Sandboxes" value={data.usage.total_sandboxes} />
+        <UsagePill label="Storage (GiB)" value={data.usage.total_storage_gib} />
+        <UsagePill label="Waitlist apps" value={data.usage.waitlist_applications} />
+      </div>
+      <p className="mt-3 text-[10px] text-muted-foreground">
+        Refreshed at {new Date(data.refreshed_at).toLocaleString()}
+      </p>
+    </div>
+  )
+}
+
+function PlatformLimitsEditor({ data }: { data: PlatformLimitsResponse }) {
+  const updateLimits = useUpdatePlatformLimits()
+  const [form, setForm] = useState(() => configToForm(data.config))
+  const [initialForm] = useState(() => configToForm(data.config))
+
+  const dirty = useMemo(() => buildPatch(initialForm, form) !== null, [initialForm, form])
+
+  const handleSave = () => {
+    const patch = buildPatch(initialForm, form)
+    if (!patch) {
+      toast.message("No changes to save.")
+      return
+    }
+    updateLimits.mutate(patch, {
+      onSuccess: () => {
+        toast.success("Platform limits updated.")
+      },
+      onError: (e: Error) => toast.error(e.message),
+    })
+  }
+
+  const handleReset = () => {
+    setForm({ ...initialForm })
+  }
+
+  return (
+    <div className="rounded-lg border border-border/20 bg-card p-5">
+      <h2 className="mb-4 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+        Limits
+      </h2>
+      <div className="grid max-w-2xl grid-cols-1 gap-4 md:grid-cols-2">
+        <LimitField
+          label="Max registered users"
+          hint="Empty = unlimited"
+          value={form.max_registered_users}
+          onChange={(v) => setForm((f) => ({ ...f, max_registered_users: v }))}
+        />
+        <LimitField
+          label="Max total sandboxes"
+          hint="Non-deleted sandboxes"
+          value={form.max_total_sandboxes}
+          onChange={(v) => setForm((f) => ({ ...f, max_total_sandboxes: v }))}
+        />
+        <LimitField
+          label="Max total storage (GiB)"
+          hint="Persistent volumes only"
+          value={form.max_total_storage_gib}
+          onChange={(v) => setForm((f) => ({ ...f, max_total_storage_gib: v }))}
+        />
+        <LimitField
+          label="Max waitlist applications"
+          hint="Empty = unlimited"
+          value={form.max_waitlist_applications}
+          onChange={(v) => setForm((f) => ({ ...f, max_waitlist_applications: v }))}
+        />
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!dirty || updateLimits.isPending}
+          className="rounded bg-primary px-4 py-2 text-xs font-semibold uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {updateLimits.isPending ? "Saving…" : "Save changes"}
+        </button>
+        <button
+          type="button"
+          onClick={handleReset}
+          disabled={!dirty || updateLimits.isPending}
+          className="rounded border border-border/40 px-4 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/30 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function UsagePill({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded border border-border/30 bg-background px-3 py-2">
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold tabular-nums text-foreground">{value}</div>
+    </div>
+  )
+}
+
+function LimitField({
+  label,
+  hint,
+  value,
+  onChange,
+}: {
+  label: string
+  hint: string
+  value: string
+  onChange: (v: string) => void
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-[11px] font-medium text-foreground">{label}</span>
+      <input
+        type="text"
+        inputMode="numeric"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Unlimited"
+        className="h-[38px] rounded-sm border border-border/40 bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+      <span className="text-[10px] text-muted-foreground">{hint}</span>
+    </label>
+  )
+}


### PR DESCRIPTION
## Summary

Adds configurable platform-wide caps enforced at registration, sandbox creation, OAuth flows, and waitlist submission. Introduces a `platform_limits` singleton table (Alembic migration), `PlatformLimitsService` with periodic usage snapshots, admin API to read/update limits, and new `TreadstoneError` subclasses for limit exceeded cases.

## Test Plan

- [ ] CI lint and tests pass on the PR
- (Optional) Apply migration and verify admin limit updates and enforcement paths in a dev environment

Made with [Cursor](https://cursor.com)