### PR TITLE
[codex] Fix rootless sandbox nginx bootstrap

### DIFF
--- a/deploy/sandbox-image/Dockerfile
+++ b/deploy/sandbox-image/Dockerfile
@@ -73,6 +73,7 @@ RUN set -euo pipefail \
     && install -d -m 755 -o gem -g gem \
          /opt/treadstone \
          /opt/treadstone/home-template \
+         /var/log/nginx \
          /var/lib/nginx \
     && for home_dir in /home/gem /opt/treadstone/home-template; do \
          install -d -m 755 -o gem -g gem \
@@ -96,7 +97,9 @@ RUN set -euo pipefail \
          /opt/jupyter \
          /opt/aio \
          /etc/browser/policies/managed \
+         /var/log/nginx \
          /var/lib/nginx \
+    && touch /var/log/nginx/error.log \
     && chmod 755 /opt/gem/run.sh /opt/gem/entrypoint.sh /opt/gem/jupyter-lab.sh /opt/gem/tinyproxy.sh
 
 RUN claude --version \

--- a/deploy/sandbox-image/run.sh
+++ b/deploy/sandbox-image/run.sh
@@ -59,12 +59,16 @@ envsubst '${XDG_RUNTIME_DIR}' \
   </opt/treadstone/templates/nginx.conf.template >/opt/gem/nginx.conf
 envsubst '${MCP_HUB_PORT} ${SANDBOX_SRV_PORT}' \
   </opt/gem/nginx/nginx.python_srv.conf >/opt/gem/nginx/python_srv.conf
+rm -f /opt/gem/nginx/nginx.python_srv.conf
 envsubst '${MCP_HUB_PORT}' \
   </opt/gem/nginx/nginx.mcp_hub.conf >/opt/gem/nginx/mcp_hub.conf
+rm -f /opt/gem/nginx/nginx.mcp_hub.conf
 envsubst '${JUPYTER_LAB_PORT}' \
   </opt/gem/nginx/nginx.jupyter_lab.conf >/opt/gem/nginx/jupyter_lab.conf
+rm -f /opt/gem/nginx/nginx.jupyter_lab.conf
 envsubst '${CODE_SERVER_PORT}' \
   </opt/gem/nginx/nginx.code_server.conf >/opt/gem/nginx/code_server.conf
+rm -f /opt/gem/nginx/nginx.code_server.conf
 envsubst '${PUBLIC_PORT}' \
   </opt/gem/nginx-server-port-proxy.conf.template >/opt/gem/nginx-server-port-proxy.conf
 envsubst '${SANDBOX_SRV_PORT} ${MCP_SERVER_BROWSER_PORT} ${BROWSER_REMOTE_DEBUGGING_PORT}' \


### PR DESCRIPTION
## What changed

- remove the rendered nginx template source files after `run.sh` materializes the runtime configs
- create and hand ownership of `/var/log/nginx/error.log` to `gem` at image build time so rootless nginx can finish startup

## Why

The rootless sandbox image was failing before `/v1/sandbox` could come up for two concrete reasons:

1. `run.sh` rendered `nginx.python_srv.conf`, `nginx.mcp_hub.conf`, `nginx.jupyter_lab.conf`, and `nginx.code_server.conf` into the same directory but left the template files in place. Because the active server config still does `include /opt/gem/nginx/*.conf`, nginx loaded both the template and rendered files, which creates duplicate `location` blocks.
2. Even after that, nginx still attempts to open its default `/var/log/nginx/error.log` during startup. In the rootless image that path was not writable by `gem`, so nginx aborted with `Permission denied` before the custom `error_log /dev/stderr;` directive could take effect.

Together these keep port `8080` closed, so the K8s startup probe fails, the Sandbox CR stays `DependenciesNotReady`, and E2E sees `status=creating` until timeout.

## Validation

- `git diff --check`
- `docker build --platform linux/amd64 -f deploy/sandbox-image/Dockerfile -t treadstone-sandbox:pr337fix2 --build-arg TREADSTONE_SANDBOX_VERSION=pr337fix2 deploy/sandbox-image`
- `docker run --platform linux/amd64 treadstone-sandbox:pr337fix2`
- `curl http://127.0.0.1:8080/v1/sandbox` inside the container now returns `HTTP/1.1 200 OK`

## Follow-up

- Re-run the PR `K8s E2E` workflow on `#337` to confirm the hosted Kind path no longer stalls all sandbox-heavy cases in `creating`.
