### PR TITLE
fix(e2e): correct field name email_verified → is_verified

### DIFF
--- a/tests/e2e/01-auth-session.hurl
+++ b/tests/e2e/01-auth-session.hurl
@@ -77,7 +77,7 @@ HTTP 200
 jsonpath "$.id" == "{{user_id}}"
 jsonpath "$.email" == "{{email_01}}"
 jsonpath "$.is_active" == true
-jsonpath "$.email_verified" == true
+jsonpath "$.is_verified" == true
 jsonpath "$.role" isString
 
 


### PR DESCRIPTION
## Summary
- PR #325 was merged before commit `7f5cef4` (the `email_verified` → `is_verified` fix) landed
- Main branch `01-auth-session.hurl:80` has `email_verified` which doesn't exist in the API response
- Correct field name is `is_verified` (see `api/auth.py:934`)

## One-line fix
`jsonpath "$.email_verified" == true` → `jsonpath "$.is_verified" == true`

## Test plan
- [ ] k8s-e2e CI passes with 15/15 files green

🤖 Generated with [Claude Code](https://claude.com/claude-code)