### PR TITLE
test(e2e): stabilize sandbox readiness waits and Hurl timing

### DIFF
--- a/tests/e2e/05-sandbox-dual-path.hurl
+++ b/tests/e2e/05-sandbox-dual-path.hurl
@@ -113,7 +113,9 @@ jsonpath "$.storage_size" == null
 GET {{base_url}}/v1/sandboxes/{{claim_sandbox_id}}
 Authorization: Bearer {{api_key}}
 [Options]
-retry: 30
+# CI / loaded clusters can keep a sandbox in "creating" longer than local runs;
+# allow the same ~3 min readiness window used by the dedicated lifecycle tests.
+retry: 90
 retry-interval: 2s
 HTTP 200
 [Asserts]
@@ -126,7 +128,8 @@ HTTP 200
 GET {{base_url}}/v1/sandboxes/{{claim_sandbox_id}}
 Authorization: Bearer {{api_key}}
 [Options]
-retry: 20
+# Stop is also async via the K8s control loop; give it up to ~60s in CI.
+retry: 30
 retry-interval: 2s
 HTTP 200
 [Asserts]

--- a/tests/e2e/06-sandbox-names-web-link.hurl
+++ b/tests/e2e/06-sandbox-names-web-link.hurl
@@ -125,7 +125,9 @@ jsonpath "$.web_url" startsWith "http://sandbox-{{sandbox_id_a}}.sandbox.localho
 GET {{base_url}}/v1/sandboxes/{{sandbox_id_a}}
 Authorization: Bearer {{api_key_a}}
 [Options]
-retry: 30
+# CI / loaded clusters can keep a sandbox in "creating" longer than local runs;
+# allow the same ~3 min readiness window used by the lifecycle/data-plane files.
+retry: 90
 retry-interval: 2s
 HTTP 200
 [Asserts]
@@ -138,7 +140,8 @@ HTTP 200
 GET {{base_url}}/v1/sandboxes/{{sandbox_id_a}}
 Authorization: Bearer {{api_key_a}}
 [Options]
-retry: 20
+# Stop is async via the K8s control loop; give it up to ~60s in CI.
+retry: 30
 retry-interval: 2s
 HTTP 200
 [Asserts]

--- a/tests/e2e/09-data-plane-proxy.hurl
+++ b/tests/e2e/09-data-plane-proxy.hurl
@@ -133,7 +133,9 @@ POST {{base_url}}/v1/sandboxes/{{sandbox_id}}/proxy/v1/shell/exec
 Authorization: Bearer {{api_key}}
 Content-Type: application/json
 [Options]
