### PR TITLE
fix: remove X-Sandbox-* routing from data plane proxy

### DIFF
--- a/tests/api/test_sandbox_proxy_api.py
+++ b/tests/api/test_sandbox_proxy_api.py
@@ -172,6 +172,58 @@ async def test_proxy_success_for_ready_sandbox(auth_client):
     assert resp.json() == {"ok": True}
 
 
+async def test_proxy_ignores_x_sandbox_override_headers(auth_client):
+    """Client-supplied X-Sandbox-* must not change upstream host/port or k8s id."""
+    create_resp = await auth_client.post(
+        "/v1/sandboxes",
+        json={"template": "aio-sandbox-tiny", "name": "proxy-ignore-headers-sb"},
+    )
+    sandbox_id = create_resp.json()["id"]
+
+    async with _test_session_factory() as session:
+        from treadstone.models.sandbox import Sandbox
+
+        sb = await session.get(Sandbox, sandbox_id)
+        sb.status = "ready"
+        session.add(sb)
+        await session.commit()
+        expected_ns = sb.k8s_namespace
+        k8s_id = sb.k8s_sandbox_name or sb.k8s_sandbox_claim_name or sb.id
+
+    captured_urls: list[str] = []
+
+    def build_request_capture(method, url, headers, content):
+        captured_urls.append(str(url))
+        return httpx.Request(method, url)
+
+    mock_client = _mock_upstream(
+        body=b"ok",
+        headers={"content-type": "text/plain"},
+    )
+    mock_client.build_request.side_effect = build_request_capture
+
+    key_resp = await auth_client.post("/v1/auth/api-keys", json={"name": "proxy-ignore-h"})
+    api_key = key_resp.json()["key"]
+
+    with patch("treadstone.services.sandbox_proxy._http_client", mock_client):
+        resp = await auth_client.get(
+            f"/v1/sandboxes/{sandbox_id}/proxy/healthz",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "X-Sandbox-Port": "9999",
+                "X-Sandbox-Namespace": "attacker-ns",
+                "X-Sandbox-ID": "evil-id",
+            },
+        )
+    assert resp.status_code == 200
+    assert len(captured_urls) == 1
+    url = captured_urls[0]
+    assert f"{k8s_id}.{expected_ns}.svc.cluster.local" in url
+    assert "attacker-ns" not in url
+    assert ":9999" not in url
+    assert ":8080" in url
+
+
 async def test_proxy_cookie_auth_returns_401_auth_invalid(auth_client):
     create_resp = await auth_client.post(
         "/v1/sandboxes",

--- a/tests/unit/test_sandbox_proxy.py
+++ b/tests/unit/test_sandbox_proxy.py
@@ -1,12 +1,10 @@
 """Unit tests for treadstone.services.sandbox_proxy helpers."""
 
-import pytest
-
 from treadstone.services.sandbox_proxy import (
     _filter_request_headers,
     _filter_response_headers,
+    _is_x_sandbox_vendor_header,
     build_sandbox_url,
-    resolve_routing,
 )
 
 
@@ -35,79 +33,6 @@ class TestBuildSandboxUrl:
         assert url == "http://sb-1.ns.svc.cluster.local:8080/some/path"
 
 
-class TestResolveRouting:
-    def test_from_headers(self):
-        result = resolve_routing(
-            {
-                "x-sandbox-id": "sb-abc",
-                "x-sandbox-namespace": "dev",
-                "x-sandbox-port": "9090",
-            }
-        )
-        assert result == {"sandbox_id": "sb-abc", "namespace": "dev", "port": 9090}
-
-    def test_path_sandbox_id_takes_priority(self):
-        result = resolve_routing(
-            {"x-sandbox-id": "from-header"},
-            path_sandbox_id="from-path",
-        )
-        assert result["sandbox_id"] == "from-path"
-
-    def test_path_sandbox_id_with_namespace_from_header(self):
-        result = resolve_routing(
-            {"x-sandbox-namespace": "staging", "x-sandbox-port": "9090"},
-            path_sandbox_id="sb-1",
-        )
-        assert result == {"sandbox_id": "sb-1", "namespace": "staging", "port": 9090}
-
-    def test_missing_sandbox_id_raises(self):
-        with pytest.raises(ValueError, match="X-Sandbox-ID header is required"):
-            resolve_routing({})
-
-    def test_invalid_sandbox_id_raises(self):
-        with pytest.raises(ValueError, match="Invalid sandbox ID format"):
-            resolve_routing({}, path_sandbox_id="bad id!")
-
-    def test_invalid_namespace_raises(self):
-        with pytest.raises(ValueError, match="Invalid namespace format"):
-            resolve_routing(
-                {
-                    "x-sandbox-id": "sb-1",
-                    "x-sandbox-namespace": "bad namespace!",
-                }
-            )
-
-    def test_hyphenated_namespace_ok(self):
-        result = resolve_routing(
-            {
-                "x-sandbox-id": "sb-1",
-                "x-sandbox-namespace": "my-namespace",
-            }
-        )
-        assert result["namespace"] == "my-namespace"
-
-    def test_invalid_port_raises(self):
-        with pytest.raises(ValueError, match="Invalid port format"):
-            resolve_routing(
-                {
-                    "x-sandbox-id": "sb-1",
-                    "x-sandbox-port": "not-a-number",
-                }
-            )
-
-    def test_defaults_come_from_settings(self, monkeypatch):
-        monkeypatch.setenv("TREADSTONE_SANDBOX_NAMESPACE", "staging")
-        monkeypatch.setenv("TREADSTONE_SANDBOX_PORT", "9999")
-        from treadstone.config import Settings
-
-        s = Settings()
-        monkeypatch.setattr("treadstone.services.sandbox_proxy.settings", s)
-
-        result = resolve_routing({"x-sandbox-id": "sb-1"})
-        assert result["namespace"] == "staging"
-        assert result["port"] == 9999
-
-
 class TestFilterRequestHeaders:
     def test_removes_hop_by_hop(self):
         h = {"host": "example.com", "connection": "keep-alive", "x-custom": "yes"}
@@ -119,6 +44,19 @@ class TestFilterRequestHeaders:
     def test_forces_identity_encoding(self):
         filtered = _filter_request_headers({"accept-encoding": "gzip, br"})
         assert filtered["accept-encoding"] == "identity"
+
+    def test_strips_all_x_sandbox_prefixed_headers_case_insensitive(self):
+        h = {
+            "X-Sandbox-Port": "9999",
+            "x-sandbox-namespace": "other-ns",
+            "X-Sandbox-ID": "evil",
+            "X-Sandbox-Custom": "noise",
+            "x-forwarded-for": "1.2.3.4",
+        }
+        filtered = _filter_request_headers(h)
+        for k in filtered:
+            assert not _is_x_sandbox_vendor_header(k)
+        assert filtered.get("x-forwarded-for") == "1.2.3.4"
 
 
 class TestFilterResponseHeaders:

--- a/treadstone/api/sandbox_proxy.py
+++ b/treadstone/api/sandbox_proxy.py
@@ -11,22 +11,18 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from treadstone.api.deps import _authenticate_api_key_value, get_current_data_plane_user
+from treadstone.config import settings
 from treadstone.core.database import async_session, get_session
 from treadstone.core.errors import (
     SandboxNotFoundError,
     SandboxNotReadyError,
     SandboxUnreachableError,
-    ValidationError,
 )
 from treadstone.core.request_context import set_scope_context
 from treadstone.models.api_key import ApiKeyDataPlaneMode, ApiKeySandboxGrant
 from treadstone.models.sandbox import Sandbox, SandboxStatus
 from treadstone.models.user import User, utc_now
-from treadstone.services.sandbox_proxy import (
-    proxy_http_request,
-    proxy_websocket,
-    resolve_routing,
-)
+from treadstone.services.sandbox_proxy import proxy_http_request, proxy_websocket
 
 logger = logging.getLogger(__name__)
 
@@ -56,13 +52,7 @@ async def http_proxy(
         raise SandboxNotReadyError(sandbox_id, sandbox.status)
 
     headers = dict(request.headers)
-    try:
-        routing = resolve_routing(
-            headers,
-            path_sandbox_id=sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.id,
-        )
-    except ValueError as exc:
-        raise ValidationError(str(exc)) from exc
+    k8s_id = sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.id
 
     body = await request.body()
 
@@ -73,12 +63,12 @@ async def http_proxy(
     try:
         status_code, resp_headers, resp = await proxy_http_request(
             method=request.method,
-            sandbox_id=routing["sandbox_id"],
+            sandbox_id=k8s_id,
             path=full_path,
             headers=headers,
             body=body,
-            namespace=routing["namespace"],
-            port=routing["port"],
+            namespace=sandbox.k8s_namespace,
+            port=settings.sandbox_port,
         )
     except Exception:
         logger.exception("Proxy failed for sandbox %s", sandbox_id)
@@ -108,8 +98,7 @@ async def ws_proxy(
     - ``Authorization: Bearer sk-…`` header (preferred)
     - ``?token=sk-…`` query param (for clients that cannot set WS headers)
 
-    X-Sandbox-Namespace and X-Sandbox-Port headers are honoured for routing,
-    matching the behaviour of the HTTP proxy.
+    Upstream namespace and port match the HTTP proxy (sandbox row + settings).
     """
     auth_header = websocket.headers.get("authorization", "")
     token_param = websocket.query_params.get("token", "")
@@ -184,15 +173,7 @@ async def ws_proxy(
     else:
         full_path = f"{path}?{query_string}" if query_string else path
 
-    # Resolve namespace / port overrides from WS headers (same as HTTP proxy).
-    ws_headers = dict(websocket.headers)
     k8s_id = sandbox.k8s_sandbox_name or sandbox.k8s_sandbox_claim_name or sandbox.id
-    try:
-        routing = resolve_routing(ws_headers, path_sandbox_id=k8s_id)
-    except ValueError as exc:
-        logger.warning("WebSocket routing error for sandbox %s: %s", sandbox_id, exc)
-        await websocket.close(code=1008, reason=str(exc))
-        return
 
     async def _touch_activity() -> None:
         async with async_session() as touch_session:
@@ -206,10 +187,10 @@ async def ws_proxy(
     try:
         await proxy_websocket(
             client_ws=websocket,
-            sandbox_id=routing["sandbox_id"],
+            sandbox_id=k8s_id,
             path=full_path,
-            namespace=routing["namespace"],
-            port=routing["port"],
+            namespace=sandbox.k8s_namespace,
+            port=settings.sandbox_port,
             on_activity=_touch_activity,
         )
     except Exception:

--- a/treadstone/config.py
+++ b/treadstone/config.py
@@ -51,7 +51,7 @@ class Settings(BaseSettings):
     password_reset_request_cooldown_seconds: int = 60
     password_reset_ip_hourly_limit: int = 5
 
-    # Sandbox proxy defaults (overridable per-request via X-Sandbox-* headers)
+    # Sandbox workload namespace/port defaults (proxy, subdomain, new sandboxes)
     sandbox_namespace: str = "treadstone-local"
     sandbox_port: int = 8080
     sandbox_proxy_timeout: float = 180.0

--- a/treadstone/services/sandbox_proxy.py
+++ b/treadstone/services/sandbox_proxy.py
@@ -1,12 +1,11 @@
 """
 Transparent reverse proxy to Sandbox pods running in Kubernetes.
 
-Replaces the upstream sandbox-router
+Inspired by the upstream sandbox-router
 (https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py)
-with a first-party implementation that also supports WebSocket proxying.
-
-The API contract is intentionally compatible with the official sandbox-router so
-that the k8s-agent-sandbox Python SDK can target this service as well.
+but implemented in-tree with WebSocket support. Routing (namespace, port,
+Kubernetes service name) is decided by the API layer and settings, not by
+client request headers.
 """
 
 from __future__ import annotations
@@ -14,7 +13,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any
 
 import httpx
 import websockets
@@ -38,6 +36,11 @@ PROXY_HOP_HEADERS = frozenset(
         "trailers",
     }
 )
+
+
+def _is_x_sandbox_vendor_header(name: str) -> bool:
+    """True if the header is in the legacy X-Sandbox-* family; never forward to the workload."""
+    return name.lower().startswith("x-sandbox")
 
 
 def _build_http_client() -> httpx.AsyncClient:
@@ -75,17 +78,11 @@ def build_sandbox_url(
     return f"{scheme}://{host}:{p}/{path.lstrip('/')}"
 
 
-def _sanitize_namespace(namespace: str) -> bool:
-    return namespace.replace("-", "").replace("_", "").isalnum()
-
-
-def _sanitize_sandbox_id(sandbox_id: str) -> bool:
-    return sandbox_id.replace("-", "").replace("_", "").isalnum()
-
-
 def _filter_request_headers(headers: dict[str, str]) -> dict[str, str]:
-    """Remove hop-by-hop headers and force identity encoding."""
-    filtered = {k: v for k, v in headers.items() if k.lower() not in PROXY_HOP_HEADERS}
+    """Remove hop-by-hop headers, X-Sandbox-* (any suffix), and force identity encoding."""
+    filtered = {
+        k: v for k, v in headers.items() if k.lower() not in PROXY_HOP_HEADERS and not _is_x_sandbox_vendor_header(k)
+    }
     filtered["accept-encoding"] = "identity"
     return filtered
 
@@ -93,38 +90,6 @@ def _filter_request_headers(headers: dict[str, str]) -> dict[str, str]:
 def _filter_response_headers(headers: httpx.Headers) -> dict[str, str]:
     """Keep content headers, strip hop-by-hop."""
     return {k: v for k, v in headers.multi_items() if k.lower() not in PROXY_HOP_HEADERS}
-
-
-def resolve_routing(
-    headers: dict[str, str],
-    *,
-    path_sandbox_id: str | None = None,
-) -> dict[str, Any]:
-    """Resolve sandbox routing from path params (priority) and/or headers.
-
-    Defaults for namespace and port come from settings, overridable per-request
-    via X-Sandbox-Namespace / X-Sandbox-Port headers.
-
-    Returns a dict with sandbox_id, namespace, port.
-    Raises ValueError for invalid input.
-    """
-    sandbox_id = path_sandbox_id or headers.get("x-sandbox-id")
-    if not sandbox_id:
-        raise ValueError("X-Sandbox-ID header is required.")
-    if not _sanitize_sandbox_id(sandbox_id):
-        raise ValueError("Invalid sandbox ID format.")
-
-    namespace = headers.get("x-sandbox-namespace", settings.sandbox_namespace)
-    if not _sanitize_namespace(namespace):
-        raise ValueError("Invalid namespace format.")
-
-    port_raw = headers.get("x-sandbox-port", str(settings.sandbox_port))
-    try:
-        port = int(port_raw)
-    except (ValueError, TypeError) as exc:
-        raise ValueError("Invalid port format.") from exc
-
-    return {"sandbox_id": sandbox_id, "namespace": namespace, "port": port}
 
 
 async def proxy_http_request(


### PR DESCRIPTION
## Summary
- Remove `resolve_routing()` and all server-side use of `X-Sandbox-*` headers for data-plane HTTP/WebSocket proxy targets.
- Route using `k8s_id` from the sandbox row, `namespace=sandbox.k8s_namespace`, `port=settings.sandbox_port`.
- Strip any request header whose name (case-insensitive) starts with `x-sandbox` before forwarding to the workload (HTTP).
- Updates module/config comments; adds API and unit regression tests.

Closes security concern from #301 (client could no longer override namespace/port via headers).

## Test Plan
- [x] `make test`
- [x] `make lint`

**Note:** `sdk/python/**` unchanged (no OpenAPI / SDK regen for this fix).

Made with [Cursor](https://cursor.com)