### PR TITLE
feat: optional sandbox NetworkPolicies and compatible security baseline

### DIFF
--- a/deploy/sandbox-runtime/README.md
+++ b/deploy/sandbox-runtime/README.md
@@ -36,8 +36,31 @@ This is a practical V1 control, not a final hard-isolation model:
 - cluster-internal reachability is reduced through the denylist, not fully auto-discovered
 - future tightening can move to `80/443`-only defaults or plan-specific exceptions without changing sandbox lifecycle code
 
-## Pod Security Standards (PSS)
+## Sandbox Security Context Baseline
 
-Defaults are **less strict** on purpose: `readOnlyRootFilesystem` is **false** so the stock sandbox image can write where it expects (e.g. under `/tmp`). That is closer to the **baseline** profile than to **restricted** (which requires a read-only root filesystem and writable paths only through declared volumes). Namespaces that **enforce restricted** may reject these Pods unless you tighten the image/volumes first and set `readOnlyRootFilesystem: true` (and related overrides) in values.
+The current `ghcr.io/agent-infra/sandbox` image is an opaque upstream image and is **not rootless-compatible**. Its startup scripts create the `gem` user/group and perform other bootstrap steps as root on every start. Because of that, Treadstone does **not** force the main sandbox container to run as UID/GID 1000.
+
+The default Treadstone baseline is therefore **compatibility-first hardening**:
+
+- keep `automountServiceAccountToken: false`
+- keep `allowPrivilegeEscalation: false`
+- keep `seccompProfile: RuntimeDefault`
+- keep `readOnlyRootFilesystem: false`
+- drop all capabilities and then add back only the minimum verified startup set:
+  - `CHOWN`
+  - `DAC_OVERRIDE`
+  - `FOWNER`
+  - `KILL`
+  - `SETUID`
+  - `SETGID`
+
+This is a deliberate boundary, not a hack:
+
+- the main container must still start as root because the image bootstraps runtime accounts dynamically
+- the direct-path `init-home` init container remains non-root
+- direct sandboxes still use `fsGroup` for the PVC-backed `/home/gem` workspace
+- this baseline is **not** Pod Security Standards `restricted` compliance
+
+If you later move to a custom image that is truly rootless-compatible, you can revisit `runAsNonRoot`, `runAsUser`, and a tighter capability set in a second phase. Until then, prefer this explicit compatible baseline over a misleading rootless configuration that fails at runtime.
 
 Workspace PVCs rely on **fsGroup** for permissions; confirm your **StorageClass / CSI** supports `fsGroup` behavior for production.

--- a/deploy/sandbox-runtime/values.yaml
+++ b/deploy/sandbox-runtime/values.yaml
@@ -67,30 +67,31 @@ networkPolicies:
     # Use this for environment-specific allow rules without changing chart code.
     extraAllowRules: []
 
-# Pod Security Standards (PSS): these defaults intentionally target the LESS strict end of the
-# spectrum (closer to the "baseline" profile): readOnlyRootFilesystem stays false so the AIO
-# sandbox image can write outside declared volumes (e.g. /tmp). That does NOT satisfy the
-# "restricted" profile, which requires a read-only root filesystem and writable paths only via volumes.
-# If your namespace enforces restricted, override values and/or change the image layout first.
-# Keep in sync with treadstone/services/k8s_client.py (SANDBOX_READ_ONLY_ROOT_FILESYSTEM).
+# Baseline-compatible hardening for the current opaque AIO image.
+# The stock image is not rootless-compatible: it bootstraps the `gem` account
+# and other runtime state as root on every start. Keep the main container on
+# the image default user, retain seccomp + no-new-privilege style controls, and
+# add only the minimum verified capabilities required for startup. This is not
+# Pod Security Standards "restricted" compliance.
 sandboxPodSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
   seccompProfile:
     type: RuntimeDefault
 
 sandboxContainerSecurityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: false
-  runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
   seccompProfile:
     type: RuntimeDefault
   capabilities:
     drop:
       - ALL
+    add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - KILL
+      - SETUID
+      - SETGID
 
 sandboxTemplates:
   - name: aio-sandbox-tiny

--- a/tests/unit/test_k8s_client.py
+++ b/tests/unit/test_k8s_client.py
@@ -14,6 +14,24 @@ from treadstone.services.k8s_client import (
     format_shutdown_time,
 )
 
