### PR TITLE
ci(e2e): raise hurl job count to 2

### DIFF
--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -184,7 +184,10 @@ jobs:
 
       - name: make test-e2e
         env:
-          HURL_JOBS: "1"
+          # Controlled concurrency experiment: keep Hurl below full fan-out while
+          # we measure whether sandbox creation stalls are caused by shared Kind /
+          # runtime resource contention rather than strict test ordering.
+          HURL_JOBS: "2"
           E2E_FILE: ${{ github.event.inputs.file || '' }}
         run: |
           if [ -n "${E2E_FILE:-}" ]; then


### PR DESCRIPTION
## Summary
- raise K8s E2E Hurl concurrency from 1 to 2
- keep this as a controlled experiment instead of full fan-out
- preserve the richer failure diagnostics added in the previous change

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/k8s-e2e.yml"); puts "yaml-ok"'
- git diff --check