### PR TITLE
Fix reconstructed image chmod glob failure

### DIFF
--- a/deploy/sandbox-image/reconstructed/Dockerfile
+++ b/deploy/sandbox-image/reconstructed/Dockerfile
@@ -203,13 +203,16 @@ RUN python3 -m pip install --no-cache-dir /opt/gem-server \
     '    sys.exit(cli())' \
     > /usr/local/bin/python-server \
   && chmod +x /usr/local/bin/python-server \
-  && chmod +x \
+  && shopt -s nullglob \
+  && executables=( \
     /opt/gem/*.sh \
     /opt/gem/run.sh \
     /opt/gem/entrypoint.sh \
     /opt/gem/xdg-settings \
     /opt/gem-server/gem-server \
     /opt/python3.12/lib/python3.12/site-packages/app/scripts/*.sh \
+  ) \
+  && if [ "${#executables[@]}" -gt 0 ]; then chmod +x "${executables[@]}"; fi \
   && chmod -R a+rX /opt/gem /opt/gem-server /opt/aio /opt/terminal /opt/application /opt/python3.12/lib/python3.12/site-packages/app /opt/python3.12/lib/python3.12/site-packages/vendors
 
 RUN printf '%s\n' "${VERSION}" > /etc/aio_version


### PR DESCRIPTION
## Summary
- tolerate missing optional reconstructed app script globs during chmod
- unblock sandbox-image-reconstructed workflow after PR #332 merge

## Validation
- git diff --check
- analyzed failed workflow run 24574935091 and fixed the exact failing line
