### PR TITLE
feat(web): select sandboxes when creating data-plane API keys

### DIFF
--- a/web/src/api/sandboxes.ts
+++ b/web/src/api/sandboxes.ts
@@ -8,13 +8,14 @@ export type CreateSandboxBody = components["schemas"]["CreateSandboxRequest"]
 const TRANSITIONING_STATUSES = new Set(["creating", "starting", "stopping", "deleting"])
 const TRANSITIONING_OPERATIONS = new Set(["snapshotting", "restoring"])
 
-export function useSandboxes() {
+export function useSandboxes(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ["sandboxes"],
     queryFn: async () => {
       const { data } = await client.GET("/v1/sandboxes")
       return data!
     },
+    enabled: options?.enabled ?? true,
     refetchInterval: (query) => {
       const data = query.state.data
       if (!data) return 30_000

--- a/web/src/pages/app/api-keys.tsx
+++ b/web/src/pages/app/api-keys.tsx
@@ -11,6 +11,7 @@ import {
   useDeleteApiKey,
   type ApiKey,
 } from "@/api/api-keys"
+import { useSandboxes } from "@/api/sandboxes"
 import { HelpIcon } from "@/components/ui/help-icon"
 import { DOC } from "@/lib/console-docs"
 import { cn } from "@/lib/utils"
@@ -55,6 +56,11 @@ function ScopeBadges({ keyRow }: { keyRow: ApiKey }) {
   const cp = keyRow.scope.control_plane
   const dpMode = keyRow.scope.data_plane.mode
   const hasData = dpMode !== "none"
+  const selectedCount = keyRow.scope.data_plane.sandbox_ids?.length ?? 0
+  const dataPlaneLabel =
+    dpMode === "selected" && selectedCount > 0
+      ? `Data plane (${selectedCount})`
+      : "Data plane"
   return (
     <div className="flex flex-wrap gap-1">
       {cp && (
@@ -64,7 +70,7 @@ function ScopeBadges({ keyRow }: { keyRow: ApiKey }) {
       )}
       {hasData && (
         <span className="bg-primary/15 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-primary">
-          Data plane
+          {dataPlaneLabel}
         </span>
       )}
       {!cp && !hasData && (
@@ -89,8 +95,14 @@ export function ApiKeysPage() {
   const [expiryPreset, setExpiryPreset] = useState<ExpiryPresetId>("360d")
   const [scopeControl, setScopeControl] = useState(true)
   const [scopeData, setScopeData] = useState(true)
+  const [dataPlaneScopeMode, setDataPlaneScopeMode] = useState<"all" | "selected">("all")
+  const [selectedSandboxIds, setSelectedSandboxIds] = useState<string[]>([])
 
   const [createdSecret, setCreatedSecret] = useState<string | null>(null)
+
+  const { data: sandboxListData, isLoading: sandboxesLoading } = useSandboxes({
+    enabled: createOpen,
+  })
 
   const filtered = useMemo(() => {
     if (!filter.trim()) return items
@@ -119,17 +131,30 @@ export function ApiKeysPage() {
     setExpiryPreset("360d")
     setScopeControl(true)
     setScopeData(true)
+    setDataPlaneScopeMode("all")
+    setSelectedSandboxIds([])
+  }
+
+  function toggleSandboxInSelection(id: string) {
+    setSelectedSandboxIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    )
   }
 
   async function handleCreate() {
+    const dataPlane =
+      !scopeData
+        ? ({ mode: "none" as const } as const)
+        : dataPlaneScopeMode === "all"
+          ? ({ mode: "all" as const } as const)
+          : ({ mode: "selected" as const, sandbox_ids: selectedSandboxIds } as const)
+
     const body = {
       name: newName.trim() || "default",
       expires_in: selectedExpiryPreset.seconds,
       scope: {
         control_plane: scopeControl,
-        data_plane: scopeData
-          ? { mode: "all" as const }
-          : { mode: "none" as const },
+        data_plane: dataPlane,
       },
     }
 
@@ -333,7 +358,7 @@ export function ApiKeysPage() {
       <Dialog.Root open={createOpen} onOpenChange={setCreateOpen}>
         <Dialog.Portal>
           <Dialog.Overlay className="fixed inset-0 z-50 bg-black/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(100vw-2rem,440px)] -translate-x-1/2 -translate-y-1/2 border border-border/20 bg-card p-6 shadow-xl outline-none">
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(100vw-2rem,520px)] max-h-[min(90vh,720px)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto border border-border/20 bg-card p-6 shadow-xl outline-none">
             <div className="flex items-start justify-between gap-4">
               <div>
                 <Dialog.Title className="text-lg font-bold text-foreground">Create API key</Dialog.Title>
@@ -413,12 +438,94 @@ export function ApiKeysPage() {
                   </div>
                   <Switch.Root
                     checked={scopeData}
-                    onCheckedChange={setScopeData}
+                    onCheckedChange={(on) => {
+                      setScopeData(on)
+                      if (!on) {
+                        setDataPlaneScopeMode("all")
+                        setSelectedSandboxIds([])
+                      }
+                    }}
                     className="h-6 w-11 shrink-0 rounded-full bg-muted-foreground/30 outline-none data-[state=checked]:bg-primary"
                   >
                     <Switch.Thumb className="block size-5 translate-x-0.5 rounded-full bg-background transition-transform will-change-transform data-[state=checked]:translate-x-[22px]" />
                   </Switch.Root>
                 </div>
+                {scopeData && (
+                  <div className="space-y-3 border-t border-border/10 pt-3">
+                    <p className="text-xs font-medium text-muted-foreground">Data plane access</p>
+                    <div role="radiogroup" aria-label="Data plane scope" className="grid gap-2">
+                      <button
+                        type="button"
+                        role="radio"
+                        aria-checked={dataPlaneScopeMode === "all"}
+                        onClick={() => setDataPlaneScopeMode("all")}
+                        className={cn(
+                          "border px-3 py-2 text-left text-sm transition-colors focus:outline-none focus:ring-1 focus:ring-ring",
+                          dataPlaneScopeMode === "all"
+                            ? "border-primary bg-primary/10 text-foreground"
+                            : "border-border/30 bg-background text-muted-foreground hover:border-border/60 hover:text-foreground",
+                        )}
+                      >
+                        <span className="font-medium">All sandboxes</span>
+                        <span className="mt-0.5 block text-xs text-muted-foreground">
+                          Can call the proxy for any sandbox you own.
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        role="radio"
+                        aria-checked={dataPlaneScopeMode === "selected"}
+                        onClick={() => setDataPlaneScopeMode("selected")}
+                        className={cn(
+                          "border px-3 py-2 text-left text-sm transition-colors focus:outline-none focus:ring-1 focus:ring-ring",
+                          dataPlaneScopeMode === "selected"
+                            ? "border-primary bg-primary/10 text-foreground"
+                            : "border-border/30 bg-background text-muted-foreground hover:border-border/60 hover:text-foreground",
+                        )}
+                      >
+                        <span className="font-medium">Selected sandboxes</span>
+                        <span className="mt-0.5 block text-xs text-muted-foreground">
+                          Restrict proxy access to the sandboxes you pick below.
+                        </span>
+                      </button>
+                    </div>
+                    {dataPlaneScopeMode === "selected" && (
+                      <div className="rounded border border-border/20 bg-background/80 p-3">
+                        {sandboxesLoading ? (
+                          <p className="text-xs text-muted-foreground">Loading sandboxes…</p>
+                        ) : (sandboxListData?.items ?? []).length === 0 ? (
+                          <p className="text-xs text-muted-foreground">
+                            No sandboxes yet. Create one first, then issue a key scoped to it.
+                          </p>
+                        ) : (
+                          <ul className="max-h-40 space-y-2 overflow-y-auto pr-1">
+                            {(sandboxListData?.items ?? [])
+                              .slice()
+                              .sort((a, b) => a.name.localeCompare(b.name))
+                              .map((s) => (
+                                <li key={s.id}>
+                                  <label className="flex cursor-pointer items-start gap-2 text-sm">
+                                    <input
+                                      type="checkbox"
+                                      checked={selectedSandboxIds.includes(s.id)}
+                                      onChange={() => toggleSandboxInSelection(s.id)}
+                                      className="mt-0.5 size-4 shrink-0 rounded border-border/40"
+                                    />
+                                    <span className="min-w-0">
+                                      <span className="font-medium text-foreground">{s.name}</span>
+                                      <span className="mt-0.5 block font-mono text-[11px] text-muted-foreground">
+                                        {s.id}
+                                      </span>
+                                    </span>
+                                  </label>
+                                </li>
+                              ))}
+                          </ul>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
 
@@ -433,7 +540,13 @@ export function ApiKeysPage() {
               </Dialog.Close>
               <button
                 type="button"
-                disabled={createKey.isPending || (!scopeControl && !scopeData)}
+                disabled={
+                  createKey.isPending ||
+                  (!scopeControl && !scopeData) ||
+                  (scopeData &&
+                    dataPlaneScopeMode === "selected" &&
+                    selectedSandboxIds.length === 0)
+                }
                 onClick={() => void handleCreate()}
                 className="bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:opacity-40"
               >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Console API Keys page always sent `data_plane: { mode: "all" }` when the data plane toggle was on. The control plane API already supports `mode: "selected"` with `sandbox_ids`, matching the CLI.

This change adds **All sandboxes** vs **Selected sandboxes** under the data plane scope when creating a key, with a checkbox list of the user’s sandboxes (loaded only while the create dialog is open). The keys table scope badge shows **Data plane (N)** when the key uses selected sandboxes.

`useSandboxes` accepts an optional `{ enabled }` so other pages keep their current behavior.

## Test plan

- `make lint` — passed
- `pnpm exec eslint` on touched files — passed
- `make test` — 23 failures in `test_sandbox_subdomain_api`, `test_sandboxes_api` (web URL), and `test_config`; appears unrelated to this web-only change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10271fa1-0f4b-48eb-81d1-8cef2d4106b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10271fa1-0f4b-48eb-81d1-8cef2d4106b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