-retry: 8
+# A sandbox can report status=ready slightly before the proxied workload is
+# consistently reachable; keep a second retry window for proxy-path readiness.
+retry: 12
 retry-interval: 3s
 {
     "command": "echo e2e-data-plane-ok && pwd",

--- a/tests/e2e/10-sandbox-lifecycle.hurl
+++ b/tests/e2e/10-sandbox-lifecycle.hurl
@@ -87,7 +87,8 @@ HTTP 200
 GET {{base_url}}/v1/sandboxes/{{sandbox_id}}
 Authorization: Bearer {{api_key}}
 [Options]
-retry: 20
+# Stop is async via the K8s control loop; allow ~60s in CI.
+retry: 30
 retry-interval: 2s
 HTTP 200
 [Asserts]

--- a/tests/e2e/11-sandbox-lifecycle-ephemeral.hurl
+++ b/tests/e2e/11-sandbox-lifecycle-ephemeral.hurl
@@ -140,7 +140,8 @@ HTTP 200
 GET {{base_url}}/v1/sandboxes/{{sandbox_id}}
 Authorization: Bearer {{api_key}}
 [Options]
-retry: 20
+# Stop is async via the K8s control loop; allow ~60s in CI.
+retry: 30
 retry-interval: 2s
 HTTP 200
 [Asserts]

--- a/tests/e2e/12-sandbox-lifecycle-persistent.hurl
+++ b/tests/e2e/12-sandbox-lifecycle-persistent.hurl
@@ -151,7 +151,8 @@ HTTP 200
 GET {{base_url}}/v1/sandboxes/{{sandbox_id}}
 Authorization: Bearer {{api_key}}
 [Options]
-retry: 20
+# Persistent sandbox stop can be slower in CI because storage/K8s teardown is async.
+retry: 30
 retry-interval: 2s
 HTTP 200
 [Asserts]

--- a/tests/e2e/13-sandbox-quota-enforcement.hurl
+++ b/tests/e2e/13-sandbox-quota-enforcement.hurl
@@ -111,7 +111,8 @@ HTTP 200
 GET {{base_url}}/v1/sandboxes/{{sandbox_1_id}}
 Authorization: Bearer {{api_key}}
 [Options]
-retry: 20
+# Stop is async via the K8s control loop; allow ~60s before assuming quota state is stale.
+retry: 30
 retry-interval: 2s
 HTTP 200
 [Asserts]

--- a/tests/e2e/15-data-plane-proxy-extended.hurl
+++ b/tests/e2e/15-data-plane-proxy-extended.hurl
@@ -145,7 +145,9 @@ POST {{base_url}}/v1/sandboxes/{{sandbox_id}}/proxy/v1/shell/exec
 Authorization: Bearer {{dp_only_key}}
 Content-Type: application/json
 [Options]
-retry: 8
+# A sandbox can report status=ready slightly before the proxied workload is
+# consistently reachable; keep a second retry window for proxy-path readiness.
+retry: 12
 retry-interval: 3s
 {
     "command": "echo e2e-dp-only-ok",
@@ -172,7 +174,7 @@ POST {{base_url}}/v1/sandboxes/{{sandbox_id}}/proxy/v1/shell/exec
 Authorization: Bearer {{api_key}}
 Content-Type: application/json
 [Options]
-retry: 8
+retry: 12
 retry-interval: 3s
 {
     "command": "echo e2e-data-plane-ok && pwd",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -46,7 +46,7 @@ The **K8s E2E** workflow merges each successful HTML report into the **`gh-pages
 
 - **Self-contained files**: each registers its own users (except `08` which relies on `admin_email` from the runner).
 - **Email verification**: several flows use `GET /v1/admin/verification-token-by-email` as admin (first user is admin on fresh DB).
-- **Retries**: Hurl `[Options] retry` + `retry-interval` poll async state (`ready`, `stopped`).
+- **Retries**: Hurl `[Options] retry` + `retry-interval` poll async state (`ready`, `stopped`). Sandbox readiness waits intentionally use wider CI-safe windows than local runs, and data-plane proxy calls keep an additional retry window because `status=ready` can precede full proxy-path availability by a few seconds.
 - **Sandbox template**: `scripts/e2e-test.sh` sets `sandbox_template` (default `aio-sandbox-tiny`) to match the seeded free-tier `allowed_templates`. Do not use `GET /v1/sandbox-templates` `items[0]` — sort order may pick a template the free tier is not allowed to use (→ HTTP 403 `template_not_allowed`).
 - **Persist + storage**: free tier seeds `storage_capacity_gib` = 0. Tests needing `persist=true` use admin `POST /v1/admin/users/{id}/storage-grants` first (otherwise HTTP 402 `storage_quota_exceeded`).
 - **Web link after sandbox delete**: `GET /v1/sandboxes/{id}/web-link` may return **404** `sandbox_not_found` once the row is gone (fast reconcile); it is not always **200** with `enabled: false`.


### PR DESCRIPTION
## Summary
- widen CI-facing sandbox readiness waits in Hurl lifecycle/data-plane files
- give stop->stopped polling a larger async K8s control-loop window
- widen proxy exec retries because status=ready can precede proxy-path availability
- document the CI-safe retry rationale in tests/e2e/README.md

## Verification
- git diff --check
- local review of retry regressions introduced by 6083080 (reduced retry limits)

## Notes
- Full K8s E2E / hosted-runner validation is still needed to confirm the real CI path end-to-end.