### PR TITLE
test: add benchmark scenario YAMLs for mixed templates and stateless burst

### DIFF
--- a/tests/benchmark/scenarios/mixed_templates_180.yaml
+++ b/tests/benchmark/scenarios/mixed_templates_180.yaml
@@ -1,0 +1,37 @@
+# 180 sandboxes: 50 small + 50 tiny + 50 medium + 30 large
+# Run with --no-cleanup to keep sandboxes running after the benchmark exits.
+
+name: "mixed-templates-180"
+description: >
+  Mixed template burst: small/tiny stateless; medium/large with 5Gi persistent
+  storage (matches existing benchmark conventions).
+
+matrix:
+  - template: aio-sandbox-small
+    count: 50
+    persist: false
+
+  - template: aio-sandbox-tiny
+    count: 50
+    persist: false
+
+  - template: aio-sandbox-medium
+    count: 50
+    persist: true
+    storage_size: "5Gi"
+
+  - template: aio-sandbox-large
+    count: 30
+    persist: true
+    storage_size: "5Gi"
+
+concurrency: 15
+ready_timeout_sec: 1200
+poll_interval_sec: 10
+
+auto_stop_interval: 60
+auto_delete_interval: -1
+
+cleanup:
+  after_run: false
+  on_failure: true

--- a/tests/benchmark/scenarios/mixed_tiny_small_medium_120.yaml
+++ b/tests/benchmark/scenarios/mixed_tiny_small_medium_120.yaml
@@ -1,0 +1,80 @@
+# 120 sandboxes: Tiny/Small/Medium only.
+# Stateless vs stateful 1:1 (60 / 60). Stateful uses 5Gi / 10Gi / 20Gi (20 each),
+# with templates split 7+7+6 per tier for dispersion.
+
+name: "mixed-tsm-120-balanced-storage"
+description: >
+  60 stateless + 60 persistent (5Gi/10Gi/20Gi × 20 each; 7 tiny + 7 small + 6 medium per tier).
+
+matrix:
+  # Stateless (60): equal mix
+  - template: aio-sandbox-tiny
+    count: 20
+    persist: false
+
+  - template: aio-sandbox-small
+    count: 20
+    persist: false
+
+  - template: aio-sandbox-medium
+    count: 20
+    persist: false
+
+  # Stateful 5Gi (20)
+  - template: aio-sandbox-tiny
+    count: 7
+    persist: true
+    storage_size: "5Gi"
+
+  - template: aio-sandbox-small
+    count: 7
+    persist: true
+    storage_size: "5Gi"
+
+  - template: aio-sandbox-medium
+    count: 6
+    persist: true
+    storage_size: "5Gi"
+
+  # Stateful 10Gi (20)
+  - template: aio-sandbox-tiny
+    count: 7
+    persist: true
+    storage_size: "10Gi"
+
+  - template: aio-sandbox-small
+    count: 7
+    persist: true
+    storage_size: "10Gi"
+
+  - template: aio-sandbox-medium
+    count: 6
+    persist: true
+    storage_size: "10Gi"
+
+  # Stateful 20Gi (20)
+  - template: aio-sandbox-tiny
+    count: 7
+    persist: true
+    storage_size: "20Gi"
+
+  - template: aio-sandbox-small
+    count: 7
+    persist: true
+    storage_size: "20Gi"
+
+  - template: aio-sandbox-medium
+    count: 6
+    persist: true
+    storage_size: "20Gi"
+
+concurrency: 15
+ready_timeout_sec: 1200
+poll_interval_sec: 10
+
+auto_stop_interval: 60
+auto_delete_interval: -1
+
+cleanup:
+  after_run: true
+  on_failure: true

--- a/tests/benchmark/scenarios/stateless_burst_500.yaml
+++ b/tests/benchmark/scenarios/stateless_burst_500.yaml
@@ -1,0 +1,22 @@
+# Scenario: stateless-burst-500
+# Burst-create 500 stateless sandboxes (aio-sandbox-tiny).
+
+name: "stateless-burst-500"
+description: >
+  Burst-create 500 stateless sandboxes for capacity testing.
+
+matrix:
+  - template: aio-sandbox-tiny
+    count: 500
+    persist: false
+
+concurrency: 20
+ready_timeout_sec: 900
+poll_interval_sec: 10
+
+auto_stop_interval: 60
+auto_delete_interval: -1
+
+cleanup:
+  after_run: true
+  on_failure: true


### PR DESCRIPTION
## Summary
- Add `mixed_templates_180`: 180 concurrent mixed-template sandbox scenario
- Add `mixed_tiny_small_medium_120`: 120 concurrent tiny/small/medium mix scenario
- Add `stateless_burst_500`: 500-sandbox stateless burst load test scenario

## Test Plan
- No code changes; YAML scenario files only

Made with [Cursor](https://cursor.com)