### PR TITLE
fix(ci): pin sandbox image and skip flaky warm pool wait in K8s E2E

### DIFF
--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -143,10 +143,12 @@ jobs:
           EOF
           sed -i 's/^[[:space:]]*//' .env.local
 
+      # Pin the same tag as values-prod / deploy/README.md — not :latest (moving tag can break
+      # controller compatibility or stall warm-pool readiness for the full wait-k8s loop).
       - name: Sandbox runtime image override (GitHub-hosted runners)
         run: |
           cat > /tmp/ci-sandbox-runtime-image.yaml <<'EOF'
-          image: ghcr.io/agent-infra/sandbox:latest
+          image: ghcr.io/agent-infra/sandbox:1.0.0.152
           EOF
 
       # Mirrors scripts/up.sh local + make deploy-all, but applies extension CRDs and waits for
@@ -161,6 +163,8 @@ jobs:
           kind load docker-image treadstone:latest --name treadstone
           make image-web
           kind load docker-image treadstone-web:latest --name treadstone
+          docker pull ghcr.io/agent-infra/sandbox:1.0.0.152
+          kind load docker-image ghcr.io/agent-infra/sandbox:1.0.0.152 --name treadstone
           bash scripts/check-k8s-context.sh local
           make deploy-storage deploy-infra ENV=local
           kubectl apply -f deploy/agent-sandbox/upstream/extensions.yaml
@@ -168,6 +172,10 @@ jobs:
           make deploy-runtime deploy-api deploy-web ENV=local
 
       - name: make wait-k8s
+        env:
+          # Hurl E2E does not require a pre-warmed pool; skipping avoids a flaky 10-minute poll when
+          # status.readyReplicas never reaches spec.replicas (e.g. image pull or probe variance on GH runners).
+          SKIP_SANDBOX_WARM_POOL_WAIT: "1"
         run: make wait-k8s ENV=local
 
       - name: make smoke-web

--- a/scripts/wait-k8s.sh
+++ b/scripts/wait-k8s.sh
@@ -58,8 +58,10 @@ kubectl rollout status "deployment/${WEB_DEPLOY}" -n "$NS" --timeout="$TIMEOUT_R
 
 # Warm pool for aio-sandbox-tiny (values-local): pool name is "<template>-pool"
 POOL_NAME="${SANDBOX_WARM_POOL_NAME:-aio-sandbox-tiny-pool}"
-echo "Waiting for SandboxWarmPool ${POOL_NAME} (best-effort, up to ~10 min) ..."
-if kubectl get sandboxwarmpool "$POOL_NAME" -n "$NS" &>/dev/null; then
+if [[ "${SKIP_SANDBOX_WARM_POOL_WAIT:-}" == "1" ]]; then
+	echo "Skipping SandboxWarmPool wait (SKIP_SANDBOX_WARM_POOL_WAIT=1)."
+elif kubectl get sandboxwarmpool "$POOL_NAME" -n "$NS" &>/dev/null; then
+	echo "Waiting for SandboxWarmPool ${POOL_NAME} (best-effort, up to ~10 min) ..."
 	for i in $(seq 1 120); do
 		ready=$(kubectl get sandboxwarmpool "$POOL_NAME" -n "$NS" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "")
 		want=$(kubectl get sandboxwarmpool "$POOL_NAME" -n "$NS" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "1")


### PR DESCRIPTION
Pins ghcr.io/agent-infra/sandbox to 1.0.0.152 in k8s-e2e (instead of :latest), preloads the image into Kind, and sets SKIP_SANDBOX_WARM_POOL_WAIT in wait-k8s to avoid a 10-minute SandboxWarmPool poll when readyReplicas never reaches spec on GitHub runners.

Made with [Cursor](https://cursor.com)