### PR TITLE
fix: keep sandbox security context ACS-compatible

### DIFF
--- a/deploy/sandbox-runtime/README.md
+++ b/deploy/sandbox-runtime/README.md
@@ -46,19 +46,14 @@ The default Treadstone baseline is therefore **compatibility-first hardening**:
 - keep `allowPrivilegeEscalation: false`
 - keep `seccompProfile: RuntimeDefault`
 - keep `readOnlyRootFilesystem: false`
-- drop all capabilities and then add back only the minimum verified startup set:
-  - `CHOWN`
-  - `DAC_OVERRIDE`
-  - `FOWNER`
-  - `KILL`
-  - `SETUID`
-  - `SETGID`
+- do not force a `capabilities` override on the main container
 
 This is a deliberate boundary, not a hack:
 
 - the main container must still start as root because the image bootstraps runtime accounts dynamically
 - the direct-path `init-home` init container remains non-root
 - direct sandboxes still use `fsGroup` for the PVC-backed `/home/gem` workspace
+- ACS/ECI scheduling remains compatible because the Pod spec does not request disallowed capability overrides
 - this baseline is **not** Pod Security Standards `restricted` compliance
 
 If you later move to a custom image that is truly rootless-compatible, you can revisit `runAsNonRoot`, `runAsUser`, and a tighter capability set in a second phase. Until then, prefer this explicit compatible baseline over a misleading rootless configuration that fails at runtime.

--- a/deploy/sandbox-runtime/values.yaml
+++ b/deploy/sandbox-runtime/values.yaml
@@ -70,9 +70,10 @@ networkPolicies:
 # Baseline-compatible hardening for the current opaque AIO image.
 # The stock image is not rootless-compatible: it bootstraps the `gem` account
 # and other runtime state as root on every start. Keep the main container on
-# the image default user, retain seccomp + no-new-privilege style controls, and
-# add only the minimum verified capabilities required for startup. This is not
-# Pod Security Standards "restricted" compliance.
+# the image default user and retain seccomp + no-new-privilege style controls.
+# Do not set explicit Linux capabilities here: some ACS/ECI policies reject
+# capability overrides entirely, while the stock image still starts correctly
+# with the runtime defaults when no capabilities stanza is present.
 sandboxPodSecurityContext:
   seccompProfile:
     type: RuntimeDefault
@@ -82,16 +83,6 @@ sandboxContainerSecurityContext:
   readOnlyRootFilesystem: false
   seccompProfile:
     type: RuntimeDefault
-  capabilities:
-    drop:
-      - ALL
-    add:
-      - CHOWN
-      - DAC_OVERRIDE
-      - FOWNER
-      - KILL
-      - SETUID
-      - SETGID
 
 sandboxTemplates:
   - name: aio-sandbox-tiny

--- a/tests/unit/test_k8s_client.py
+++ b/tests/unit/test_k8s_client.py
@@ -16,10 +16,6 @@ from treadstone.services.k8s_client import (
 
 EXPECTED_MAIN_SECURITY_CONTEXT = {
     "allowPrivilegeEscalation": False,
-    "capabilities": {
-        "drop": ["ALL"],
-        "add": ["CHOWN", "DAC_OVERRIDE", "FOWNER", "KILL", "SETUID", "SETGID"],
-    },
     "readOnlyRootFilesystem": False,
     "seccompProfile": {"type": "RuntimeDefault"},
 }

--- a/tests/unit/test_sandbox_runtime_values.py
+++ b/tests/unit/test_sandbox_runtime_values.py
@@ -50,10 +50,6 @@ EXPECTED_SANDBOX_CONTAINER_SECURITY_CONTEXT = {
     "allowPrivilegeEscalation": False,
     "readOnlyRootFilesystem": False,
     "seccompProfile": {"type": "RuntimeDefault"},
-    "capabilities": {
-        "drop": ["ALL"],
-        "add": ["CHOWN", "DAC_OVERRIDE", "FOWNER", "KILL", "SETUID", "SETGID"],
-    },
 }
 
 

--- a/treadstone/services/k8s_client.py
+++ b/treadstone/services/k8s_client.py
@@ -16,9 +16,10 @@ Security note: the stock ``ghcr.io/agent-infra/sandbox`` image is **not
 rootless-compatible**. Its entrypoint bootstraps the ``gem`` user/group and
 other runtime state as root on every start. Defaults here therefore target a
 **compatible hardening baseline**: keep seccomp and no-new-privilege style
-controls, retain a writable root filesystem, and add only the minimum verified
-Linux capabilities needed for startup. This is not Kubernetes Pod Security
-Standards ``restricted`` compliance.
+controls, retain a writable root filesystem, and avoid explicit Linux
+capability overrides. Some ACS/ECI policies reject any ``capabilities`` stanza
+even when the image starts fine with runtime defaults. This is not Kubernetes
+Pod Security Standards ``restricted`` compliance.
 
 Two implementations:
 - FakeK8sClient: In-memory stub for testing
@@ -58,14 +59,6 @@ SANDBOX_GID = 1000
 # False = compatible with the stock opaque image, which writes outside declared
 # volumes during bootstrap. True would require image/layout changes first.
 SANDBOX_READ_ONLY_ROOT_FILESYSTEM = False
-SANDBOX_STARTUP_CAPABILITIES = [
-    "CHOWN",
-    "DAC_OVERRIDE",
-    "FOWNER",
-    "KILL",
-    "SETUID",
-    "SETGID",
-]
 
 DEFAULT_STARTUP_PROBE: dict[str, Any] = {
     "httpGet": {"path": "/v1/sandbox", "port": 8080},
@@ -100,10 +93,9 @@ def _sandbox_pod_security_context(*, with_pvc: bool) -> dict[str, Any]:
 
 
 def _sandbox_main_container_security_context() -> dict[str, Any]:
-    """Main sandbox container: root-compatible minimum capability baseline mirrored from Helm defaults."""
+    """Main sandbox container: compatible baseline mirrored from Helm defaults."""
     return {
         "allowPrivilegeEscalation": False,
-        "capabilities": {"drop": ["ALL"], "add": SANDBOX_STARTUP_CAPABILITIES},
         "readOnlyRootFilesystem": SANDBOX_READ_ONLY_ROOT_FILESYSTEM,
         "seccompProfile": {"type": "RuntimeDefault"},
     }


### PR DESCRIPTION
## Summary
- remove explicit sandbox container capabilities so ACS/ECI can provision overflow sandboxes
- keep compatible hardening in place, including no service account token mount, seccomp, and no privilege escalation
- update docs and unit expectations to match the ACS-compatible security baseline

## Context
ACS/ECI rejects Pods that set the current sandbox `securityContext.capabilities` override with `reason=InvalidParameter` and `validating policy[capabilities] failed`. This blocks both claim and direct sandboxes from overflowing onto ACS when ECS capacity is exhausted.

## Test Plan
- Not rerun locally in this PR flow per request
- Previously verified with targeted unit checks, `ruff`, and `helm template` while developing the fix