### PR TITLE
Align reconstructed python site-packages paths

### DIFF
--- a/deploy/sandbox-image/reconstructed/Dockerfile
+++ b/deploy/sandbox-image/reconstructed/Dockerfile
@@ -193,6 +193,7 @@ COPY runtime/ /
 
 RUN python3 -m pip install --no-cache-dir /opt/gem-server \
   && mkdir -p /opt/python3.12/lib/python3.12/site-packages \
+  && if [ -d /opt/python3.12/site-packages ]; then cp -a /opt/python3.12/site-packages/. /opt/python3.12/lib/python3.12/site-packages/; fi \
   && printf '%s\n' \
     '#!/opt/python3.12/bin/python3.12' \
     'import re' \


### PR DESCRIPTION
## Summary
- copy extracted reconstructed python assets into the standard /opt/python3.12/lib/python3.12/site-packages path
- align the copied runtime tree with the paths used later in chmod and python-server startup
- unblock the next reconstructed image workflow attempt after run 24575151240

## Validation
- git diff --check
- analyzed failed workflow run 24575151240 and fixed the exact path mismatch