+EXPECTED_MAIN_SECURITY_CONTEXT = {
+    "allowPrivilegeEscalation": False,
+    "capabilities": {
+        "drop": ["ALL"],
+        "add": ["CHOWN", "DAC_OVERRIDE", "FOWNER", "KILL", "SETUID", "SETGID"],
+    },
+    "readOnlyRootFilesystem": False,
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+EXPECTED_INIT_SECURITY_CONTEXT = {
+    "allowPrivilegeEscalation": False,
+    "capabilities": {"drop": ["ALL"]},
+    "runAsNonRoot": True,
+    "runAsUser": 1000,
+    "runAsGroup": 1000,
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+
 
 class _EmptyStreamResponse:
     def __init__(self, payload: dict | None = None):
@@ -147,6 +165,8 @@ async def test_create_claim_also_creates_sandbox():
     assert ps["automountServiceAccountToken"] is False
     assert ps["securityContext"] == _sandbox_pod_security_context(with_pvc=False)
     assert ps["containers"][0]["securityContext"] == _sandbox_main_container_security_context()
+    assert ps["securityContext"] == {"seccompProfile": {"type": "RuntimeDefault"}}
+    assert ps["containers"][0]["securityContext"] == EXPECTED_MAIN_SECURITY_CONTEXT
     assert sb["status"]["serviceFQDN"] == "my-sb.treadstone-local.svc.cluster.local"
 
 
@@ -387,8 +407,13 @@ async def test_create_sandbox_requests_expected_manifest_with_probes():
     pod_spec = call["json"]["spec"]["podTemplate"]["spec"]
     assert pod_spec["automountServiceAccountToken"] is False
     assert pod_spec["securityContext"] == _sandbox_pod_security_context(with_pvc=False)
+    assert pod_spec["securityContext"] == {"seccompProfile": {"type": "RuntimeDefault"}}
     container = pod_spec["containers"][0]
     assert container["securityContext"] == _sandbox_main_container_security_context()
+    assert container["securityContext"] == EXPECTED_MAIN_SECURITY_CONTEXT
+    assert "runAsNonRoot" not in container["securityContext"]
+    assert "runAsUser" not in container["securityContext"]
+    assert "runAsGroup" not in container["securityContext"]
     assert container["startupProbe"]["httpGet"]["path"] == "/v1/sandbox"
     assert container["readinessProbe"]["failureThreshold"] == 3
     assert "livenessProbe" not in container
@@ -436,8 +461,17 @@ async def test_create_sandbox_manifest_mounts_pvc_at_home_dir():
     main = pod_spec["containers"][0]
     assert main["volumeMounts"] == [{"name": "workspace", "mountPath": SANDBOX_HOME_DIR}]
     assert main["securityContext"] == _sandbox_main_container_security_context()
+    assert main["securityContext"] == EXPECTED_MAIN_SECURITY_CONTEXT
+    assert "runAsNonRoot" not in main["securityContext"]
+    assert "runAsUser" not in main["securityContext"]
+    assert "runAsGroup" not in main["securityContext"]
 
     assert pod_spec["securityContext"] == _sandbox_pod_security_context(with_pvc=True)
+    assert pod_spec["securityContext"] == {
+        "seccompProfile": {"type": "RuntimeDefault"},
+        "fsGroup": 1000,
+        "fsGroupChangePolicy": "OnRootMismatch",
+    }
 
     # initContainer seeds home contents on first boot using a sentinel file
     # (not ls -A empty-check, which breaks on ext4 volumes with lost+found)
@@ -445,6 +479,7 @@ async def test_create_sandbox_manifest_mounts_pvc_at_home_dir():
     assert init["name"] == "init-home"
     assert init["image"] == image
     assert init["securityContext"] == _sandbox_init_container_security_context()
+    assert init["securityContext"] == EXPECTED_INIT_SECURITY_CONTEXT
     assert init["volumeMounts"] == [{"name": "workspace", "mountPath": "/mnt/home"}]
     script = init["command"][2]
     assert ".treadstone-home-initialized" in script
@@ -452,7 +487,7 @@ async def test_create_sandbox_manifest_mounts_pvc_at_home_dir():
 
 
 async def test_create_sandbox_manifest_without_pvc_has_baseline_security_no_init():
-    """Ephemeral sandbox (no PVC): PSS baseline on pod/main container; no init or PVC mounts."""
+    """Ephemeral sandbox (no PVC): compatible baseline on pod/main container; no init or PVC mounts."""
     client = Kr8sClient()
     api = _RecordingAPI()
 
@@ -474,7 +509,9 @@ async def test_create_sandbox_manifest_without_pvc_has_baseline_security_no_init
 
     assert pod_spec["automountServiceAccountToken"] is False
     assert pod_spec["securityContext"] == _sandbox_pod_security_context(with_pvc=False)
+    assert pod_spec["securityContext"] == {"seccompProfile": {"type": "RuntimeDefault"}}
     assert pod_spec["containers"][0]["securityContext"] == _sandbox_main_container_security_context()
+    assert pod_spec["containers"][0]["securityContext"] == EXPECTED_MAIN_SECURITY_CONTEXT
     assert "initContainers" not in pod_spec
     assert "volumeMounts" not in pod_spec["containers"][0]
     assert "volumeClaimTemplates" not in manifest["spec"]
@@ -541,6 +578,7 @@ async def test_kr8s_client_preserves_explicit_pod_labels() -> None:
     pod_spec = manifest["spec"]["podTemplate"]["spec"]
     assert pod_spec["automountServiceAccountToken"] is False
     assert pod_spec["securityContext"] == _sandbox_pod_security_context(with_pvc=False)
+    assert pod_spec["securityContext"] == {"seccompProfile": {"type": "RuntimeDefault"}}
     assert "tolerations" not in pod_spec
     labels = manifest["spec"]["podTemplate"]["metadata"]["labels"]
     assert labels["treadstone-ai.dev/workload"] == "sandbox"

--- a/tests/unit/test_sandbox_runtime_values.py
+++ b/tests/unit/test_sandbox_runtime_values.py
@@ -43,6 +43,18 @@ EXPECTED_NETWORK_POLICY_DENYLIST = [
     "169.254.0.0/16",
     "127.0.0.0/8",
 ]
+EXPECTED_SANDBOX_POD_SECURITY_CONTEXT = {
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+EXPECTED_SANDBOX_CONTAINER_SECURITY_CONTEXT = {
+    "allowPrivilegeEscalation": False,
+    "readOnlyRootFilesystem": False,
+    "seccompProfile": {"type": "RuntimeDefault"},
+    "capabilities": {
+        "drop": ["ALL"],
+        "add": ["CHOWN", "DAC_OVERRIDE", "FOWNER", "KILL", "SETUID", "SETGID"],
+    },
+}
 
 
 def _load_values(name: str) -> dict:
@@ -65,6 +77,13 @@ def test_default_values_enable_shared_sandbox_network_policies() -> None:
     assert network_policies["ingress"]["allowFromApi"]["podSelector"] == {"treadstone-ai.dev/component": "api"}
     assert network_policies["egress"]["allowPublicInternet"]["enabled"] is True
     assert network_policies["egress"]["allowPublicInternet"]["exceptCidrs"] == EXPECTED_NETWORK_POLICY_DENYLIST
+
+
+def test_default_values_define_compatible_sandbox_security_contexts() -> None:
+    values = _load_values("values.yaml")
+
+    assert values["sandboxPodSecurityContext"] == EXPECTED_SANDBOX_POD_SECURITY_CONTEXT
+    assert values["sandboxContainerSecurityContext"] == EXPECTED_SANDBOX_CONTAINER_SECURITY_CONTEXT
 
 
 def test_prod_values_enable_direct_acs_with_expected_unit_order() -> None:

--- a/treadstone/services/k8s_client.py
+++ b/treadstone/services/k8s_client.py
@@ -12,9 +12,13 @@ Pod/container ``securityContext`` defaults here should stay aligned with
 ``deploy/sandbox-runtime/values.yaml`` (``sandboxPodSecurityContext``,
 ``sandboxContainerSecurityContext``).
 
-PSS note: defaults match the chart — non-root, seccomp, dropped caps, but **writable root FS**
-(``readOnlyRootFilesystem`` false). That aligns with **baseline-oriented** hardening, not the
-Kubernetes **restricted** profile (which needs read-only root plus writable paths only on volumes).
+Security note: the stock ``ghcr.io/agent-infra/sandbox`` image is **not
+rootless-compatible**. Its entrypoint bootstraps the ``gem`` user/group and
+other runtime state as root on every start. Defaults here therefore target a
+**compatible hardening baseline**: keep seccomp and no-new-privilege style
+controls, retain a writable root filesystem, and add only the minimum verified
+Linux capabilities needed for startup. This is not Kubernetes Pod Security
+Standards ``restricted`` compliance.
 
 Two implementations:
 - FakeK8sClient: In-memory stub for testing
@@ -51,9 +55,17 @@ SANDBOX_UID = 1000
 SANDBOX_GID = 1000
 
 # Align default with deploy/sandbox-runtime/values.yaml sandboxContainerSecurityContext.
-# False = less strict (baseline-friendly): image may write to paths not backed by a volume.
-# True = required for PSS "restricted"; needs emptyDir/tmpfs (or similar) for every writable path.
+# False = compatible with the stock opaque image, which writes outside declared
+# volumes during bootstrap. True would require image/layout changes first.
 SANDBOX_READ_ONLY_ROOT_FILESYSTEM = False
+SANDBOX_STARTUP_CAPABILITIES = [
+    "CHOWN",
+    "DAC_OVERRIDE",
+    "FOWNER",
+    "KILL",
+    "SETUID",
+    "SETGID",
+]
 
 DEFAULT_STARTUP_PROBE: dict[str, Any] = {
     "httpGet": {"path": "/v1/sandbox", "port": 8080},
@@ -79,13 +91,8 @@ def format_shutdown_time(dt: datetime) -> str:
 
 
 def _sandbox_pod_security_context(*, with_pvc: bool) -> dict[str, Any]:
-    """Pod-level securityContext (baseline-oriented PSS hardening). Adds fsGroup when a workspace PVC is used."""
-    ctx: dict[str, Any] = {
-        "runAsNonRoot": True,
-        "runAsUser": SANDBOX_UID,
-        "runAsGroup": SANDBOX_GID,
-        "seccompProfile": {"type": "RuntimeDefault"},
-    }
+    """Pod-level compatible hardening; direct sandboxes keep fsGroup for PVC-backed home directories."""
+    ctx: dict[str, Any] = {"seccompProfile": {"type": "RuntimeDefault"}}
     if with_pvc:
         ctx["fsGroup"] = SANDBOX_GID
         ctx["fsGroupChangePolicy"] = "OnRootMismatch"
@@ -93,20 +100,17 @@ def _sandbox_pod_security_context(*, with_pvc: bool) -> dict[str, Any]:
 
 
 def _sandbox_main_container_security_context() -> dict[str, Any]:
-    """Main sandbox container: matches Helm sandboxContainerSecurityContext defaults."""
+    """Main sandbox container: root-compatible minimum capability baseline mirrored from Helm defaults."""
     return {
         "allowPrivilegeEscalation": False,
-        "capabilities": {"drop": ["ALL"]},
+        "capabilities": {"drop": ["ALL"], "add": SANDBOX_STARTUP_CAPABILITIES},
         "readOnlyRootFilesystem": SANDBOX_READ_ONLY_ROOT_FILESYSTEM,
-        "runAsNonRoot": True,
-        "runAsUser": SANDBOX_UID,
-        "runAsGroup": SANDBOX_GID,
         "seccompProfile": {"type": "RuntimeDefault"},
     }
 
 
 def _sandbox_init_container_security_context() -> dict[str, Any]:
-    """init-home runs as the same UID as the main process; root is not required for cp with fsGroup."""
+    """init-home remains non-root; the incompatibility is in the main image entrypoint bootstrap."""
     return {
         "allowPrivilegeEscalation": False,
         "capabilities": {"drop": ["ALL"]},
@@ -321,7 +325,8 @@ class Kr8sClient:
             # etc.) so the main container's entrypoint can layer runtime state
             # on top.  A sentinel file tracks whether seeding has happened —
             # `ls -A` empty-checks break on ext4 volumes that ship lost+found.
-            # Runs as UID/GID SANDBOX_* with pod fsGroup; no chown (PSS restricted).
+            # init-home stays non-root and avoids chown; the main opaque image
+            # still boots as root to create its runtime user/group.
             _sentinel = "/mnt/home/.treadstone-home-initialized"
             init_script = (
                 f"if [ ! -f {_sentinel} ]; then "


### PR DESCRIPTION
## Summary
- Add optional sandbox `NetworkPolicy` resources (denylist-based egress control) and related Helm values / documentation.
- Label the API pod for policy targeting where needed.
- Align sandbox pod/container `securityContext` with the stock AIO image: remove forced non-root UID for the main container, document the compatibility-first baseline, and add the minimum capability set required for image bootstrap; extend unit tests and `values.yaml` comments accordingly.

## Test Plan
- [x] `make test` and `make lint` (author verified locally)

Made with [Cursor](https://cursor.com)